### PR TITLE
[#IC-436] Add internal error queues to fn-elt to implement retry mechanism

### DIFF
--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -159,9 +159,12 @@ module "function_elt" {
     "private_dns_zone_queue_ids" = [data.azurerm_private_dns_zone.privatelink_queue_core_windows_net.id],
     "private_dns_zone_table_ids" = [data.azurerm_private_dns_zone.privatelink_table_core_windows_net.id],
     "queues" = [
-      local.function_elt.app_settings.MESSAGES_FAILURE_QUEUE_NAME, "${local.function_elt.app_settings.MESSAGES_FAILURE_QUEUE_NAME}-poison",
-      local.function_elt.app_settings.MESSAGE_STATUS_FAILURE_QUEUE_NAME, "${local.function_elt.app_settings.MESSAGE_STATUS_FAILURE_QUEUE_NAME}-poison",
-      local.function_elt.app_settings.SERVICES_FAILURE_QUEUE_NAME, "${local.function_elt.app_settings.SERVICES_FAILURE_QUEUE_NAME}-poison",
+      local.function_elt.app_settings.MESSAGES_FAILURE_QUEUE_NAME,
+      "${local.function_elt.app_settings.MESSAGES_FAILURE_QUEUE_NAME}-poison",
+      local.function_elt.app_settings.MESSAGE_STATUS_FAILURE_QUEUE_NAME,
+      "${local.function_elt.app_settings.MESSAGE_STATUS_FAILURE_QUEUE_NAME}-poison",
+      local.function_elt.app_settings.SERVICES_FAILURE_QUEUE_NAME,
+      "${local.function_elt.app_settings.SERVICES_FAILURE_QUEUE_NAME}-poison"
     ],
     "containers"           = [],
     "blobs_retention_days" = 1,

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -155,12 +155,16 @@ module "function_elt" {
   internal_storage = {
     "enable"                     = true,
     "private_endpoint_subnet_id" = data.azurerm_subnet.private_endpoints_subnet.id,
+    "private_dns_zone_blob_ids"  = [data.azurerm_private_dns_zone.privatelink_blob_core_windows_net.id],
     "private_dns_zone_queue_ids" = [data.azurerm_private_dns_zone.privatelink_queue_core_windows_net.id],
+    "private_dns_zone_table_ids" = [data.azurerm_private_dns_zone.privatelink_table_core_windows_net.id],
     "queues" = [
       local.function_elt.app_settings.MESSAGES_FAILURE_QUEUE_NAME, "${local.function_elt.app_settings.MESSAGES_FAILURE_QUEUE_NAME}-poison",
       local.function_elt.app_settings.MESSAGE_STATUS_FAILURE_QUEUE_NAME, "${local.function_elt.app_settings.MESSAGE_STATUS_FAILURE_QUEUE_NAME}-poison",
       local.function_elt.app_settings.SERVICES_FAILURE_QUEUE_NAME, "${local.function_elt.app_settings.SERVICES_FAILURE_QUEUE_NAME}-poison",
-    ]
+    ],
+    "containers"           = [],
+    "blobs_retention_days" = 1,
   }
 
   allowed_subnets = [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The current data stream implemented on fn-elt store errors without reprocessing. We will use a storage queue for each stream to re-processs failed publishing operation.

### List of changes
<!--- Describe your changes in detail -->
enable internal storage
add messages queue
add message-status queue
add services queue

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
Implements retry mechanism for kafka publishing

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
