### PR TITLE
Revert "fix: Enable routing to old fn-services"

### DIFF
--- a/src/core/api/io_services/v1/post_submitmessageforuserwithfiscalcodeinbody_policy/policy.xml
+++ b/src/core/api/io_services/v1/post_submitmessageforuserwithfiscalcodeinbody_policy/policy.xml
@@ -9,10 +9,10 @@
                   int urlWeight = rnd.Next(1, 101);
                   return urlWeight;}" />
                 <choose>
-                    <when condition="@(context.Variables.GetValueOrDefault<int>("urlWeight") <= 100)">
+                    <when condition="@(context.Variables.GetValueOrDefault<int>("urlWeight") <= 1)">
                         <set-backend-service base-url="{{io-fn3-eucovidcert-url}}/api/v1" />
                     </when>
-                    <when condition="@(context.Variables.GetValueOrDefault<int>("urlWeight") > 100)">
+                    <when condition="@(context.Variables.GetValueOrDefault<int>("urlWeight") > 1)">
                         <set-backend-service base-url="{{io-fn3-eucovidcert-url-alt}}/api/v1" />
                     </when>
                     <otherwise>


### PR DESCRIPTION
#392 disable routing towards newly created `fn-eucovidcerts` as we were experiencing production issues. 
Once we apply #413 we can revert #392

Depends on #413 