### PR TITLE
[#IC-256] Allow `io-p-app-selfcare-be` to reach `io-p-subsmigrations-fn` via VNET

### DIFF
--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -137,7 +137,7 @@ locals {
 }
 
 module "function_subscriptionmigrations" {
-  source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v2.1.31"
+  source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v2.2.1"
 
   name                = format("%s-%s-fn", local.project, local.function_subscriptionmigrations.app_context.name)
   location            = local.function_subscriptionmigrations.app_context.resource_group.location
@@ -180,7 +180,7 @@ module "function_subscriptionmigrations" {
 
 
 module "function_subscriptionmigrations_staging_slot" {
-  source = "git::https://github.com/pagopa/azurerm.git//function_app_slot?ref=v2.1.31"
+  source = "git::https://github.com/pagopa/azurerm.git//function_app_slot?ref=v2.2.1"
 
   name                = "staging"
   location            = local.function_subscriptionmigrations.app_context.resource_group.location

--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -137,7 +137,7 @@ locals {
 }
 
 module "function_subscriptionmigrations" {
-  source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v2.2.1"
+  source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v2.2.2"
 
   name                = format("%s-%s-fn", local.project, local.function_subscriptionmigrations.app_context.name)
   location            = local.function_subscriptionmigrations.app_context.resource_group.location
@@ -180,7 +180,7 @@ module "function_subscriptionmigrations" {
 
 
 module "function_subscriptionmigrations_staging_slot" {
-  source = "git::https://github.com/pagopa/azurerm.git//function_app_slot?ref=v2.2.1"
+  source = "git::https://github.com/pagopa/azurerm.git//function_app_slot?ref=v2.2.2"
 
   name                = "staging"
   location            = local.function_subscriptionmigrations.app_context.resource_group.location

--- a/src/core/function_subscription_migrations.tf
+++ b/src/core/function_subscription_migrations.tf
@@ -45,6 +45,8 @@ locals {
       QUEUE_ALL_SUBSCRIPTIONS_TO_MIGRATE = "migrate-all-subscriptions-jobs" // when a migration is requested for all subscriptions
       QUEUE_SUBSCRIPTION_TO_MIGRATE      = "migrate-one-subscription-jobs"  // when a subscription is requested to migrate its ownership
 
+      WEBSITE_VNET_ROUTE_ALL = "1"
+      WEBSITE_DNS_SERVER     = "168.63.129.16"
     }
 
     // As we run this application under SelfCare IO logic subdomain,
@@ -164,7 +166,7 @@ module "function_subscriptionmigrations" {
   subnet_id   = local.function_subscriptionmigrations.app_context.snet.id
   allowed_ips = local.app_insights_ips_west_europe
   allowed_subnets = [
-    data.azurerm_subnet.azdoa_snet[0].id,
+    module.selfcare_be_common_snet.id,
   ]
 
   app_settings = merge(local.function_subscriptionmigrations.app_settings_commons, {

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -172,7 +172,7 @@ resource "azurerm_app_service_virtual_network_swift_connection" "selfcare_be" {
 }
 
 module "appservice_selfcare_be" {
-  source = "git::https://github.com/pagopa/azurerm.git//app_service?ref=v2.0.13"
+  source = "git::https://github.com/pagopa/azurerm.git//app_service?ref=v2.2.1"
 
   name                = format("%s-app-selfcare-be", local.project)
   resource_group_name = azurerm_resource_group.selfcare_be_rg.name

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -243,7 +243,8 @@ module "appservice_selfcare_be" {
     SUBSCRIPTION_MIGRATIONS_URL    = format("https://%s.azurewebsites.net/api/v1", module.function_subscriptionmigrations.name)
     SUBSCRIPTION_MIGRATIONS_APIKEY = data.azurerm_key_vault_secret.selfcare_subsmigrations_apikey.value
 
-    WEBSITE_DNS_SERVER = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL                          = "1"
+    WEBSITE_DNS_SERVER                              = "168.63.129.16"
   }
 
   allowed_subnets = [module.appgateway_snet.id]

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -242,6 +242,9 @@ module "appservice_selfcare_be" {
 
     SUBSCRIPTION_MIGRATIONS_URL    = format("https://%s.azurewebsites.net/api/v1", module.function_subscriptionmigrations.name)
     SUBSCRIPTION_MIGRATIONS_APIKEY = data.azurerm_key_vault_secret.selfcare_subsmigrations_apikey.value
+
+    WEBSITE_VNET_ROUTE_ALL                          = "1"
+    WEBSITE_DNS_SERVER                              = "168.63.129.16"
   }
 
   allowed_subnets = [module.appgateway_snet.id]

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -243,8 +243,8 @@ module "appservice_selfcare_be" {
     SUBSCRIPTION_MIGRATIONS_URL    = format("https://%s.azurewebsites.net/api/v1", module.function_subscriptionmigrations.name)
     SUBSCRIPTION_MIGRATIONS_APIKEY = data.azurerm_key_vault_secret.selfcare_subsmigrations_apikey.value
 
-    WEBSITE_VNET_ROUTE_ALL                          = "1"
-    WEBSITE_DNS_SERVER                              = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = "1"
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
   }
 
   allowed_subnets = [module.appgateway_snet.id]

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -243,8 +243,7 @@ module "appservice_selfcare_be" {
     SUBSCRIPTION_MIGRATIONS_URL    = format("https://%s.azurewebsites.net/api/v1", module.function_subscriptionmigrations.name)
     SUBSCRIPTION_MIGRATIONS_APIKEY = data.azurerm_key_vault_secret.selfcare_subsmigrations_apikey.value
 
-    WEBSITE_VNET_ROUTE_ALL                          = "1"
-    WEBSITE_DNS_SERVER                              = "168.63.129.16"
+    WEBSITE_DNS_SERVER = "168.63.129.16"
   }
 
   allowed_subnets = [module.appgateway_snet.id]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
`io-p-app-selfcare-be` needs to reach `io-p-subsmigrations-fn`

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
