### PR TITLE
Unlock script

### DIFF
--- a/src/core/terraform.sh
+++ b/src/core/terraform.sh
@@ -24,6 +24,24 @@ source "./env/$env/backend.ini"
 
 az account set -s "${subscription}"
 
+if [ "$action" = "force-unlock" ]; then
+  echo "🧭 terraform INIT in env: ${env}"
+  terraform init -reconfigure -backend-config="./env/$env/backend.tfvars" $other
+  warn_message="You are about to unlock Terraform's remote state. 
+  This is a dangerous task you want to be aware of before going on.
+  This operation won't affect your infrastructure directly.
+  However, please note that you may lose pieces of information about partially-applied configurations.
+
+  Please refer to the official Terraform documentation about the command:
+  https://developer.hashicorp.com/terraform/cli/commands/force-unlock"
+  printf "\n\e[33m%s\e[0m\n\n" "$warn_message"
+
+  read -r -p "Please enter the LOCK ID: " lock_id
+  terraform force-unlock "$lock_id"
+  
+  exit 0 # this line prevents the script to go on
+fi
+
 if echo "init plan apply refresh import output state taint destroy" | grep -w "$action" > /dev/null; then
   if [ "$action" = "init" ]; then
     echo "🧭 terraform INIT in env: ${env}"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* Enable `force-unlock` in `./terraform.sh`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
There are cases in which we may want to perform `force-unlock` to unlock the state. This may be in case of CI/CD pipeline failures or manual cancellation. 
The aim of the script is to provide the correct setup for the command to be executed.

**The script is meant to be executed by a human**, hence warnings are shown and manual input is required.
Should we want to have a dedicated pipeline? That would have the benefit of not having the command executed on a developer machine. However, this may _enforce focus_ on the operation being executed due to the script being interactive.

### Example
![Screen Shot 2023-01-14 at 14 58 36](https://user-images.githubusercontent.com/265564/212475600-e5e2a539-ce0a-4526-a33b-cb3c8c5a44bc.png)

