### PR TITLE
Alter column type for DeveloperPortalServiceData schema

### DIFF
--- a/src/psql/selfcare/devportal-service-data/migrations/db/v3__schema_fixed.sql
+++ b/src/psql/selfcare/devportal-service-data/migrations/db/v3__schema_fixed.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "DeveloperPortalServiceData".services
+     ALTER COLUMN "requireSecureChannels" TYPE boolean NOT NULL; -- if true the message will be available only in the IOApp instead of both e-mail and IOApp


### PR DESCRIPTION
Needs to alter column type for `RequireSecureChannels` in DeveloperPortalServiceData schema, cause we missed to specify the column type into boolean.

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
