### PR TITLE
fix: Upgrade Storage to latest version to avoid unwanted changes

### DIFF
--- a/src/domains/citizen-auth-common/03_storage.tf
+++ b/src/domains/citizen-auth-common/03_storage.tf
@@ -1,5 +1,5 @@
 module "lollipop_assertions_storage" {
-  source                     = "git::https://github.com/pagopa/terraform-azurerm-v3//storage_account?ref=v4.3.1"
+  source                     = "git::https://github.com/pagopa/terraform-azurerm-v3//storage_account?ref=v6.1.0"
   name                       = replace(format("%s-lollipop-assertions-st", local.product), "-", "") # `lollipop-assertions-st` is used in src/core/99_variables.tf#citizen_auth_assertion_storage_name
   domain                     = upper(var.domain)
   account_kind               = "StorageV2"

--- a/src/domains/citizen-auth-common/03_storage.tf
+++ b/src/domains/citizen-auth-common/03_storage.tf
@@ -1,15 +1,17 @@
 module "lollipop_assertions_storage" {
-  source                     = "git::https://github.com/pagopa/terraform-azurerm-v3//storage_account?ref=v6.1.0"
-  name                       = replace(format("%s-lollipop-assertions-st", local.product), "-", "") # `lollipop-assertions-st` is used in src/core/99_variables.tf#citizen_auth_assertion_storage_name
-  domain                     = upper(var.domain)
-  account_kind               = "StorageV2"
-  account_tier               = "Standard"
-  access_tier                = "Hot"
-  account_replication_type   = "GZRS"
-  resource_group_name        = azurerm_resource_group.data_rg.name
-  location                   = var.location
-  advanced_threat_protection = true
-  enable_identity            = true
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3//storage_account?ref=v6.1.0"
+
+  name                          = replace(format("%s-lollipop-assertions-st", local.product), "-", "") # `lollipop-assertions-st` is used in src/core/99_variables.tf#citizen_auth_assertion_storage_name
+  domain                        = upper(var.domain)
+  account_kind                  = "StorageV2"
+  account_tier                  = "Standard"
+  access_tier                   = "Hot"
+  account_replication_type      = "GZRS"
+  resource_group_name           = azurerm_resource_group.data_rg.name
+  location                      = var.location
+  advanced_threat_protection    = true
+  enable_identity               = true
+  public_network_access_enabled = false
 
   tags = var.tags
 }

--- a/src/domains/citizen-auth-common/README.md
+++ b/src/domains/citizen-auth-common/README.md
@@ -24,7 +24,7 @@
 | <a name="module_cosmosdb_account"></a> [cosmosdb\_account](#module\_cosmosdb\_account) | git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_account | v4.3.1 |
 | <a name="module_cosmosdb_sql_database_citizen_auth"></a> [cosmosdb\_sql\_database\_citizen\_auth](#module\_cosmosdb\_sql\_database\_citizen\_auth) | git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_sql_database | v4.3.1 |
 | <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault) | git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault | v4.1.3 |
-| <a name="module_lollipop_assertions_storage"></a> [lollipop\_assertions\_storage](#module\_lollipop\_assertions\_storage) | git::https://github.com/pagopa/terraform-azurerm-v3//storage_account | v4.3.1 |
+| <a name="module_lollipop_assertions_storage"></a> [lollipop\_assertions\_storage](#module\_lollipop\_assertions\_storage) | git::https://github.com/pagopa/terraform-azurerm-v3//storage_account | v6.1.0 |
 | <a name="module_lollipop_assertions_storage_customer_managed_key"></a> [lollipop\_assertions\_storage\_customer\_managed\_key](#module\_lollipop\_assertions\_storage\_customer\_managed\_key) | git::https://github.com/pagopa/terraform-azurerm-v3//storage_account_customer_managed_key | v4.3.1 |
 
 ## Resources


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- upgrade to storage account 6.1.0 module to avoid unwanted changes using customer key
- set public network access to false to restrict internet access

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
