### PR TITLE
[#IC-160] Implement jwk signature verification on `SelfCare IO` (cleanup)

### DIFF
--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -212,7 +212,7 @@ module "appservice_selfcare_be" {
     BACKEND_URL         = "${local.selfcare_io.backend_hostname}"
     LOGIN_URL           = "https://${local.selfcare_io.frontend_hostname}/login"
     FAILURE_URL         = "https://${local.selfcare_io.frontend_hostname}/500.html"
-    SELFCARE_LOGIN_URL  = "${local.selfcare.hostname}/auth/login"
+    SELFCARE_LOGIN_URL  = "https://${local.selfcare.hostname}/auth/login"
     SELFCARE_IDP_ISSUER = local.selfcare.jwt_issuer
     SELFCARE_JWKS_URL   = data.http.selfcare_well_known_jwks_json.url
     JWT_SIGNATURE_KEY   = trimspace(module.selfcare_jwt.jwt_private_key_pem) # to avoid unwanted changes

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -107,11 +107,6 @@ data "azurerm_key_vault_secret" "selfcare_devportal_jira_token" {
   key_vault_id = data.azurerm_key_vault.common.id
 }
 
-data "azurerm_key_vault_secret" "selfcare_selfcare_idp_issuer_jwt_signature_key" {
-  name         = "selfcare-SELFCARE-IDP-ISSUER-JWT-SIGNATURE-KEY"
-  key_vault_id = data.azurerm_key_vault.common.id
-}
-
 # JWT
 module "selfcare_jwt" {
   source = "git::https://github.com/pagopa/azurerm.git//jwt_keys?ref=v2.0.21"

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -5,6 +5,11 @@ locals {
     backend_hostname  = "api.${var.dns_zone_io_selfcare}.${var.external_domain}"
     frontend_hostname = "${var.dns_zone_io_selfcare}.${var.external_domain}"
   }
+
+  selfcare = {
+    base_url   = "https://uat.${var.selfcare_external_hostname}"
+    jwt_issuer = "api.${var.selfcare_external_hostname}"
+  }
 }
 
 ### Frontend common resources
@@ -212,10 +217,11 @@ module "appservice_selfcare_be" {
     BACKEND_URL                           = "${local.selfcare_io.backend_hostname}"
     LOGIN_URL                             = "https://${local.selfcare_io.frontend_hostname}/login"
     FAILURE_URL                           = "https://${local.selfcare_io.frontend_hostname}/500.html"
-    SELFCARE_LOGIN_URL                    = "https://uat.${var.selfcare_external_hostname}/auth/login"
-    SELFCARE_IDP_ISSUER                   = "api.${var.selfcare_external_hostname}"
-    SELFCARE_IDP_ISSUER_JWT_SIGNATURE_KEY = data.azurerm_key_vault_secret.selfcare_selfcare_idp_issuer_jwt_signature_key.value # todo data.http.selfcare_well_known_jwks_json.body
-    JWT_SIGNATURE_KEY                     = trimspace(module.selfcare_jwt.jwt_private_key_pem) # to avoid unwanted changes
+    SELFCARE_LOGIN_URL                    = "${local.selfcare.base_url}/auth/login"
+    SELFCARE_IDP_ISSUER                   = local.selfcare.jwt_issuer
+    SELFCARE_JWKS_URL                     = data.http.selfcare_well_known_jwks_json.url
+    SELFCARE_IDP_ISSUER_JWT_SIGNATURE_KEY = data.azurerm_key_vault_secret.selfcare_selfcare_idp_issuer_jwt_signature_key.value # to be removed
+    JWT_SIGNATURE_KEY                     = trimspace(module.selfcare_jwt.jwt_private_key_pem)                                 # to avoid unwanted changes
 
     # JIRA integration for Service review workflow
     JIRA_USERNAME              = "github-bot@pagopa.it"
@@ -242,7 +248,7 @@ module "appservice_selfcare_be" {
 }
 
 data "http" "selfcare_well_known_jwks_json" {
-  url = "https://dev.${var.selfcare_external_hostname}/.well-known/jwks.json" # todo remove .dev
+  url = "${local.selfcare.base_url}/.well-known/jwks.json"
 
   # Optional request headers
   request_headers = {

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -1,7 +1,7 @@
 ### Common resources
 
 locals {
-  selfcare = {
+  selfcare_io = {
     backend_hostname  = "api.${var.dns_zone_io_selfcare}.${var.external_domain}"
     frontend_hostname = "${var.dns_zone_io_selfcare}.${var.external_domain}"
   }
@@ -208,10 +208,10 @@ module "appservice_selfcare_be" {
     SERVICE_PRINCIPAL_TENANT_ID = data.azurerm_client_config.current.tenant_id
     USE_SERVICE_PRINCIPAL       = "1"
 
-    FRONTEND_URL                          = "https://${local.selfcare.frontend_hostname}"
-    BACKEND_URL                           = "${local.selfcare.backend_hostname}"
-    LOGIN_URL                             = "https://${local.selfcare.frontend_hostname}/login"
-    FAILURE_URL                           = "https://${local.selfcare.frontend_hostname}/500.html"
+    FRONTEND_URL                          = "https://${local.selfcare_io.frontend_hostname}"
+    BACKEND_URL                           = "${local.selfcare_io.backend_hostname}"
+    LOGIN_URL                             = "https://${local.selfcare_io.frontend_hostname}/login"
+    FAILURE_URL                           = "https://${local.selfcare_io.frontend_hostname}/500.html"
     SELFCARE_LOGIN_URL                    = "https://uat.${var.selfcare_external_hostname}/auth/login"
     SELFCARE_IDP_ISSUER                   = "api.${var.selfcare_external_hostname}"
     SELFCARE_IDP_ISSUER_JWT_SIGNATURE_KEY = data.azurerm_key_vault_secret.selfcare_selfcare_idp_issuer_jwt_signature_key.value # todo data.http.selfcare_well_known_jwks_json.body

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -213,15 +213,14 @@ module "appservice_selfcare_be" {
     SERVICE_PRINCIPAL_TENANT_ID = data.azurerm_client_config.current.tenant_id
     USE_SERVICE_PRINCIPAL       = "1"
 
-    FRONTEND_URL                          = "https://${local.selfcare_io.frontend_hostname}"
-    BACKEND_URL                           = "${local.selfcare_io.backend_hostname}"
-    LOGIN_URL                             = "https://${local.selfcare_io.frontend_hostname}/login"
-    FAILURE_URL                           = "https://${local.selfcare_io.frontend_hostname}/500.html"
-    SELFCARE_LOGIN_URL                    = "${local.selfcare.base_url}/auth/login"
-    SELFCARE_IDP_ISSUER                   = local.selfcare.jwt_issuer
-    SELFCARE_JWKS_URL                     = data.http.selfcare_well_known_jwks_json.url
-    SELFCARE_IDP_ISSUER_JWT_SIGNATURE_KEY = data.azurerm_key_vault_secret.selfcare_selfcare_idp_issuer_jwt_signature_key.value # to be removed
-    JWT_SIGNATURE_KEY                     = trimspace(module.selfcare_jwt.jwt_private_key_pem)                                 # to avoid unwanted changes
+    FRONTEND_URL        = "https://${local.selfcare_io.frontend_hostname}"
+    BACKEND_URL         = "${local.selfcare_io.backend_hostname}"
+    LOGIN_URL           = "https://${local.selfcare_io.frontend_hostname}/login"
+    FAILURE_URL         = "https://${local.selfcare_io.frontend_hostname}/500.html"
+    SELFCARE_LOGIN_URL  = "${local.selfcare.base_url}/auth/login"
+    SELFCARE_IDP_ISSUER = local.selfcare.jwt_issuer
+    SELFCARE_JWKS_URL   = data.http.selfcare_well_known_jwks_json.url
+    JWT_SIGNATURE_KEY   = trimspace(module.selfcare_jwt.jwt_private_key_pem) # to avoid unwanted changes
 
     # JIRA integration for Service review workflow
     JIRA_USERNAME              = "github-bot@pagopa.it"


### PR DESCRIPTION
Cleanup unused `SELFCARE_IDP_ISSUER_JWT_SIGNATURE_KEY` env var.

To be applied and merged after https://github.com/pagopa/io-developer-portal-backend/pull/152 and https://github.com/pagopa/io-infra/pull/67 are deployed