### PR TITLE
[#IC-319] Change UAT pagopa-proxy url in io-backend conf

### DIFF
--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -76,7 +76,7 @@ locals {
 
       // PAGOPA
       PAGOPA_API_URL_PROD          = "https://${data.azurerm_app_service.pagopa_proxy_prod.default_site_hostname}" # change me for new pagoPA proxy
-      PAGOPA_API_URL_TEST          = "https://${data.azurerm_app_service.pagopa_proxy_test.default_site_hostname}" # change me for new pagoPA proxy
+      PAGOPA_API_URL_TEST          = "https://api.uat.platform.pagopa.it/checkout/auth/payments/v1" # change me for new pagoPA proxy
       PAGOPA_BASE_PATH             = "/pagopa/api/v1"
       PAGOPA_API_KEY_PROD          = data.azurerm_key_vault_secret.app_backend_PAGOPA_API_KEY_PROD.value
       PAGOPA_API_KEY_UAT           = data.azurerm_key_vault_secret.app_backend_PAGOPA_API_KEY_UAT.value

--- a/src/core/data.tf
+++ b/src/core/data.tf
@@ -73,6 +73,7 @@ data "azurerm_app_service" "pagopa_proxy_prod" {
   resource_group_name = format("%s-rg-external", local.project)
 }
 
+# TODO: Can this data be removed?
 data "azurerm_app_service" "pagopa_proxy_test" {
   name                = format("%s-app-pagopaproxytest", local.project)
   resource_group_name = format("%s-rg-external", local.project)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Change the url to the UAT `pagopa-proxy` into the `io-backend` configuration.
<!--- Describe your changes in detail -->

### Motivation and context
The `pagopa-proxy` will be moved to another Azure subscription. The first step il change the url for the UAT `pagopa-proxy` in `io-backend` to verify the proper integration.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Can we remove the data declaration for the old TEST `pagopa-proxy`?

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
