### PR TITLE
fix: http fn-admin on apim

### DIFF
--- a/src/core/apim_io_admin_api.tf
+++ b/src/core/apim_io_admin_api.tf
@@ -47,7 +47,7 @@ module "api_admin" {
   description         = "ADMIN API for IO platform."
 
   path        = "adm"
-  protocols   = ["https"]
+  protocols   = ["http", "https"]
   product_ids = [module.apim_product_admin.product_id]
 
   service_url = null

--- a/src/core/devportal.tf
+++ b/src/core/devportal.tf
@@ -90,7 +90,7 @@ module "appservice_devportal_be" {
     LOGO_URL            = "https://assets.cdn.io.pagopa.it/logos"
 
     # Fn-Admin connection
-    ADMIN_API_URL = "http://${local.apim_hostname_api_app_internal}"
+    ADMIN_API_URL = "https://${local.apim_hostname_api_app_internal}"
     ADMIN_API_KEY = data.azurerm_key_vault_secret.devportal_apim_io_service_key.value
 
     # Apim connection

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -201,7 +201,7 @@ module "appservice_selfcare_be" {
     IDP = "selfcare"
 
     # Fn-Admin connection
-    ADMIN_API_URL = "http://${local.apim_hostname_api_app_internal}"
+    ADMIN_API_URL = "https://${local.apim_hostname_api_app_internal}"
     ADMIN_API_KEY = data.azurerm_key_vault_secret.selfcare_apim_io_service_key.value
 
     # Apim connection


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Due client configuration, we re-enable the http protocol on api management admin api

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
