### PR TITLE
fix: Avoid code review to run on lock.hcl files

### DIFF
--- a/.devops/core-code-review-pipelines.yml
+++ b/.devops/core-code-review-pipelines.yml
@@ -7,6 +7,8 @@ pr:
     include:
       - "src/core/*"
       - ".devops/core-code-review-pipelines.yml"
+    exclude:
+      - '**/*.lock.hcl'
 
 parameters:
   - name: "PROD"

--- a/.devops/messages-code-review-pipelines.yml
+++ b/.devops/messages-code-review-pipelines.yml
@@ -8,6 +8,8 @@ pr:
       - 'src/domains/messages-app'
       - 'src/domains/messages-common'
       - ".devops/messages-code-review-pipelines.yml"
+    exclude:
+      - '**/*.lock.hcl'
 
 parameters:
   - name: 'COMMON'

--- a/.devops/payments-code-review-pipelines.yml
+++ b/.devops/payments-code-review-pipelines.yml
@@ -8,6 +8,8 @@ pr:
       - 'src/domains/payments-app'
       - 'src/domains/payments-common'
       - ".devops/payments-code-review-pipelines.yml"
+    exclude:
+      - '**/*.lock.hcl'
 
 parameters:
   - name: 'COMMON'

--- a/.devops/profile-code-review-pipelines.yml
+++ b/.devops/profile-code-review-pipelines.yml
@@ -8,6 +8,8 @@ pr:
       - 'src/domains/profile-app'
       - 'src/domains/profile-common'
       - ".devops/profile-code-review-pipelines.yml"
+    exclude:
+      - '**/*.lock.hcl'
 
 parameters:
   - name: 'COMMON'

--- a/.devops/sign-code-review-pipelines.yml
+++ b/.devops/sign-code-review-pipelines.yml
@@ -8,6 +8,8 @@ pr:
       - "src/domains/sign-app"
       - "src/domains/sign"
       - ".devops/sign-code-review-pipelines.yml"
+    exclude:
+      - '**/*.lock.hcl'
 
 # parameters:
 #   - name: "COMMON"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Added in all the code review pipelines the snippet:

```yaml
    exclude:
      - '**/*.lock.hcl'
```
### Motivation and context

Avoid code-review to run in case other commits, during pre-commit change the lock.hcl files in other folders

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
