### PR TITLE
Fix DB Schame Name to DeveloperPortalServiceData

### DIFF
--- a/src/core/function_devportal_service_data.tf
+++ b/src/core/function_devportal_service_data.tf
@@ -35,7 +35,7 @@ locals {
       DB_PORT         = 5432
       DB_IDLE_TIMEOUT = 30000 // milliseconds
       DB_NAME         = "db"
-      DB_SCHEMA       = "DevPortalServiceData"
+      DB_SCHEMA       = "DeveloperPortalServiceData"
       DB_TABLE        = "services"
       DB_USER         = format("%s@%s", data.azurerm_key_vault_secret.devportalservicedata_db_server_adm_username.value, format("%s.postgres.database.azure.com", format("%s-%s-db-postgresql", local.project, "devportalservicedata")))
       DB_PASSWORD     = data.azurerm_key_vault_secret.devportalservicedata_db_server_adm_password.value


### PR DESCRIPTION
This PR fix a Configuration Field name for Azure Function releated to devportalservicedata application

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
