### PR TITLE
[#ICC-121]  Add queues for failures and disable legacy publish services function

### DIFF
--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -1,3 +1,95 @@
+locals {
+  function_elt = {
+    app_settings = {
+      AzureWebJobs.CosmosApiServicesChangeFeed.Disabled" = "1"
+
+      FUNCTIONS_WORKER_RUNTIME       = "node"
+      WEBSITE_NODE_DEFAULT_VERSION   = "14.16.0"
+      FUNCTIONS_WORKER_PROCESS_COUNT = 4
+      NODE_ENV                       = "production"
+
+      // Keepalive fields are all optionals
+      FETCH_KEEPALIVE_ENABLED             = "true"
+      FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL   = "110000"
+      FETCH_KEEPALIVE_MAX_SOCKETS         = "40"
+      FETCH_KEEPALIVE_MAX_FREE_SOCKETS    = "10"
+      FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
+      FETCH_KEEPALIVE_TIMEOUT             = "60000"
+
+      COSMOSDB_NAME                = "db"
+      COSMOSDB_URI                 = data.azurerm_cosmosdb_account.cosmos_api.endpoint
+      COSMOSDB_KEY                 = data.azurerm_cosmosdb_account.cosmos_api.primary_master_key
+      COSMOS_API_CONNECTION_STRING = format("AccountEndpoint=%s;AccountKey=%s;", data.azurerm_cosmosdb_account.cosmos_api.endpoint, data.azurerm_cosmosdb_account.cosmos_api.primary_master_key)
+
+      TARGETKAFKA_clientId            = "IO_FUNCTIONS_ELT"
+      TARGETKAFKA_brokers             = local.event_hub.connection
+      TARGETKAFKA_ssl                 = "true"
+      TARGETKAFKA_sasl_mechanism      = "plain"
+      TARGETKAFKA_sasl_username       = "$ConnectionString"
+      TARGETKAFKA_sasl_password       = module.event_hub.keys["io-cosmosdb-services.io-fn-elt"].primary_connection_string
+      TARGETKAFKA_maxInFlightRequests = "1"
+      TARGETKAFKA_idempotent          = "true"
+      TARGETKAFKA_transactionalId     = "IO_ELT"
+      TARGETKAFKA_topic               = "io-cosmosdb-services"
+
+      MESSAGES_TOPIC_NAME              = "pdnd-io-cosmosdb-messages"
+      MESSAGES_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-messages.io-fn-elt"].primary_connection_string
+      MESSAGES_LEASES_PREFIX           = "messages-001"
+
+      MESSAGE_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-message-status"
+      MESSAGE_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-message-status.io-fn-elt"].primary_connection_string
+      MESSAGE_STATUS_LEASES_PREFIX           = "message-status-001"
+
+      NOTIFICATION_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-notification-status"
+      NOTIFICATION_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-notification-status.io-fn-elt"].primary_connection_string
+      NOTIFICATION_STATUS_LEASES_PREFIX           = "notification-status-001"
+
+
+      ERROR_STORAGE_ACCOUNT                   = module.storage_account_elt.name
+      ERROR_STORAGE_KEY                       = module.storage_account_elt.primary_access_key
+      ERROR_STORAGE_TABLE                     = azurerm_storage_table.fnelterrors.name
+      ERROR_STORAGE_TABLE_MESSAGES            = azurerm_storage_table.fnelterrors_messages.name
+      ERROR_STORAGE_TABLE_MESSAGE_STATUS      = azurerm_storage_table.fnelterrors_message_status.name
+      ERROR_STORAGE_TABLE_NOTIFICATION_STATUS = azurerm_storage_table.fnelterrors_notification_status.name
+
+      COMMAND_STORAGE                = module.storage_account_elt.primary_connection_string
+      COMMAND_STORAGE_TABLE          = azurerm_storage_table.fneltcommands.name
+      IMPORT_TOPIC_NAME              = "import-command"
+      IMPORT_TOPIC_CONNECTION_STRING = module.event_hub.keys["import-command.io-fn-elt"].primary_connection_string
+
+      PROFILE_TOPIC_NAME              = "io-cosmosdb-profiles"
+      PROFILE_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-profiles.io-fn-elt"].primary_connection_string
+
+      COSMOSDB_REPLICA_NAME     = "db"
+      COSMOSDB_REPLICA_URI      = replace(data.azurerm_cosmosdb_account.cosmos_api.endpoint, "io-p-cosmos-api", "io-p-cosmos-api-northeurope")
+      COSMOSDB_REPLICA_KEY      = data.azurerm_cosmosdb_account.cosmos_api.primary_master_key
+      COSMOSDB_REPLICA_LOCATION = "North Europe"
+
+      MESSAGE_EXPORTS_COMMAND_TABLE       = azurerm_storage_table.fneltexports.name
+      MESSAGE_EXPORT_STEP_1_CONTAINER     = azurerm_storage_container.container_messages_report_step1.name
+      MESSAGE_EXPORT_STEP_FINAL_CONTAINER = azurerm_storage_container.container_messages_report_step_final.name
+
+      COSMOS_CHUNK_SIZE            = "1000"
+      COSMOS_DEGREE_OF_PARALLELISM = "2"
+      MESSAGE_CONTENT_CHUNK_SIZE   = "200"
+
+      SERVICEID_EXCLUSION_LIST = data.azurerm_key_vault_secret.services_exclusion_list.value
+
+      PN_SERVICE_ID = var.pn_service_id
+
+      #iopstapi connection string
+      MessageContentPrimaryStorageConnection = data.azurerm_storage_account.iopstapi.primary_connection_string
+      #iopstapireplica connection string
+      MessageContentStorageConnection  = data.azurerm_storage_account.api_replica.primary_connection_string
+      ServiceInfoBlobStorageConnection = data.azurerm_storage_account.cdnassets.primary_connection_string
+
+      MESSAGES_FAILURE_QUEUE_NAME       = "pdnd-io-cosmosdb-messages-failure"
+      MESSAGE_STATUS_FAILURE_QUEUE_NAME = "pdnd-io-cosmosdb-message-status-failure"
+      SERVICES_FAILURE_QUEUE_NAME       = "pdnd-io-cosmosdb-services-failure"
+    }
+  }
+}
+
 resource "azurerm_resource_group" "elt_rg" {
   name     = format("%s-elt-rg", local.project)
   location = var.location
@@ -59,88 +151,27 @@ module "function_elt" {
     maximum_elastic_worker_count = 1
   }
 
-  app_settings = {
-    AzureWebJobs.CosmosApiServicesChangeFeed.Disabled" = "1"
+  app_settings = merge(
+    local.function_elt.app_settings,
+    {}
+  )
 
-    FUNCTIONS_WORKER_RUNTIME       = "node"
-    WEBSITE_NODE_DEFAULT_VERSION   = "14.16.0"
-    FUNCTIONS_WORKER_PROCESS_COUNT = 4
-    NODE_ENV                       = "production"
-
-    // Keepalive fields are all optionals
-    FETCH_KEEPALIVE_ENABLED             = "true"
-    FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL   = "110000"
-    FETCH_KEEPALIVE_MAX_SOCKETS         = "40"
-    FETCH_KEEPALIVE_MAX_FREE_SOCKETS    = "10"
-    FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
-    FETCH_KEEPALIVE_TIMEOUT             = "60000"
-
-    COSMOSDB_NAME                = "db"
-    COSMOSDB_URI                 = data.azurerm_cosmosdb_account.cosmos_api.endpoint
-    COSMOSDB_KEY                 = data.azurerm_cosmosdb_account.cosmos_api.primary_master_key
-    COSMOS_API_CONNECTION_STRING = format("AccountEndpoint=%s;AccountKey=%s;", data.azurerm_cosmosdb_account.cosmos_api.endpoint, data.azurerm_cosmosdb_account.cosmos_api.primary_master_key)
-
-    TARGETKAFKA_clientId            = "IO_FUNCTIONS_ELT"
-    TARGETKAFKA_brokers             = local.event_hub.connection
-    TARGETKAFKA_ssl                 = "true"
-    TARGETKAFKA_sasl_mechanism      = "plain"
-    TARGETKAFKA_sasl_username       = "$ConnectionString"
-    TARGETKAFKA_sasl_password       = module.event_hub.keys["io-cosmosdb-services.io-fn-elt"].primary_connection_string
-    TARGETKAFKA_maxInFlightRequests = "1"
-    TARGETKAFKA_idempotent          = "true"
-    TARGETKAFKA_transactionalId     = "IO_ELT"
-    TARGETKAFKA_topic               = "io-cosmosdb-services"
-
-    MESSAGES_TOPIC_NAME              = "pdnd-io-cosmosdb-messages"
-    MESSAGES_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-messages.io-fn-elt"].primary_connection_string
-    MESSAGES_LEASES_PREFIX           = "messages-001"
-
-    MESSAGE_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-message-status"
-    MESSAGE_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-message-status.io-fn-elt"].primary_connection_string
-    MESSAGE_STATUS_LEASES_PREFIX           = "message-status-001"
-
-    NOTIFICATION_STATUS_TOPIC_NAME              = "pdnd-io-cosmosdb-notification-status"
-    NOTIFICATION_STATUS_TOPIC_CONNECTION_STRING = module.event_hub.keys["pdnd-io-cosmosdb-notification-status.io-fn-elt"].primary_connection_string
-    NOTIFICATION_STATUS_LEASES_PREFIX           = "notification-status-001"
-
-
-    ERROR_STORAGE_ACCOUNT                   = module.storage_account_elt.name
-    ERROR_STORAGE_KEY                       = module.storage_account_elt.primary_access_key
-    ERROR_STORAGE_TABLE                     = azurerm_storage_table.fnelterrors.name
-    ERROR_STORAGE_TABLE_MESSAGES            = azurerm_storage_table.fnelterrors_messages.name
-    ERROR_STORAGE_TABLE_MESSAGE_STATUS      = azurerm_storage_table.fnelterrors_message_status.name
-    ERROR_STORAGE_TABLE_NOTIFICATION_STATUS = azurerm_storage_table.fnelterrors_notification_status.name
-
-    COMMAND_STORAGE                = module.storage_account_elt.primary_connection_string
-    COMMAND_STORAGE_TABLE          = azurerm_storage_table.fneltcommands.name
-    IMPORT_TOPIC_NAME              = "import-command"
-    IMPORT_TOPIC_CONNECTION_STRING = module.event_hub.keys["import-command.io-fn-elt"].primary_connection_string
-
-    PROFILE_TOPIC_NAME              = "io-cosmosdb-profiles"
-    PROFILE_TOPIC_CONNECTION_STRING = module.event_hub.keys["io-cosmosdb-profiles.io-fn-elt"].primary_connection_string
-
-    COSMOSDB_REPLICA_NAME     = "db"
-    COSMOSDB_REPLICA_URI      = replace(data.azurerm_cosmosdb_account.cosmos_api.endpoint, "io-p-cosmos-api", "io-p-cosmos-api-northeurope")
-    COSMOSDB_REPLICA_KEY      = data.azurerm_cosmosdb_account.cosmos_api.primary_master_key
-    COSMOSDB_REPLICA_LOCATION = "North Europe"
-
-    MESSAGE_EXPORTS_COMMAND_TABLE       = azurerm_storage_table.fneltexports.name
-    MESSAGE_EXPORT_STEP_1_CONTAINER     = azurerm_storage_container.container_messages_report_step1.name
-    MESSAGE_EXPORT_STEP_FINAL_CONTAINER = azurerm_storage_container.container_messages_report_step_final.name
-
-    COSMOS_CHUNK_SIZE            = "1000"
-    COSMOS_DEGREE_OF_PARALLELISM = "2"
-    MESSAGE_CONTENT_CHUNK_SIZE   = "200"
-
-    SERVICEID_EXCLUSION_LIST = data.azurerm_key_vault_secret.services_exclusion_list.value
-
-    PN_SERVICE_ID = var.pn_service_id
-
-    #iopstapi connection string
-    MessageContentPrimaryStorageConnection = data.azurerm_storage_account.iopstapi.primary_connection_string
-    #iopstapireplica connection string
-    MessageContentStorageConnection  = data.azurerm_storage_account.api_replica.primary_connection_string
-    ServiceInfoBlobStorageConnection = data.azurerm_storage_account.cdnassets.primary_connection_string
+  internal_storage = {
+    "enable"                     = true,
+    "private_endpoint_subnet_id" = data.azurerm_subnet.private_endpoints_subnet.id,
+    "private_dns_zone_blob_ids"  = [data.azurerm_private_dns_zone.privatelink_blob_core_windows_net.id],
+    "private_dns_zone_queue_ids" = [data.azurerm_private_dns_zone.privatelink_queue_core_windows_net.id],
+    "private_dns_zone_table_ids" = [data.azurerm_private_dns_zone.privatelink_table_core_windows_net.id],
+    "queues" = [
+      local.function_elt.app_settings.MESSAGES_FAILURE_QUEUE_NAME,
+      "${local.function_elt.app_settings.MESSAGES_FAILURE_QUEUE_NAME}-poison",
+      local.function_elt.app_settings.MESSAGE_STATUS_FAILURE_QUEUE_NAME,
+      "${local.function_elt.app_settings.MESSAGE_STATUS_FAILURE_QUEUE_NAME}-poison",
+      local.function_elt.app_settings.SERVICES_FAILURE_QUEUE_NAME,
+      "${local.function_elt.app_settings.SERVICES_FAILURE_QUEUE_NAME}-poison"
+    ],
+    "containers"           = [],
+    "blobs_retention_days" = 1,
   }
 
   allowed_subnets = [

--- a/src/core/function_elt.tf
+++ b/src/core/function_elt.tf
@@ -60,6 +60,8 @@ module "function_elt" {
   }
 
   app_settings = {
+    AzureWebJobs.CosmosApiServicesChangeFeed.Disabled" = "1"
+
     FUNCTIONS_WORKER_RUNTIME       = "node"
     WEBSITE_NODE_DEFAULT_VERSION   = "14.16.0"
     FUNCTIONS_WORKER_PROCESS_COUNT = 4


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add storage queues to manage failures.

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
