### PR TITLE
[#IOPSC-24] Add healthcheck to appbackend instances

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -276,6 +276,8 @@
 | [azurerm_key_vault_secret.app_backend_PAGOPA_API_KEY_UAT](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_PECSERVER_ARUBA_TOKEN_SECRET](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_PECSERVER_TOKEN_SECRET](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.app_backend_PN_API_KEY_PROD_ENV](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.app_backend_PN_API_KEY_TEST_ENV](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_PRE_SHARED_KEY](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_SAML_CERT](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_SAML_KEY](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |

--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -8,6 +8,7 @@ locals {
       WEBSITE_RUN_FROM_PACKAGE                        = "1"
       WEBSITE_VNET_ROUTE_ALL                          = "1"
       WEBSITE_DNS_SERVER                              = "168.63.129.16"
+      WEBSITE_HEALTHCHECK_MAXPINGFAILURES             = "3"
 
       APPINSIGHTS_INSTRUMENTATIONKEY = data.azurerm_application_insights.application_insights.instrumentation_key
 
@@ -419,7 +420,7 @@ module "appservice_app_backendl1" {
   always_on         = true
   linux_fx_version  = "NODE|14-lts"
   app_command_line  = "node /home/site/wwwroot/src/server.js"
-  health_check_path = null
+  health_check_path = "/ping"
 
   app_settings = merge(
     local.app_backend.app_settings_common,
@@ -460,7 +461,7 @@ module "appservice_app_backendl1_slot_staging" {
   always_on         = true
   linux_fx_version  = "NODE|14-lts"
   app_command_line  = "node /home/site/wwwroot/src/server.js"
-  health_check_path = null
+  health_check_path = "/ping"
 
   app_settings = merge(
     local.app_backend.app_settings_common,
@@ -633,7 +634,7 @@ module "appservice_app_backendl2" {
   always_on         = true
   linux_fx_version  = "NODE|14-lts"
   app_command_line  = "node /home/site/wwwroot/src/server.js"
-  health_check_path = null
+  health_check_path = "/ping"
 
   app_settings = merge(
     local.app_backend.app_settings_common,
@@ -674,7 +675,7 @@ module "appservice_app_backendl2_slot_staging" {
   always_on         = true
   linux_fx_version  = "NODE|14-lts"
   app_command_line  = "node /home/site/wwwroot/src/server.js"
-  health_check_path = null
+  health_check_path = "/ping"
 
   app_settings = merge(
     local.app_backend.app_settings_common,
@@ -847,7 +848,7 @@ module "appservice_app_backendli" {
   always_on         = true
   linux_fx_version  = "NODE|14-lts"
   app_command_line  = "node /home/site/wwwroot/src/server.js"
-  health_check_path = null
+  health_check_path = "/ping"
 
   app_settings = merge(
     local.app_backend.app_settings_common,
@@ -886,7 +887,7 @@ module "appservice_app_backendli_slot_staging" {
   always_on         = true
   linux_fx_version  = "NODE|14-lts"
   app_command_line  = "node /home/site/wwwroot/src/server.js"
-  health_check_path = null
+  health_check_path = "/ping"
 
   app_settings = merge(
     local.app_backend.app_settings_common,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* set health check on `/ping` to enable automatic failover
* set 3 minutes as tolerance time span

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Some instances of `appbackendl1`, `appbackendl2` and `appbackendli` start with bad operating system configuration and hence fail to serve requests. By enabling health checks, we can automatically remove such instances from load balancers and increase the overall system availability.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
