### PR TITLE
[#IC-185] Add environment configs for `subscription-migrations`

### DIFF
--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -221,7 +221,7 @@ data "azurerm_key_vault_secret" "subscriptionmigrations_db_server_adm_password" 
 // db applicative user credentials
 data "azurerm_key_vault_secret" "subscriptionmigrations_db_server_fnsubsmigrations_password" {
   name         = "selfcare-subsmigrations-FNSUBSMIGRATIONS-PASSWORD"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.common.id
 }
 
 

--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -228,7 +228,7 @@ data "azurerm_key_vault_secret" "subscriptionmigrations_db_server_fnsubsmigratio
 module "subscriptionmigrations_db_server" {
   source = "git::https://github.com/pagopa/azurerm.git//postgresql_server?ref=v2.1.20"
 
-  name                = local.db.name
+  name                = local.function_subscriptionmigrations.db.name
   location            = var.location
   resource_group_name = local.function_subscriptionmigrations.app_context.resource_group.name
 

--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -35,7 +35,7 @@ locals {
       DB_PORT         = ""
       DB_IDLE_TIMEOUT = 30000 // milliseconds
       // TBC: name and schema may be the very same variable
-      DB_NAME   = "SelfcareIOSubscriptionMigrations"
+      DB_NAME   = "db"
       DB_SCHEMA = "SelfcareIOSubscriptionMigrations"
       DB_TABLE  = "migrations"
       // TODO: create and grand an applicative user for PostgresSQL

--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -37,8 +37,8 @@ locals {
       DB_NAME         = "db"
       DB_SCHEMA       = "SelfcareIOSubscriptionMigrations"
       DB_TABLE        = "migrations"
-      DB_USER         = local.db.username
-      DB_PASSWORD     = local.db.password
+      DB_USER         = format("%s@%s", "FNSUBSMIGRATIONS_USER", format("%s.postgres.database.azure.com", format("%s-%s-db-postgresql", local.project, "subsmigrations")))
+      DB_PASSWORD     = data.azurerm_key_vault_secret.subscriptionmigrations_db_server_fnsubsmigrations_password.value
 
     }
 
@@ -53,9 +53,7 @@ locals {
     }
 
     db = {
-      name     = format("%s-%s-db-postgresql", local.project, "subsmigrations")
-      username = format("%s@%s", "FNSUBSMIGRATIONS_USER", format("%s.postgres.database.azure.com", format("%s-%s-db-postgresql", local.project, "subsmigrations")))
-      password = data.azurerm_key_vault_secret.subscriptionmigrations_db_server_fnsubsmigrations_password.value
+      name = format("%s-%s-db-postgresql", local.project, "subsmigrations")
     }
 
     metric_alerts = {

--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -31,7 +31,7 @@ locals {
       APIM_TENANT_ID       = data.azurerm_client_config.current.tenant_id
 
       // connection to PostgresSQL
-      DB_HOST         = local.db.hostname
+      DB_HOST         = format("%s.postgres.database.azure.com", format("%s-%s-db-postgresql", local.project, "subsmigrations"))
       DB_PORT         = 5432
       DB_IDLE_TIMEOUT = 30000 // milliseconds
       DB_NAME         = "db"
@@ -53,9 +53,8 @@ locals {
     }
 
     db = {
-      name     = format("%s-%s-db-postgresql", local.project, local.function_subscriptionmigrations.app_context.name)
-      hostname = format("%s-postgresql.postgres.database.azure.com", local.db.name)
-      username = format("%s@%s", "FNSUBSMIGRATIONS_USER", local.db.hostname)
+      name     = format("%s-%s-db-postgresql", local.project, "subsmigrations")
+      username = format("%s@%s", "FNSUBSMIGRATIONS_USER", format("%s.postgres.database.azure.com", format("%s-%s-db-postgresql", local.project, "subsmigrations")))
       password = data.azurerm_key_vault_secret.subscriptionmigrations_db_server_fnsubsmigrations_password.value
     }
 

--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -53,7 +53,8 @@ locals {
     }
 
     db = {
-      hostname = format("%s-postgresql.postgres.database.azure.com", module.subscriptionmigrations_db_server.name)
+      name     = format("%s-%s-db-postgresql", local.project, local.function_subscriptionmigrations.app_context.name)
+      hostname = format("%s-postgresql.postgres.database.azure.com", local.db.name)
       username = format("%s@%s", "FNSUBSMIGRATIONS_USER", local.db.hostname)
       password = data.azurerm_key_vault_secret.subscriptionmigrations_db_server_fnsubsmigrations_password.value
     }
@@ -230,7 +231,7 @@ data "azurerm_key_vault_secret" "subscriptionmigrations_db_server_fnsubsmigratio
 module "subscriptionmigrations_db_server" {
   source = "git::https://github.com/pagopa/azurerm.git//postgresql_server?ref=v2.1.20"
 
-  name                = format("%s-%s-db-postgresql", local.project, local.function_subscriptionmigrations.app_context.name)
+  name                = local.db.name
   location            = var.location
   resource_group_name = local.function_subscriptionmigrations.app_context.resource_group.name
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* disable `OnServiceChange` function on both prod and staging slot
* configure connection to `IO`'s main cosmosdb
* configure connection to APIM
* configure connection to local PostgreSQL db (to be completed)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
As we are implementing this https://github.com/pagopa/io-subscription-migration/pull/10

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
