### PR TITLE
[IC-134] New env variable for messages report

### DIFF
--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -39,6 +39,13 @@ data "azurerm_cosmosdb_account" "api_northeurope" {
   resource_group_name = azurerm_resource_group.rg_internal.name
 }
 
+# Storage iopstapi replica
+data "azurerm_storage_account" "api_replica" {
+  name                = "iopstapireplica"
+  resource_group_name = azurerm_resource_group.rg_internal.name
+}
+
+
 
 module "function_elt" {
   source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v1.0.65"
@@ -104,7 +111,7 @@ module "function_elt" {
     COSMOS_DEGREE_OF_PARALLELISM = "2"
     MESSAGE_CONTENT_CHUNK_SIZE   = "500"
 
-    MessageContentStorageConnection  = module.storage_account_elt.primary_connection_string
+    MessageContentStorageConnection  = data.azurerm_storage_account.api_replica.primary_connection_string
     ServiceInfoBlobStorageConnection = data.azurerm_storage_account.cdnassets.primary_connection_string
   }
 

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -26,6 +26,11 @@ module "function_elt_snetout" {
   }
 }
 
+data "azurerm_storage_account" "cdnassets" {
+  name                = "iopstcdnassets"
+  resource_group_name = azurerm_resource_group.rg_internal.name
+}
+
 module "function_elt" {
   source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v1.0.65"
 
@@ -78,6 +83,16 @@ module "function_elt" {
 
     PROFILE_TOPIC_NAME              = "io-cosmosdb-profiles"
     PROFILE_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-profiles.io-fn-elt"].primary_connection_string
+
+    MESSAGE_EXPORT_STEP_1_CONTAINER     = azurerm_storage_container.container_messages_report_step1.name
+    MESSAGE_EXPORT_STEP_FINAL_CONTAINER = azurerm_storage_container.container_messages_report_step_final.name
+
+    COSMOS_CHUNK_SIZE            = "1000"
+    COSMOS_DEGREE_OF_PARALLELISM = "2"
+    MESSAGE_CONTENT_CHUNK_SIZE   = "500"
+
+    MessageContentStorageConnection  = module.storage_account_elt.primary_connection_string
+    ServiceInfoBlobStorageConnection = data.azurerm_storage_account.cdnassets.primary_connection_string
   }
 
   allowed_subnets = [
@@ -126,4 +141,16 @@ resource "azurerm_storage_table" "fnelterrors" {
 resource "azurerm_storage_table" "fneltcommands" {
   name                 = "fneltcommands"
   storage_account_name = module.storage_account_elt.name
+}
+
+resource "azurerm_storage_container" "container_messages_report_step1" {
+  name                  = "messages-report-step1"
+  storage_account_name  = module.storage_account_elt.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "container_messages_report_step_final" {
+  name                  = "messages-report-step-final"
+  storage_account_name  = module.storage_account_elt.name
+  container_access_type = "private"
 }

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -26,10 +26,19 @@ module "function_elt_snetout" {
   }
 }
 
+# CDN Assets storage account
 data "azurerm_storage_account" "cdnassets" {
   name                = "iopstcdnassets"
   resource_group_name = azurerm_resource_group.rg_internal.name
 }
+
+
+# CosmosDB replica
+data "azurerm_cosmosdb_account" "api_northeurope" {
+  name                = "io-p-cosmos-api-northeurope"
+  resource_group_name = azurerm_resource_group.rg_internal.name
+}
+
 
 module "function_elt" {
   source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v1.0.65"
@@ -83,6 +92,10 @@ module "function_elt" {
 
     PROFILE_TOPIC_NAME              = "io-cosmosdb-profiles"
     PROFILE_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-profiles.io-fn-elt"].primary_connection_string
+
+    COSMOSDB_REPLICA_NAME = "db"
+    COSMOSDB_REPLICA_URI  = azurerm_cosmosdb_account.api_northeurope.endpoint
+    COSMOSDB_REPLICA_KEY  = azurerm_cosmosdb_account.api_northeurope.primary_master_key
 
     MESSAGE_EXPORT_STEP_1_CONTAINER     = azurerm_storage_container.container_messages_report_step1.name
     MESSAGE_EXPORT_STEP_FINAL_CONTAINER = azurerm_storage_container.container_messages_report_step_final.name

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -29,15 +29,9 @@ module "function_elt_snetout" {
 # CDN Assets storage account
 data "azurerm_storage_account" "cdnassets" {
   name                = "iopstcdnassets"
-  resource_group_name = azurerm_resource_group.rg_internal.name
+  resource_group_name = var.common_rg
 }
 
-
-# CosmosDB replica
-data "azurerm_cosmosdb_account" "api_northeurope" {
-  name                = "io-p-cosmos-api-northeurope"
-  resource_group_name = azurerm_resource_group.rg_internal.name
-}
 
 # Storage iopstapi replica
 data "azurerm_storage_account" "api_replica" {
@@ -101,8 +95,8 @@ module "function_elt" {
     PROFILE_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-profiles.io-fn-elt"].primary_connection_string
 
     COSMOSDB_REPLICA_NAME = "db"
-    COSMOSDB_REPLICA_URI  = azurerm_cosmosdb_account.api_northeurope.endpoint
-    COSMOSDB_REPLICA_KEY  = azurerm_cosmosdb_account.api_northeurope.primary_master_key
+    COSMOSDB_REPLICA_URI  = replace(data.azurerm_cosmosdb_account.cosmos_api.endpoint, "io-p-cosmos-api", "io-p-cosmos-api-northeurope")
+    COSMOSDB_REPLICA_KEY  = data.azurerm_cosmosdb_account.cosmos_api.primary_master_key
 
     MESSAGE_EXPORT_STEP_1_CONTAINER     = azurerm_storage_container.container_messages_report_step1.name
     MESSAGE_EXPORT_STEP_FINAL_CONTAINER = azurerm_storage_container.container_messages_report_step_final.name


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- add connection strings to `io-p-cosmos-api-northeurope`
- add connection string to `iopstapireplica`
- add connection string to `iopstcdnassets` for reading `visible-services-extended.json`
- add new blob containers `messages-report-step1` and `messages-report-step-final`
- add new variable for new handlers, used for tuning cosmos and blob storage queries

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

In order to retrieve aggregated data for messages, ad new handler triggered by a command from EH topic that will scan messages and write a csv with required aggregated data.

NOTE: this is just a workaroud to get data quickly.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
