### PR TITLE
[#IOCIT-74] Change UAT PN endpoint to DEV, enable FF

### DIFF
--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -131,7 +131,7 @@ locals {
       FF_MESSAGES_BETA_TESTER_LIST   = data.azurerm_key_vault_secret.app_backend_APP_MESSAGES_BETA_FISCAL_CODES.value
       FF_MESSAGES_CANARY_USERS_REGEX = "XYZ"
 
-      FF_PN_ACTIVATION_ENABLED = "0" // Temporarily disabled
+      FF_PN_ACTIVATION_ENABLED = "1"
 
       // TEST LOGIN
       TEST_LOGIN_PASSWORD     = data.azurerm_key_vault_secret.app_backend_TEST_LOGIN_PASSWORD.value
@@ -168,7 +168,7 @@ locals {
       PN_API_KEY              = data.azurerm_key_vault_secret.app_backend_PN_API_KEY.value
       PN_API_KEY_UAT          = data.azurerm_key_vault_secret.app_backend_PN_API_KEY_UAT.value
       PN_API_URL              = "https://api-io.pn.pagopa.it"
-      PN_API_URL_UAT          = "https://api-io.coll.pn.pagopa.it"
+      PN_API_URL_UAT          = "https://api-io.dev.pn.pagopa.it" // DEV value will be changed with UAT when available
 
       // Third Party Services
       THIRD_PARTY_CONFIG_LIST = jsonencode([


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Enable FF for PN Activation service
Change UAT service url for PN to DEV service url
<!--- Describe your changes in detail -->

### Motivation and context
UAT service url is temporarily unavailable, we update the configuration with DEV endpoint to complete an integration test with App and PN.
Enable the feature flag to activate the new endpoint in `io-backend`.  
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
