### PR TITLE
[IC-134] Setup cosmos variables after tuning

### DIFF
--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -104,7 +104,7 @@ module "function_elt" {
 
     COSMOS_CHUNK_SIZE            = "1000"
     COSMOS_DEGREE_OF_PARALLELISM = "2"
-    MESSAGE_CONTENT_CHUNK_SIZE   = "250"
+    MESSAGE_CONTENT_CHUNK_SIZE   = "200"
 
     MessageContentStorageConnection  = data.azurerm_storage_account.api_replica.primary_connection_string
     ServiceInfoBlobStorageConnection = data.azurerm_storage_account.cdnassets.primary_connection_string

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -94,16 +94,17 @@ module "function_elt" {
     PROFILE_TOPIC_NAME              = "io-cosmosdb-profiles"
     PROFILE_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-profiles.io-fn-elt"].primary_connection_string
 
-    COSMOSDB_REPLICA_NAME = "db"
-    COSMOSDB_REPLICA_URI  = replace(data.azurerm_cosmosdb_account.cosmos_api.endpoint, "io-p-cosmos-api", "io-p-cosmos-api-northeurope")
-    COSMOSDB_REPLICA_KEY  = data.azurerm_cosmosdb_account.cosmos_api.primary_master_key
+    COSMOSDB_REPLICA_NAME     = "db"
+    COSMOSDB_REPLICA_URI      = replace(data.azurerm_cosmosdb_account.cosmos_api.endpoint, "io-p-cosmos-api", "io-p-cosmos-api-northeurope")
+    COSMOSDB_REPLICA_KEY      = data.azurerm_cosmosdb_account.cosmos_api.primary_master_key
+    COSMOSDB_REPLICA_LOCATION = "North Europe"
 
     MESSAGE_EXPORT_STEP_1_CONTAINER     = azurerm_storage_container.container_messages_report_step1.name
     MESSAGE_EXPORT_STEP_FINAL_CONTAINER = azurerm_storage_container.container_messages_report_step_final.name
 
     COSMOS_CHUNK_SIZE            = "1000"
     COSMOS_DEGREE_OF_PARALLELISM = "2"
-    MESSAGE_CONTENT_CHUNK_SIZE   = "500"
+    MESSAGE_CONTENT_CHUNK_SIZE   = "250"
 
     MessageContentStorageConnection  = data.azurerm_storage_account.api_replica.primary_connection_string
     ServiceInfoBlobStorageConnection = data.azurerm_storage_account.cdnassets.primary_connection_string

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -99,6 +99,7 @@ module "function_elt" {
     COSMOSDB_REPLICA_KEY      = data.azurerm_cosmosdb_account.cosmos_api.primary_master_key
     COSMOSDB_REPLICA_LOCATION = "North Europe"
 
+    MESSAGE_EXPORTS_COMMAND_TABLE = azurerm_storage_table.fneltexports.name
     MESSAGE_EXPORT_STEP_1_CONTAINER     = azurerm_storage_container.container_messages_report_step1.name
     MESSAGE_EXPORT_STEP_FINAL_CONTAINER = azurerm_storage_container.container_messages_report_step_final.name
 
@@ -155,6 +156,10 @@ resource "azurerm_storage_table" "fnelterrors" {
 
 resource "azurerm_storage_table" "fneltcommands" {
   name                 = "fneltcommands"
+  storage_account_name = module.storage_account_elt.name
+}
+resource "azurerm_storage_table" "fneltexports" {
+  name                 = "fneltexports"
   storage_account_name = module.storage_account_elt.name
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Setup cosmos variables after tuning
- Add `COSMOSDB_REPLICA_LOCATION` new variable
- Add new `fneltexports` table

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
