### PR TITLE
[IC-364]  Add fn-elt variables

### DIFF
--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -221,5 +221,65 @@ eventhubs = [
         manage = false
       }
     ]
+  },
+  {
+    name              = "pdnd-io-cosmosdb-messages"
+    partitions        = 30
+    message_retention = 7
+    consumers         = []
+    keys = [
+      {
+        name   = "io-fn-elt"
+        listen = false
+        send   = true
+        manage = false
+      },
+      {
+        name   = "pdnd"
+        listen = true
+        send   = false
+        manage = false
+      }
+    ]
+  },
+  {
+    name              = "pdnd-io-cosmosdb-message-status"
+    partitions        = 30
+    message_retention = 7
+    consumers         = []
+    keys = [
+      {
+        name   = "io-fn-elt"
+        listen = false
+        send   = true
+        manage = false
+      },
+      {
+        name   = "pdnd"
+        listen = true
+        send   = false
+        manage = false
+      }
+    ]
+  },
+  {
+    name              = "pdnd-io-cosmosdb-notification-status"
+    partitions        = 30
+    message_retention = 7
+    consumers         = []
+    keys = [
+      {
+        name   = "io-fn-elt"
+        listen = false
+        send   = true
+        manage = false
+      },
+      {
+        name   = "pdnd"
+        listen = true
+        send   = false
+        manage = false
+      }
+    ]
   }
 ]

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -76,15 +76,15 @@ module "function_elt" {
     TARGETKAFKA_topic               = "io-cosmosdb-services"
 
     MESSAGES_TOPIC_NAME              = "pdnd-io-cosmosdb-messages"
-    MESSAGES_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-services.io-fn-elt"].primary_connection_string
+    MESSAGES_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-messages"].primary_connection_string
     MESSAGES_LEASES_PREFIX           = "messages-001"
 
     MESSAGE_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-message-status"
-    MESSAGE_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-services.io-fn-elt"].primary_connection_string
+    MESSAGE_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-message-status"].primary_connection_string
     MESSAGE_STATUS_LEASES_PREFIX           = "message-status-001"
 
     NOTIFICATION_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-message-status"
-    NOTIFICATION_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-services.io-fn-elt"].primary_connection_string
+    NOTIFICATION_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-notification-status"].primary_connection_string
     NOTIFICATION_STATUS_LEASES_PREFIX           = "notification-status-001"
 
 

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -76,15 +76,15 @@ module "function_elt" {
     TARGETKAFKA_topic               = "io-cosmosdb-services"
 
     MESSAGES_TOPIC_NAME              = "pdnd-io-cosmosdb-messages"
-    MESSAGES_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-messages"].primary_connection_string
+    MESSAGES_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-messages.io-fn-elt"].primary_connection_string
     MESSAGES_LEASES_PREFIX           = "messages-001"
 
     MESSAGE_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-message-status"
-    MESSAGE_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-message-status"].primary_connection_string
+    MESSAGE_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-message-status.io-fn-elt"].primary_connection_string
     MESSAGE_STATUS_LEASES_PREFIX           = "message-status-001"
 
     NOTIFICATION_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-message-status"
-    NOTIFICATION_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-notification-status"].primary_connection_string
+    NOTIFICATION_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-notification-status.io-fn-elt"].primary_connection_string
     NOTIFICATION_STATUS_LEASES_PREFIX           = "notification-status-001"
 
 

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -74,13 +74,31 @@ module "function_elt" {
     TARGETKAFKA_idempotent          = "true"
     TARGETKAFKA_transactionalId     = "IO_ELT"
     TARGETKAFKA_topic               = "io-cosmosdb-services"
-    ERROR_STORAGE_ACCOUNT           = module.storage_account_elt.name
-    ERROR_STORAGE_KEY               = module.storage_account_elt.primary_access_key
-    ERROR_STORAGE_TABLE             = azurerm_storage_table.fnelterrors.name
-    COMMAND_STORAGE                 = module.storage_account_elt.primary_connection_string
-    COMMAND_STORAGE_TABLE           = azurerm_storage_table.fneltcommands.name
-    IMPORT_TOPIC_NAME               = "import-command"
-    IMPORT_TOPIC_CONNECTION_STRING  = module.event_hub.keys["import-command.io-fn-elt"].primary_connection_string
+
+    MESSAGES_TOPIC_NAME              = "pdnd-io-cosmosdb-messages"
+    MESSAGES_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-services.io-fn-elt"].primary_connection_string
+    MESSAGES_LEASES_PREFIX           = "messages-001"
+
+    MESSAGE_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-message-status"
+    MESSAGE_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-services.io-fn-elt"].primary_connection_string
+    MESSAGE_STATUS_LEASES_PREFIX           = "message-status-001"
+
+    NOTIFICATION_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-message-status"
+    NOTIFICATION_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-services.io-fn-elt"].primary_connection_string
+    NOTIFICATION_STATUS_LEASES_PREFIX           = "notification-status-001"
+
+
+    ERROR_STORAGE_ACCOUNT                   = module.storage_account_elt.name
+    ERROR_STORAGE_KEY                       = module.storage_account_elt.primary_access_key
+    ERROR_STORAGE_TABLE                     = azurerm_storage_table.fnelterrors.name
+    ERROR_STORAGE_TABLE_MESSAGES            = azurerm_storage_table.fnelterrors_messages.name
+    ERROR_STORAGE_TABLE_MESSAGE_STATUS      = azurerm_storage_table.fnelterrors_message_status.name
+    ERROR_STORAGE_TABLE_NOTIFICATION_STATUS = azurerm_storage_table.fnelterrors_notification_status.name
+
+    COMMAND_STORAGE                = module.storage_account_elt.primary_connection_string
+    COMMAND_STORAGE_TABLE          = azurerm_storage_table.fneltcommands.name
+    IMPORT_TOPIC_NAME              = "import-command"
+    IMPORT_TOPIC_CONNECTION_STRING = module.event_hub.keys["import-command.io-fn-elt"].primary_connection_string
 
     PROFILE_TOPIC_NAME              = "io-cosmosdb-profiles"
     PROFILE_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-profiles.io-fn-elt"].primary_connection_string
@@ -144,6 +162,21 @@ module "storage_account_elt" {
 
 resource "azurerm_storage_table" "fnelterrors" {
   name                 = "fnelterrors"
+  storage_account_name = module.storage_account_elt.name
+}
+
+resource "azurerm_storage_table" "fnelterrors_messages" {
+  name                 = "fnelterrorsMessages"
+  storage_account_name = module.storage_account_elt.name
+}
+
+resource "azurerm_storage_table" "fnelterrors_message_status" {
+  name                 = "fnelterrorsMessageStatus"
+  storage_account_name = module.storage_account_elt.name
+}
+
+resource "azurerm_storage_table" "fnelterrors_notification_status" {
+  name                 = "fnelterrorsNotificationStatus"
   storage_account_name = module.storage_account_elt.name
 }
 

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -26,6 +26,12 @@ module "function_elt_snetout" {
   }
 }
 
+# Storage iopstapi
+data "azurerm_storage_account" "iopstapi" {
+  name                = "iopstapi"
+  resource_group_name = azurerm_resource_group.rg_internal.name
+}
+
 # Storage iopstapi replica
 data "azurerm_storage_account" "api_replica" {
   name                = "iopstapireplica"
@@ -118,8 +124,11 @@ module "function_elt" {
 
     SERVICEID_EXCLUSION_LIST = data.azurerm_key_vault_secret.services_exclusion_list.value
 
-    MessageContentStorageConnection  = data.azurerm_storage_account.api_replica.primary_connection_string
-    ServiceInfoBlobStorageConnection = data.azurerm_storage_account.cdnassets.primary_connection_string
+    #iopstapi connection string
+    MessageContentPrimaryStorageConnection = data.azurerm_storage_account.iopstapi.primary_connection_string
+    #iopstapireplica connection string
+    MessageContentStorageConnection        = data.azurerm_storage_account.api_replica.primary_connection_string
+    ServiceInfoBlobStorageConnection       = data.azurerm_storage_account.cdnassets.primary_connection_string
   }
 
   allowed_subnets = [

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -83,7 +83,7 @@ module "function_elt" {
     MESSAGE_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-message-status.io-fn-elt"].primary_connection_string
     MESSAGE_STATUS_LEASES_PREFIX           = "message-status-001"
 
-    NOTIFICATION_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-message-status"
+    NOTIFICATION_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-notification-status"
     NOTIFICATION_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-notification-status.io-fn-elt"].primary_connection_string
     NOTIFICATION_STATUS_LEASES_PREFIX           = "notification-status-001"
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
 - Added 3 new Event Hub topic: `pdnd-io-cosmosdb-messages`, `pdnd-io-cosmosdb-message-status`, `pdnd-io-cosmosdb-message-status`
 - Added new tables for handling kafka failures: `fnelterrors_messages`, `fnelterrors_message_status`, `fnelterrors_notification_status`
 - Set new env variables for enabling ChangeFeed leases over `messages`, `message-status` and `notification-status` collections

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Enable sending message data to PDND

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
