### PR TITLE
[#ICC-273] Configure LolliPOP allowed User-Agent

### DIFF
--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -206,6 +206,8 @@ locals {
         }
       ])
 
+      // LolliPOP
+      LOLLIPOP_ALLOWED_USER_AGENTS = "IO-App/2.23"
     }
     app_settings_l1 = {
       IS_APPBACKENDLI = "false"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Add `LOLLIPOP_ALLOWED_USER_AGENTS` env variable
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This is needed in order to restrict allowed user-agents that could initialize LolliPOP flow
### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
