### PR TITLE
chore: Add lollipop config to `io-sign`

### DIFF
--- a/src/domains/sign/io_sign_user_func.tf
+++ b/src/domains/sign/io_sign_user_func.tf
@@ -32,6 +32,8 @@ locals {
       SelfCareEventHubConnectionString                = module.key_vault_secrets.values["SelfCareEventHubConnectionString"].value
       SelfCareApiBasePath                             = "https://api.selfcare.pagopa.it"
       SelfCareApiKey                                  = module.key_vault_secrets.values["SelfCareApiKey"].value
+      LollipopApiBasePath                             = "https://api.io.pagopa.it"
+      LollipopApiKey                                  = module.key_vault_secrets.values["LollipopPrimaryApiKey"].value
     }
   }
 }

--- a/src/domains/sign/key_vault.tf
+++ b/src/domains/sign/key_vault.tf
@@ -12,7 +12,9 @@ module "key_vault_secrets" {
     "SpidAssertionMock",
     "SelfCareEventHubConnectionString",
     "SelfCareApiKey",
-    "SlackApiToken"
+    "SlackApiToken",
+    "LollipopPrimaryApiKey",
+    "LollipopSecondaryApiKey"
   ]
 }
 


### PR DESCRIPTION
This PR add lollipop config to `io-func-sign-user` envvar.

### List of changes
- Add LollipopApiBasePath
- Add LollipopApiKey from KV

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
