### PR TITLE
[#SFEQS-1401]  Typo fix in io-sign baseUrl for third party messages

### DIFF
--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -211,7 +211,7 @@ locals {
           schemaKind = "IO-SIGN",
           jsonSchema = "unused",
           prodEnvironment = {
-            baseUrl = "https://io-p-sign-user-func.azurewebsites.net",
+            baseUrl = "https://io-p-sign-user-func.azurewebsites.net/api/v1/sign",
             detailsAuthentication = {
               type            = "API_KEY",
               header_key_name = "X-Functions-Key",


### PR DESCRIPTION
This PR fix a typo in `baseUrl` in `THIRD_PARTY_CONFIG_LIST`  [io-sign](https://github.com/pagopa/io-sign).

### List of changes
- Updated `io-sign` configuration to `THIRD_PARTY_CONFIG_LIST`

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
