### PR TITLE
[#IOCIT-74] Add PN Activation configuration

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -276,8 +276,10 @@
 | [azurerm_key_vault_secret.app_backend_PAGOPA_API_KEY_UAT](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_PECSERVER_ARUBA_TOKEN_SECRET](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_PECSERVER_TOKEN_SECRET](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.app_backend_PN_API_KEY](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_PN_API_KEY_PROD_ENV](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_PN_API_KEY_TEST_ENV](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.app_backend_PN_API_KEY_UAT](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_PRE_SHARED_KEY](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_SAML_CERT](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_SAML_KEY](https://registry.terraform.io/providers/hashicorp/azurerm/2.87.0/docs/data-sources/key_vault_secret) | data source |

--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -131,6 +131,8 @@ locals {
       FF_MESSAGES_BETA_TESTER_LIST   = data.azurerm_key_vault_secret.app_backend_APP_MESSAGES_BETA_FISCAL_CODES.value
       FF_MESSAGES_CANARY_USERS_REGEX = "XYZ"
 
+      FF_PN_ACTIVATION_ENABLED = "0" // Temporarily disabled
+
       // TEST LOGIN
       TEST_LOGIN_PASSWORD     = data.azurerm_key_vault_secret.app_backend_TEST_LOGIN_PASSWORD.value
       TEST_LOGIN_FISCAL_CODES = local.test_users
@@ -160,6 +162,13 @@ locals {
 
       // Service ID PN
       PN_SERVICE_ID = var.pn_service_id
+
+      // PN Service Activation
+      PN_ACTIVATION_BASE_PATH = "/api/v1/pn"
+      PN_API_KEY              = data.azurerm_key_vault_secret.app_backend_PN_API_KEY.value
+      PN_API_KEY_UAT          = data.azurerm_key_vault_secret.app_backend_PN_API_KEY_UAT.value
+      PN_API_URL              = "https://api-iol.pn.pagopa.it"
+      PN_API_URL_UAT          = "https://api-io.coll.pn.pagopa.it"
 
       // Third Party Services
       THIRD_PARTY_CONFIG_LIST = jsonencode([
@@ -369,6 +378,16 @@ data "azurerm_key_vault_secret" "app_backend_APP_MESSAGES_BETA_FISCAL_CODES" {
 
 data "azurerm_key_vault_secret" "app_backend_PN_API_KEY_TEST_ENV" {
   name         = "appbackend-PN-API-KEY-TEST-ENV"
+  key_vault_id = data.azurerm_key_vault.common.id
+}
+
+data "azurerm_key_vault_secret" "app_backend_PN_API_KEY" {
+  name         = "appbackend-PN-API-KEY-ENV"
+  key_vault_id = data.azurerm_key_vault.common.id
+}
+
+data "azurerm_key_vault_secret" "app_backend_PN_API_KEY_UAT" {
+  name         = "appbackend-PN-API-KEY-UAT-ENV"
   key_vault_id = data.azurerm_key_vault.common.id
 }
 

--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -167,7 +167,7 @@ locals {
       PN_ACTIVATION_BASE_PATH = "/api/v1/pn"
       PN_API_KEY              = data.azurerm_key_vault_secret.app_backend_PN_API_KEY.value
       PN_API_KEY_UAT          = data.azurerm_key_vault_secret.app_backend_PN_API_KEY_UAT.value
-      PN_API_URL              = "https://api-iol.pn.pagopa.it"
+      PN_API_URL              = "https://api-io.pn.pagopa.it"
       PN_API_URL_UAT          = "https://api-io.coll.pn.pagopa.it"
 
       // Third Party Services


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add ENV variables to `io-backend` resources.
Two new key vault values are required (`appbackend-PN-API-KEY-ENV` e `appbackend-PN-API-KEY-UAT-ENV`).


### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
To call the PN Activation service the backend requires some ENV variables that are added with this PR. The feature flags that enables the integration is temporarily disabled.

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
