### PR TITLE
[#IC-282] Disable stage slot for ChangeAllSubscriptionsOwnership and configure queue

### DIFF
--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -41,8 +41,9 @@ locals {
       DB_PASSWORD     = data.azurerm_key_vault_secret.subscriptionmigrations_db_server_adm_password.value
 
       // job queues
-      QUEUE_ADD_SERVICE_TO_MIGRATIONS = "add-service-jobs"              // when a service change is accepted to be processed into migration log
-      QUEUE_SUBSCRIPTION_TO_MIGRATE   = "migrate-one-subscription-jobs" // when a subscription is requested to migrate its ownership
+      QUEUE_ADD_SERVICE_TO_MIGRATIONS    = "add-service-jobs"               // when a service change is accepted to be processed into migration log
+      QUEUE_ALL_SUBSCRIPTIONS_TO_MIGRATE = "migrate-all-subscriptions-jobs" // when a migration is requested for all subscriptions
+      QUEUE_SUBSCRIPTION_TO_MIGRATE      = "migrate-one-subscription-jobs"  // when a subscription is requested to migrate its ownership
 
     }
 

--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -209,6 +209,7 @@ module "function_subscriptionmigrations_staging_slot" {
     "AzureWebJobs.OnServiceChange.Disabled"                = "1"
     "AzureWebJobs.UpsertSubscriptionToMigrate.Disabled"    = "1"
     "AzureWebJobs.ChangeOneSubscriptionOwnership.Disabled" = "1"
+    "AzureWebJobs.ChangeAllSubscriptionsOwnership.Disabled" = "1"
   })
 
   tags = var.tags

--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -206,9 +206,9 @@ module "function_subscriptionmigrations_staging_slot" {
 
   app_settings = merge(local.function_subscriptionmigrations.app_settings_commons, {
     // disable listeners on staging slot
-    "AzureWebJobs.OnServiceChange.Disabled"                = "1"
-    "AzureWebJobs.UpsertSubscriptionToMigrate.Disabled"    = "1"
-    "AzureWebJobs.ChangeOneSubscriptionOwnership.Disabled" = "1"
+    "AzureWebJobs.OnServiceChange.Disabled"                 = "1"
+    "AzureWebJobs.UpsertSubscriptionToMigrate.Disabled"     = "1"
+    "AzureWebJobs.ChangeOneSubscriptionOwnership.Disabled"  = "1"
     "AzureWebJobs.ChangeAllSubscriptionsOwnership.Disabled" = "1"
   })
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* disable `ChangeAllSubscriptionsOwnership` in staging slot to prevent it to consume production messages
* declare `QUEUE_ALL_SUBSCRIPTIONS_TO_MIGRATE` queue
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Configuration to support https://github.com/pagopa/io-subscription-migration/pull/32

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
