### PR TITLE
[#IOCIT-363] Add required ENVs var for Lollipop Queue Storage in io-backend

### DIFF
--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -1050,3 +1050,34 @@ variable "third_party_mock_service_id" {
   description = "The Service ID of the Third Party Mock service"
   default     = "01GQQDPM127KFGG6T3660D5TXD"
 }
+
+# Citizen auth
+
+variable "citizen_auth_domain" {
+  type = string
+  validation {
+    condition = (
+      length(var.domain) <= 12
+    )
+    error_message = "Max length is 12 chars."
+  }
+  default = "citizen-auth"
+}
+
+variable "citizen_auth_product" {
+  type        = string
+  description = "Use product name from citizen_auth domain locals"
+  default     = "io-p"
+}
+
+variable "citizen_auth_revoke_queue_name" {
+  type        = string
+  description = "Use queue storage name from citizen_auth domain storage"
+  default     = "pubkeys-revoke"
+}
+
+variable "citizen_auth_assertion_storage_name" {
+  type        = string
+  description = "Use storage name from citizen_auth domain"
+  default     = "lollipop-assertions-st"
+}

--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -1054,7 +1054,7 @@ variable "third_party_mock_service_id" {
 # Citizen auth
 
 variable "citizen_auth_domain" {
-  type = string
+  type    = string
   default = "citizen-auth"
 }
 

--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -1055,12 +1055,6 @@ variable "third_party_mock_service_id" {
 
 variable "citizen_auth_domain" {
   type = string
-  validation {
-    condition = (
-      length(var.domain) <= 12
-    )
-    error_message = "Max length is 12 chars."
-  }
   default = "citizen-auth"
 }
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -533,6 +533,7 @@
 | [azurerm_storage_account.iopstapp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.iopstcgn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
+| [azurerm_storage_account.lollipop_assertions_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.notifications](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.push_notifications_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.storage_apievents](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
@@ -609,6 +610,10 @@
 | <a name="input_cidr_weu_beta_vnet"></a> [cidr\_weu\_beta\_vnet](#input\_cidr\_weu\_beta\_vnet) | Beta Virtual network cidr. | `list(string)` | n/a | yes |
 | <a name="input_cidr_weu_prod01_vnet"></a> [cidr\_weu\_prod01\_vnet](#input\_cidr\_weu\_prod01\_vnet) | Prod01 Virtual network cidr. | `list(string)` | n/a | yes |
 | <a name="input_cidr_weu_prod02_vnet"></a> [cidr\_weu\_prod02\_vnet](#input\_cidr\_weu\_prod02\_vnet) | Prod02 Virtual network cidr. | `list(string)` | n/a | yes |
+| <a name="input_citizen_auth_assertion_storage_name"></a> [citizen\_auth\_assertion\_storage\_name](#input\_citizen\_auth\_assertion\_storage\_name) | Use storage name from citizen\_auth domain | `string` | `"lollipop-assertions-st"` | no |
+| <a name="input_citizen_auth_domain"></a> [citizen\_auth\_domain](#input\_citizen\_auth\_domain) | n/a | `string` | `"citizen-auth"` | no |
+| <a name="input_citizen_auth_product"></a> [citizen\_auth\_product](#input\_citizen\_auth\_product) | Use product name from citizen\_auth domain locals | `string` | `"io-p"` | no |
+| <a name="input_citizen_auth_revoke_queue_name"></a> [citizen\_auth\_revoke\_queue\_name](#input\_citizen\_auth\_revoke\_queue\_name) | Use queue storage name from citizen\_auth domain storage | `string` | `"pubkeys-revoke"` | no |
 | <a name="input_common_rg"></a> [common\_rg](#input\_common\_rg) | Common Virtual network resource group name. | `string` | `""` | no |
 | <a name="input_ddos_protection_plan"></a> [ddos\_protection\_plan](#input\_ddos\_protection\_plan) | n/a | <pre>object({<br>    id     = string<br>    enable = bool<br>  })</pre> | `null` | no |
 | <a name="input_dns_default_ttl_sec"></a> [dns\_default\_ttl\_sec](#input\_dns\_default\_ttl\_sec) | value | `number` | `3600` | no |

--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -239,7 +239,9 @@ locals {
       ])
 
       // LolliPOP
-      LOLLIPOP_ALLOWED_USER_AGENTS = "IO-App/2.23.0"
+      LOLLIPOP_ALLOWED_USER_AGENTS              = "IO-App/2.23.0"
+      LOLLIPOP_REVOKE_STORAGE_CONNECTION_STRING = data.azurerm_storage_account.lollipop_assertions_storage.primary_connection_string
+      LOLLIPOP_REVOKE_QUEUE_NAME                = var.citizen_auth_revoke_queue_name
     }
     app_settings_l1 = {
       IS_APPBACKENDLI = "false"

--- a/src/core/data.tf
+++ b/src/core/data.tf
@@ -71,6 +71,15 @@ data "azurerm_storage_account" "notifications" {
   resource_group_name = format("%s-rg-internal", local.project)
 }
 
+#
+# LOLLIPOP
+#
+
+data "azurerm_storage_account" "lollipop_assertions_storage" {
+  name                = replace(format("%s-%s", var.citizen_auth_product, var.citizen_auth_assertion_storage_name), "-", "")
+  resource_group_name = format("%s-%s", var.citizen_auth_product, var.citizen_auth_domain)
+}
+
 # todo migrate storage account and related resources
 locals {
   storage_account_notifications_queue_push_notifications = "push-notifications"

--- a/src/core/data.tf
+++ b/src/core/data.tf
@@ -77,7 +77,7 @@ data "azurerm_storage_account" "notifications" {
 
 data "azurerm_storage_account" "lollipop_assertions_storage" {
   name                = replace(format("%s-%s", var.citizen_auth_product, var.citizen_auth_assertion_storage_name), "-", "")
-  resource_group_name = format("%s-%s", var.citizen_auth_product, var.citizen_auth_domain)
+  resource_group_name = format("%s-%s-data-rg", var.citizen_auth_product, var.citizen_auth_domain)
 }
 
 # todo migrate storage account and related resources

--- a/src/domains/citizen-auth-common/03_storage.tf
+++ b/src/domains/citizen-auth-common/03_storage.tf
@@ -1,6 +1,6 @@
 module "lollipop_assertions_storage" {
   source                     = "git::https://github.com/pagopa/terraform-azurerm-v3//storage_account?ref=v4.3.1"
-  name                       = replace(format("%s-lollipop-assertions-st", local.product), "-", "")
+  name                       = replace(format("%s-lollipop-assertions-st", local.product), "-", "") # `lollipop-assertions-st` is used in src/core/99_variables.tf#citizen_auth_assertion_storage_name
   domain                     = upper(var.domain)
   account_kind               = "StorageV2"
   account_tier               = "Standard"
@@ -53,6 +53,6 @@ resource "azurerm_storage_container" "lollipop_assertions_storage_assertions" {
 }
 
 resource "azurerm_storage_queue" "lollipop_assertions_storage_revoke_queue" {
-  name                 = "pubkeys-revoke"
+  name                 = "pubkeys-revoke" # This value is used in src/core/99_variables.tf#citizen_auth_revoke_queue_name
   storage_account_name = module.lollipop_assertions_storage.name
 }

--- a/src/domains/citizen-auth-common/99_locals.tf
+++ b/src/domains/citizen-auth-common/99_locals.tf
@@ -1,6 +1,6 @@
 locals {
   project = "${var.prefix}-${var.env_short}-${var.location_short}-${var.domain}"
-  product = "${var.prefix}-${var.env_short}"
+  product = "${var.prefix}-${var.env_short}" # This value is used in src/core/99_variables.tf#citizen_auth_product
 
   monitor_action_group_slack_name = "SlackPagoPA"
   monitor_action_group_email_name = "EmailPagoPA"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
See commit history

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
`io-backend` requires some ENVs variables to connect to the queue storage of `LolliPOP` domain to revoke older Pub Keys.

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
