### PR TITLE
[#IC-239] Enable `OnServiceChange` trigger

### DIFF
--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -160,10 +160,7 @@ module "function_subscriptionmigrations" {
     data.azurerm_subnet.azdoa_snet[0].id,
   ]
 
-  app_settings = merge(local.function_subscriptionmigrations.app_settings_commons, {
-    // disable change feed listener until we are ready to start data migration
-    "AzureWebJobs.OnServiceChange.Disabled" = "1"
-  })
+  app_settings = merge(local.function_subscriptionmigrations.app_settings_commons, {})
 
   tags = var.tags
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* enable `OnServiceChange` on `io-subscription-migrations`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
We start syncing `migrations` table with `services` collection


### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval

----

Depends on https://github.com/pagopa/io-subscription-migration/pull/13
