### PR TITLE
[#IC-311] Add Event-hub for cosmos collection 'message-status'

### DIFF
--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -146,7 +146,7 @@ locals {
       PECSERVERS_aruba_serviceId = "01FRMRD5P7H378MDXBBW3DTYCF"
 
       // CGN
-      TEST_CGN_FISCAL_CODES = data.azurerm_key_vault_secret.app_backend_TEST_CGN_FISCAL_CODES.value
+      TEST_CGN_FISCAL_CODES = "" #data.azurerm_key_vault_secret.app_backend_TEST_CGN_FISCAL_CODES.value
     }
     app_settings_l1 = {
       // FUNCTIONS

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -189,7 +189,7 @@ eventhubs = [
   },
   {
     name              = "io-cosmosdb-message-status"
-    partitions        = 5
+    partitions        = 32
     message_retention = 7
     consumers         = ["io-messages"]
     keys = [

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -186,5 +186,25 @@ eventhubs = [
         manage = false
       }
     ]
+  },
+  {
+    name              = "io-cosmosdb-message-status"
+    partitions        = 5
+    message_retention = 7
+    consumers         = ["io-fn-messages"]
+    keys = [
+      {
+        name   = "io-cdc"
+        listen = false
+        send   = true
+        manage = false
+      },
+      {
+        name   = "io-fn-messages"
+        listen = true
+        send   = false
+        manage = false
+      }
+    ]
   }
 ]

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -191,7 +191,7 @@ eventhubs = [
     name              = "io-cosmosdb-message-status"
     partitions        = 5
     message_retention = 7
-    consumers         = ["io-fn-messages"]
+    consumers         = ["io-messages"]
     keys = [
       {
         name   = "io-cdc"
@@ -200,7 +200,7 @@ eventhubs = [
         manage = false
       },
       {
-        name   = "io-fn-messages"
+        name   = "io-messages"
         listen = true
         send   = false
         manage = false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
We need to add a new hub in the IO EventHubs to implement a change data capture on the cosmos collection "message-status". This CDC will be used to materialize message data on a cosmos collection (now) and on an elastic index (later).

### List of changes
<!--- Describe your changes in detail -->
Add a new eventubs configuration on terreform prod env

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
This change will be a part of the solution for the message pagination and search feature

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
