### PR TITLE
[#IOPAE-56] Reset schema to a correct shape

### DIFF
--- a/src/psql/selfcare/subscription-migrations/migrations/db/V1__schema.sql
+++ b/src/psql/selfcare/subscription-migrations/migrations/db/V1__schema.sql
@@ -3,16 +3,25 @@ CREATE SCHEMA "SelfcareIOSubscriptionMigrations";
 
 CREATE TABLE IF NOT EXISTS "SelfcareIOSubscriptionMigrations".migrations
 (
-    "subscriptionId" character(26)  NOT NULL,
+    "subscriptionId" character(50)  NOT NULL,
     "organizationFiscalCode" character(11)  NOT NULL,
-    "sourceId" character(26)  NOT NULL,
-    "sourceName" character(1) ,
-    "sourceSurname" character(1) ,
-    "sourceEmail" character(1) ,
-    status character(1)  NOT NULL DEFAULT 'INITIAL'::bpchar,
-    note text ,
     "serviceVersion" integer NOT NULL,
-    "serviceName" character varying ,
-    "updateAt" time without time zone DEFAULT CURRENT_TIMESTAMP,
+    "serviceName" text varying ,
+
+    "sourceId" character(26)  NOT NULL,
+    "sourceName" text ,
+    "sourceSurname" text ,
+    "sourceEmail" text ,
+    
+    -- In order to avoid null fileds, we set FALSE as default
+    -- This is harmless as
+    --  * we will ensure this field to be set at insert time
+    --  * the field is not considered yet by the application (at the time of writing)
+    ADD COLUMN "isVisible" boolean NOT NULL default false,
+    ADD COLUMN "hasBeenVisibleOnce"  boolean NOT NULL default false;
+
+    status text  NOT NULL DEFAULT 'INITIAL'::bpchar,
+    note text ,
+    "updateAt" timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT migrations_pkey PRIMARY KEY ("subscriptionId")
 )

--- a/src/psql/selfcare/subscription-migrations/migrations/db/V1__schema.sql
+++ b/src/psql/selfcare/subscription-migrations/migrations/db/V1__schema.sql
@@ -17,8 +17,8 @@ CREATE TABLE IF NOT EXISTS "SelfcareIOSubscriptionMigrations".migrations
     -- This is harmless as
     --  * we will ensure this field to be set at insert time
     --  * the field is not considered yet by the application (at the time of writing)
-    ADD COLUMN "isVisible" boolean NOT NULL default false,
-    ADD COLUMN "hasBeenVisibleOnce"  boolean NOT NULL default false;
+    "isVisible" boolean NOT NULL default false,
+    "hasBeenVisibleOnce"  boolean NOT NULL default false,
 
     status text  NOT NULL DEFAULT 'INITIAL'::bpchar,
     note text ,

--- a/src/psql/selfcare/subscription-migrations/migrations/db/V1__schema.sql
+++ b/src/psql/selfcare/subscription-migrations/migrations/db/V1__schema.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS "SelfcareIOSubscriptionMigrations".migrations
     "subscriptionId" character(50)  NOT NULL,
     "organizationFiscalCode" character(11)  NOT NULL,
     "serviceVersion" integer NOT NULL,
-    "serviceName" text varying ,
+    "serviceName" text,
 
     "sourceId" character(26)  NOT NULL,
     "sourceName" text ,

--- a/src/psql/selfcare/subscription-migrations/migrations/db/V2__schema_fixed.sql
+++ b/src/psql/selfcare/subscription-migrations/migrations/db/V2__schema_fixed.sql
@@ -1,8 +1,0 @@
-ALTER TABLE "SelfcareIOSubscriptionMigrations".migrations
-    ALTER COLUMN "subscriptionId" TYPE character(50),
-    ALTER COLUMN "sourceName" TYPE text,
-    ALTER COLUMN "sourceSurname" TYPE text,
-    ALTER COLUMN "sourceEmail" TYPE text,
-    ALTER COLUMN "status" TYPE text,
-    ALTER COLUMN "note" TYPE text,
-    ALTER COLUMN "serviceName" TYPE text;

--- a/src/psql/selfcare/subscription-migrations/migrations/db/V3__visibility_fileds.sql
+++ b/src/psql/selfcare/subscription-migrations/migrations/db/V3__visibility_fileds.sql
@@ -1,7 +1,0 @@
-ALTER TABLE "SelfcareIOSubscriptionMigrations".migrations
-    -- In order to avoid null fileds, we set FALSE as default
-    -- This is harmless as
-    --  * we will ensure this field to be set at insert time
-    --  * the field is not considered yet by the application (at the time of writing)
-    ADD COLUMN "isVisibile" boolean NOT NULL default false,
-    ADD COLUMN "hasBeenVisibleOnce"  boolean NOT NULL default false;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR corrects a typo occurred in https://github.com/pagopa/io-infra/pull/270. We thought it was an opportunity to reset the entire migration history as the database is not yet in prod.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
