### PR TITLE
[#IOPAE-56] Add visibility columns for subscription migrations

### DIFF
--- a/src/psql/selfcare/subscription-migrations/migrations/db/V3__visibility_fileds.sql
+++ b/src/psql/selfcare/subscription-migrations/migrations/db/V3__visibility_fileds.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "SelfcareIOSubscriptionMigrations".migrations
+    ADD COLUMN "isVisibile" TYPE boolean NOT NULL default false,
+    ADD COLUMN "hasBeenVisibleOnce" TYPE boolean NOT NULL default false;

--- a/src/psql/selfcare/subscription-migrations/migrations/db/V3__visibility_fileds.sql
+++ b/src/psql/selfcare/subscription-migrations/migrations/db/V3__visibility_fileds.sql
@@ -1,3 +1,7 @@
 ALTER TABLE "SelfcareIOSubscriptionMigrations".migrations
+    -- In order to avoid null fileds, we set FALSE as default
+    -- This is harmless as
+    --  * we will ensure this field to be set at insert time
+    --  * the field is not considered yet by the application (at the time of writing)
     ADD COLUMN "isVisibile" TYPE boolean NOT NULL default false,
     ADD COLUMN "hasBeenVisibleOnce" TYPE boolean NOT NULL default false;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* add `isVisibile` field
* add `hasBeenVisibleOnce` field

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Fields are both boolean and tell if the subscription is currently visible or it has been at least once in its lifetime.


### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
