### PR TITLE
[#IC-256] Reference `subsmigrations-fn` from `SelfCare IO`

### DIFF
--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -107,6 +107,11 @@ data "azurerm_key_vault_secret" "selfcare_devportal_jira_token" {
   key_vault_id = data.azurerm_key_vault.common.id
 }
 
+data "azurerm_key_vault_secret" "selfcare_subsmigrations_apikey" {
+  name         = "devportal-subsmigrations-APIKEY"
+  key_vault_id = data.azurerm_key_vault.common.id
+}
+
 # JWT
 module "selfcare_jwt" {
   source = "git::https://github.com/pagopa/azurerm.git//jwt_keys?ref=v2.0.21"
@@ -234,6 +239,9 @@ module "appservice_selfcare_be" {
     JIRA_EMAIL_ID_FIELD        = "customfield_10084"
     JIRA_ORGANIZATION_ID_FIELD = "customfield_10088"
     JIRA_TOKEN                 = data.azurerm_key_vault_secret.selfcare_devportal_jira_token.value
+
+    SUBSCRIPTION_MIGRATIONS_URLN   = format("https://%s.azurewebsites.net/api/v1", module.function_subscriptionmigrations.name) 
+    SUBSCRIPTION_MIGRATIONS_APIKEY = data.azurerm_key_vault_secret.selfcare_subsmigrations_apikey.value
   }
 
   allowed_subnets = [module.appgateway_snet.id]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* add env var to `io-p-app-selfcare-be` for `subsmigrations-fn` url and apikey

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
`io-p-app-selfcare-be` must be able to use `subsmigrations-fn`'s exposed rest api

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
