### PR TITLE
[#IP-437] Remove webhook for eucovidcert UAT

### DIFF
--- a/src/core/function_publiceventdispatcher.tf
+++ b/src/core/function_publiceventdispatcher.tf
@@ -77,13 +77,6 @@ module "function_pblevtdispatcher" {
         headers       = { "X-Functions-Key" = data.azurerm_key_vault_secret.fnapp_eucovidcert_authtoken.value },
         attributes    = { serviceId = "01F73DNTMJTCEZQKJDFNB53KEB" },
         subscriptions = ["service:subscribed"]
-      },
-      # EUCovidCert UAT
-      {
-        url           = format("https://%s/api/v1/io-events-webhook", data.azurerm_function_app.fnapp_eucovidcert.default_hostname),
-        headers       = { "X-Functions-Key" = data.azurerm_key_vault_secret.fnapp_eucovidcert_authtoken.value },
-        attributes    = { serviceId = "01F798T3NX5RARB38DVKPABKV2" },
-        subscriptions = ["service:subscribed"]
       }
     ])
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
By having two webhook pointing to the same function, we were actually doubling the same event when emitting "subscribing all"

### List of changes

<!--- Describe your changes in detail -->


### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
