### PR TITLE
[#IC-236] Add App Insight Env variables

### DIFF
--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -41,9 +41,7 @@ locals {
       DB_PASSWORD     = data.azurerm_key_vault_secret.subscriptionmigrations_db_server_fnsubsmigrations_password.value
 
       // connection to Application Insight
-      APPINSIGHTS_INSTRUMENTATIONKEY  =""
-      APPINSIGHTS_DISABLE             =""
-      APPINSIGHTS_SAMPLING_PERCENTAGE =""
+      APPINSIGHTS_INSTRUMENTATIONKEY  = data.azurerm_application_insights.application_insights.instrumentation_key
 
     }
 

--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -40,6 +40,11 @@ locals {
       DB_USER         = format("%s@%s", "FNSUBSMIGRATIONS_USER", format("%s.postgres.database.azure.com", format("%s-%s-db-postgresql", local.project, "subsmigrations")))
       DB_PASSWORD     = data.azurerm_key_vault_secret.subscriptionmigrations_db_server_fnsubsmigrations_password.value
 
+      // connection to Application Insight
+      APPINSIGHTS_INSTRUMENTATIONKEY  =""
+      APPINSIGHTS_DISABLE             =""
+      APPINSIGHTS_SAMPLING_PERCENTAGE =""
+
     }
 
     // As we run this application under SelfCare IO logic subdomain,

--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -41,7 +41,7 @@ locals {
       DB_PASSWORD     = data.azurerm_key_vault_secret.subscriptionmigrations_db_server_fnsubsmigrations_password.value
 
       // connection to Application Insight
-      APPINSIGHTS_INSTRUMENTATIONKEY  = data.azurerm_application_insights.application_insights.instrumentation_key
+      APPINSIGHTS_INSTRUMENTATIONKEY = data.azurerm_application_insights.application_insights.instrumentation_key
 
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

* Configure Application Insight connection

<!--- Describe your changes in detail -->

### Motivation and context

As we are implementing this https://github.com/pagopa/io-subscription-migration/pull/10

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
