### PR TITLE
[INFRA-290] Migrate api.io.italia.it on new app gateway

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -70,6 +70,7 @@
 | [azurerm_api_management_api_version_set.io_backend_session_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.76.0/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_container_group.coredns_forwarder](https://registry.terraform.io/providers/hashicorp/azurerm/2.76.0/docs/resources/container_group) | resource |
 | [azurerm_dns_a_record.api_app_io_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/2.76.0/docs/resources/dns_a_record) | resource |
+| [azurerm_dns_a_record.api_io_italia_it](https://registry.terraform.io/providers/hashicorp/azurerm/2.76.0/docs/resources/dns_a_record) | resource |
 | [azurerm_dns_a_record.api_io_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/2.76.0/docs/resources/dns_a_record) | resource |
 | [azurerm_dns_a_record.api_mtls_io_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/2.76.0/docs/resources/dns_a_record) | resource |
 | [azurerm_dns_a_record.developerportal_backend_io_italia_it](https://registry.terraform.io/providers/hashicorp/azurerm/2.76.0/docs/resources/dns_a_record) | resource |

--- a/src/core/dns_io_italia_it.tf
+++ b/src/core/dns_io_italia_it.tf
@@ -49,7 +49,7 @@ resource "azurerm_dns_a_record" "api_io_italia_it" {
   name                = "api"
   zone_name           = azurerm_dns_zone.io_italia_it.name
   resource_group_name = azurerm_resource_group.rg_external.name
-  ttl                 = 60 # var.dns_default_ttl_sec # after first apply, change to default ttl
+  ttl                 = 300 # var.dns_default_ttl_sec # after first apply, change to default ttl
   records             = [azurerm_public_ip.appgateway_public_ip.ip_address]
 
   tags = var.tags

--- a/src/core/dns_io_italia_it.tf
+++ b/src/core/dns_io_italia_it.tf
@@ -43,3 +43,14 @@ resource "azurerm_dns_a_record" "developerportal_backend_io_italia_it" {
 
   tags = var.tags
 }
+
+# api.io.italia.it
+resource "azurerm_dns_a_record" "api_io_italia_it" {
+  name                = "api"
+  zone_name           = azurerm_dns_zone.io_italia_it.name
+  resource_group_name = azurerm_resource_group.rg_external.name
+  ttl                 = 1 # var.dns_default_ttl_sec # after first apply, change to default ttl
+  records             = [azurerm_public_ip.appgateway_public_ip.ip_address]
+
+  tags = var.tags
+}

--- a/src/core/dns_io_italia_it.tf
+++ b/src/core/dns_io_italia_it.tf
@@ -49,7 +49,7 @@ resource "azurerm_dns_a_record" "api_io_italia_it" {
   name                = "api"
   zone_name           = azurerm_dns_zone.io_italia_it.name
   resource_group_name = azurerm_resource_group.rg_external.name
-  ttl                 = 1 # var.dns_default_ttl_sec # after first apply, change to default ttl
+  ttl                 = 60 # var.dns_default_ttl_sec # after first apply, change to default ttl
   records             = [azurerm_public_ip.appgateway_public_ip.ip_address]
 
   tags = var.tags


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

migrate api.io.italia.it on new app gateway

### Motivation and context

- cost savings
- listener issue on old app gateway

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

How to apply

```
bash terraform.sh import prod azurerm_dns_a_record.api_io_italia_it "/subscriptions/ec285037-c673-4f58-b594-d7c480da4e8b/resourceGroups/io-p-rg-external/providers/Microsoft.Network/dnszones/io.italia.it/A/api"

# apply with ttl 60 sec
bash terraform.sh apply prod

# apply with default ttl
bash terraform.sh apply prod
```

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
