### PR TITLE
Add secret for first lollipop subscription key

### DIFF
--- a/src/domains/citizen-auth-app/04_function_lollipop.tf
+++ b/src/domains/citizen-auth-app/04_function_lollipop.tf
@@ -1,5 +1,5 @@
 data "azurerm_key_vault_secret" "first_lollipop_consumer_subscription_key" {
-  name         = "first-lollipop-consumer-subscription-key"
+  name         = "first-lollipop-consumer-pagopa-subscription-key"
   key_vault_id = data.azurerm_key_vault.kv.id
 }
 

--- a/src/domains/citizen-auth-common/03_apim.tf
+++ b/src/domains/citizen-auth-common/03_apim.tf
@@ -104,4 +104,13 @@ resource "azurerm_api_management_subscription" "pagopa" {
   display_name        = "Lollipop API"
   state               = "active"
 }
+
+####################################################################################
+# PagoPA General Lollipop Secret
+####################################################################################
+resource "azurerm_key_vault_secret" "first_lollipop_consumer_subscription_key" {
+  name         = "first-lollipop-consumer-subscription-key"
+  value        = azurerm_api_management_subscription.pagopa.primary_key
+  key_vault_id = module.key_vault.id
+}
 ####################################################################################

--- a/src/domains/citizen-auth-common/03_apim.tf
+++ b/src/domains/citizen-auth-common/03_apim.tf
@@ -109,7 +109,7 @@ resource "azurerm_api_management_subscription" "pagopa" {
 # PagoPA General Lollipop Secret
 ####################################################################################
 resource "azurerm_key_vault_secret" "first_lollipop_consumer_subscription_key" {
-  name         = "first-lollipop-consumer-subscription-key"
+  name         = "first-lollipop-consumer-pagopa-subscription-key"
   value        = azurerm_api_management_subscription.pagopa.primary_key
   key_vault_id = module.key_vault.id
 }

--- a/src/domains/citizen-auth-common/README.md
+++ b/src/domains/citizen-auth-common/README.md
@@ -47,6 +47,7 @@
 | [azurerm_key_vault_certificate.lollipop_certificate_v1](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_certificate) | resource |
 | [azurerm_key_vault_secret.appinsights_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appinsights_instrumentation_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.first_lollipop_consumer_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_private_endpoint.lollipop_assertion_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.data_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
see commit history
<!--- Describe your changes in detail -->

### Motivation and context
Add a secret to store the primary key of the pagopa apim subscription used by lollipop function to retrieve an assertion.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
