### PR TITLE
Increase app gateway min instances

### DIFF
--- a/src/core/dns_io_italia_it.tf
+++ b/src/core/dns_io_italia_it.tf
@@ -60,7 +60,7 @@ resource "azurerm_dns_a_record" "app_backend_io_italia_it" {
   name                = "app-backend"
   zone_name           = azurerm_dns_zone.io_italia_it.name
   resource_group_name = azurerm_resource_group.rg_external.name
-  ttl                 = 300 # var.dns_default_ttl_sec change it after migration
+  ttl                 = var.dns_default_ttl_sec
   records             = [azurerm_public_ip.appgateway_public_ip.ip_address]
 
   tags = var.tags

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -36,7 +36,7 @@ app_gateway_api_app_certificate_name                              = "api-app-io-
 app_gateway_api_io_italia_it_certificate_name                     = "api-io-italia-it"
 app_gateway_app_backend_io_italia_it_certificate_name             = "app-backend-io-italia-it"
 app_gateway_developerportal_backend_io_italia_it_certificate_name = "developerportal-backend-io-italia-it"
-app_gateway_min_capacity                                          = 2
+app_gateway_min_capacity                                          = 3
 app_gateway_max_capacity                                          = 50
 app_gateway_alerts_enabled                                        = true
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- increase min app gateway instances to 3 (rule is compute units peak/10 -> so 30/10=3)
- increase dns ttl to default value for app-backend.io.italia.it

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
