### PR TITLE
fix: Add triggered functions to `staging_disabled`

### DIFF
--- a/src/domains/sign/io_sign_issuer_func.tf
+++ b/src/domains/sign/io_sign_issuer_func.tf
@@ -5,6 +5,8 @@ locals {
       "MarkAsSigned",
       "MarkAsWaitForSignature",
       "ValidateUpload",
+      "CreateIssuer",
+      "CreateIssuerByVatNumberView"
     ]
     app_settings = {
       FUNCTIONS_WORKER_RUNTIME                        = "node"


### PR DESCRIPTION
Add functions triggered by `cosmos` and `EventHub` to `staging_disabled`

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
