### PR TITLE
[#IC-206] Enable multi-provider for Legal Message

### DIFF
--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -128,10 +128,14 @@ locals {
       JWT_SUPPORT_TOKEN_EXPIRATION = 1209600
 
       // MVL PECSERVER
-      PECSERVER_URL          = "https://poc.pagopa.poste.it"
-      PECSERVER_BASE_PATH    = ""
-      PECSERVER_TOKEN_ISSUER = "app-backend.io.italia.it"
-      PECSERVER_TOKEN_SECRET = data.azurerm_key_vault_secret.app_backend_PECSERVER_TOKEN_SECRET.value
+      PECSERVERS_poste_url        = "https://poc.pagopa.poste.it"
+      PECSERVERS_poste_basePath   = ""
+      PECSERVERS_poste_secret     = data.azurerm_key_vault_secret.app_backend_PECSERVER_TOKEN_SECRET.value
+      PECSERVERS_poste_serviceId  = "01FQ4945RG5WJGPHKY8ZYRJMQ7"
+      PECSERVERS_aruba_url        = "http://io-mvl-server-mock:4000"
+      PECSERVERS_aruba_basePath   = ""
+      PECSERVERS_aruba_secret     = "aaaa"
+      PECSERVERS_aruba_serviceId  = "2"
 
       // CGN
       TEST_CGN_FISCAL_CODES = data.azurerm_key_vault_secret.app_backend_TEST_CGN_FISCAL_CODES.value


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The Legal Message could be sent to IO by different PEC-SERVER. IO must enrich the message with data from the proper PEC-SERVER.

### List of changes
<!--- Describe your changes in detail -->
add multi pec-server configuration for enrichment process.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
Properly routing the enrichment process to right PEC-SERVER

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
