### PR TITLE
[SFEQS-1463]: Add SelfCare integration to `io-sign`

### DIFF
--- a/src/domains/sign/io_sign_issuer_func.tf
+++ b/src/domains/sign/io_sign_issuer_func.tf
@@ -29,6 +29,8 @@ locals {
       SelfCareEventHubConnectionString                = module.key_vault_secrets.values["SelfCareEventHubConnectionString"].value
       SelfCareApiBasePath                             = "https://api.selfcare.pagopa.it"
       SelfCareApiKey                                  = module.key_vault_secrets.values["SelfCareApiKey"].value
+      SlackApiBasePath                                = "https://slack.com/api"
+      SlackApiToken                                   = module.key_vault_secrets.values["SlackApiToken"].value
     }
   }
 }

--- a/src/domains/sign/io_sign_issuer_func.tf
+++ b/src/domains/sign/io_sign_issuer_func.tf
@@ -29,7 +29,7 @@ locals {
       SelfCareEventHubConnectionString                = module.key_vault_secrets.values["SelfCareEventHubConnectionString"].value
       SelfCareApiBasePath                             = "https://api.selfcare.pagopa.it"
       SelfCareApiKey                                  = module.key_vault_secrets.values["SelfCareApiKey"].value
-      SlackApiBasePath                                = "https://slack.com/api"
+      SlackApiBasePath                                = "https://slack.com"
       SlackApiToken                                   = module.key_vault_secrets.values["SlackApiToken"].value
     }
   }

--- a/src/domains/sign/io_sign_issuer_func.tf
+++ b/src/domains/sign/io_sign_issuer_func.tf
@@ -26,6 +26,9 @@ locals {
       PdvTokenizerApiKey                              = module.key_vault_secrets.values["TokenizerApiSubscriptionKey"].value
       AnalyticsEventHubConnectionString               = module.event_hub.keys["analytics.io-sign-func-issuer"].primary_connection_string
       BillingEventHubConnectionString                 = module.event_hub.keys["billing.io-sign-func-issuer"].primary_connection_string
+      SelfCareEventHubConnectionString                = module.key_vault_secrets.values["SelfCareEventHubConnectionString"].value
+      SelfCareApiBasePath                             = "https://api.selfcare.pagopa.it"
+      SelfCareApiKey                                  = module.key_vault_secrets.values["SelfCareApiKey"].value
     }
   }
 }

--- a/src/domains/sign/io_sign_user_func.tf
+++ b/src/domains/sign/io_sign_user_func.tf
@@ -29,6 +29,9 @@ locals {
       NamirialPassword                                = module.key_vault_secrets.values["NamirialPassword"].value
       SpidAssertionMock                               = module.key_vault_secrets.values["SpidAssertionMock"].value
       AnalyticsEventHubConnectionString               = module.event_hub.keys["analytics.io-sign-func-user"].primary_connection_string
+      SelfCareEventHubConnectionString                = module.key_vault_secrets.values["SelfCareEventHubConnectionString"].value
+      SelfCareApiBasePath                             = "https://api.selfcare.pagopa.it"
+      SelfCareApiKey                                  = module.key_vault_secrets.values["SelfCareApiKey"].value
     }
   }
 }

--- a/src/domains/sign/io_sign_user_func.tf
+++ b/src/domains/sign/io_sign_user_func.tf
@@ -60,6 +60,10 @@ module "io_sign_user_func" {
   app_settings = merge(
     local.io_sign_user_func.app_settings,
     {
+      # This is temporary to collect detailed logging
+      WEBSITE_HTTPLOGGING_RETENTION_DAYS = "7"
+    },
+    {
       # Enable functions on production triggered by queue and timer
       # They had to be disabled in slots
       for to_disable in local.io_sign_user_func.staging_disabled :

--- a/src/domains/sign/key_vault.tf
+++ b/src/domains/sign/key_vault.tf
@@ -11,7 +11,8 @@ module "key_vault_secrets" {
     "NamirialPassword",
     "SpidAssertionMock",
     "SelfCareEventHubConnectionString",
-    "SelfCareApiKey"
+    "SelfCareApiKey",
+    "SlackApiToken"
   ]
 }
 

--- a/src/domains/sign/key_vault.tf
+++ b/src/domains/sign/key_vault.tf
@@ -10,6 +10,8 @@ module "key_vault_secrets" {
     "io-fn-sign-issuer-key",
     "NamirialPassword",
     "SpidAssertionMock",
+    "SelfCareEventHubConnectionString",
+    "SelfCareApiKey"
   ]
 }
 


### PR DESCRIPTION
This PR adds the necessary resources to `io-sign` for the integration of SelfCare.

### List of changes
- Added `SelfCareEventHubConnectionString` to env-vars and keyvault
- Added `SelfCareApiBasePath` to env-var s
- Added `SelfCareApiKey` to env-vars and keyvault
- Added `SlackApiBasePath` to env-vars 
- Added `SlackApiToekn` to env-vars and keyvault

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Depends on #458 

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
