### PR TITLE
[#SFEQS-1401] Add io-sign third party configuration

### DIFF
--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -945,6 +945,14 @@ variable "pn_service_id" {
   default     = "01G40DWQGKY5GRWSNM4303VNRP"
 }
 
+# io-sign service Id
+variable "io_sign_service_id" {
+  type        = string
+  description = "The Service ID of io-sign service"
+  default     = "01GQQZ9HF5GAPRVKJM1VDAVFHM"
+}
+
+
 # Function CGN
 variable "plan_cgn_kind" {
   type        = string

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -679,6 +679,7 @@
 | <a name="input_function_services_kind"></a> [function\_services\_kind](#input\_function\_services\_kind) | App service plan kind | `string` | `null` | no |
 | <a name="input_function_services_sku_size"></a> [function\_services\_sku\_size](#input\_function\_services\_sku\_size) | App service plan sku size | `string` | `null` | no |
 | <a name="input_function_services_sku_tier"></a> [function\_services\_sku\_tier](#input\_function\_services\_sku\_tier) | App service plan sku tier | `string` | `null` | no |
+| <a name="input_io_sign_service_id"></a> [io\_sign\_service\_id](#input\_io\_sign\_service\_id) | The Service ID of io-sign service | `string` | `"01GQQZ9HF5GAPRVKJM1VDAVFHM"` | no |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | `"westeurope"` | no |
 | <a name="input_lock_enable"></a> [lock\_enable](#input\_lock\_enable) | Apply locks to block accedentaly deletions. | `bool` | `false` | no |
 | <a name="input_log_analytics_workspace_name"></a> [log\_analytics\_workspace\_name](#input\_log\_analytics\_workspace\_name) | The common Log Analytics Workspace name | `string` | `""` | no |

--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -205,6 +205,20 @@ locals {
             }
           }
         },
+        # Firma con IO (io-sign)
+        {
+          serviceId  = var.io_sign_service_id,
+          schemaKind = "IO-SIGN",
+          jsonSchema = "unused",
+          prodEnvironment = {
+            baseUrl = IO_SIGN_API_URL,
+            detailsAuthentication = {
+              type            = "API_KEY",
+              header_key_name = "X-Functions-Key",
+              key             = IO_SIGN_API_KEY
+            }
+          }
+        },
         # Mock Service
         {
           serviceId  = var.third_party_mock_service_id,

--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -211,11 +211,11 @@ locals {
           schemaKind = "IO-SIGN",
           jsonSchema = "unused",
           prodEnvironment = {
-            baseUrl = IO_SIGN_API_URL,
+            baseUrl = "https://io-p-sign-user-func.azurewebsites.net",
             detailsAuthentication = {
               type            = "API_KEY",
               header_key_name = "X-Functions-Key",
-              key             = IO_SIGN_API_KEY
+              key             = data.azurerm_key_vault_secret.app_backend_IO_SIGN_API_KEY.value
             }
           }
         },


### PR DESCRIPTION
This PR adds the configuration needed to use third party messages with [io-sign](https://github.com/pagopa/io-sign).

### List of changes
- Added `io_sign_service_id` variable
- Added `io-sign` configuration to `THIRD_PARTY_CONFIG_LIST`

### Motivation and context
We have implemented the necessary endpoints on `io-sign` https://github.com/pagopa/io-sign/pull/78 to use third party messages for signed documents. Here the [openapi](https://raw.githubusercontent.com/pagopa/io-sign/8afb58882d179eacb955c48b55786ca469e3ab41/apps/io-func-sign-user/openapi.yaml)

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
