### PR TITLE
[ICC-113] [FIX] Add new IS_APPBACKENDLI env variable in appbackend instances

### DIFF
--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -158,16 +158,19 @@ locals {
       TEST_CGN_FISCAL_CODES = "" #data.azurerm_key_vault_secret.app_backend_TEST_CGN_FISCAL_CODES.value
     }
     app_settings_l1 = {
+      IS_APPBACKENDLI      = "false"
       // FUNCTIONS
       API_URL              = "http://${data.azurerm_function_app.fnapp_app1.default_hostname}/api/v1"
       APP_MESSAGES_API_URL = "https://${module.app_messages_function[0].default_hostname}/api/v1"
     }
     app_settings_l2 = {
+      IS_APPBACKENDLI      = "false"
       // FUNCTIONS
       API_URL              = "http://${data.azurerm_function_app.fnapp_app2.default_hostname}/api/v1"
       APP_MESSAGES_API_URL = "https://${module.app_messages_function[1].default_hostname}/api/v1"
     }
     app_settings_li = {
+      IS_APPBACKENDLI      = "true"
       // FUNCTIONS
       API_URL              = "http://${data.azurerm_function_app.fnapp_app1.default_hostname}/api/v1" # not used
       APP_MESSAGES_API_URL = "https://${module.app_messages_function[0].default_hostname}/api/v1"     # not used


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- add new IS_APPBACKENDLI env variable in appbackend instances
- set it to true only or appbackend_li instance

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Discriminate io-backend instance for enabling/disabling notify and session lock endpoints

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
