### PR TITLE
[#IOCIT-377] Increase autoscale RU value for cosmos lollipop pubkeys

### DIFF
--- a/src/domains/citizen-auth-common/05_database.tf
+++ b/src/domains/citizen-auth-common/05_database.tf
@@ -58,9 +58,9 @@ resource "azurerm_cosmosdb_sql_container" "lollipop_pubkeys" {
   partition_key_version = 2
 
   autoscale_settings {
-    max_throughput = 1000
+    max_throughput = var.citizen_auth_database.lollipop_pubkeys.max_throughput
   }
 
-  default_ttl = -1
+  default_ttl = var.citizen_auth_database.lollipop_pubkeys.ttl
 
 }

--- a/src/domains/citizen-auth-common/99_variables.tf
+++ b/src/domains/citizen-auth-common/99_variables.tf
@@ -62,6 +62,17 @@ variable "tags" {
   }
 }
 
+### Cosmos DB
+
+variable "citizen_auth_database" {
+  type = map(
+    object({
+      max_throughput = number
+      ttl            = number
+    })
+  )
+}
+
 ### External resources
 
 variable "monitor_resource_group_name" {

--- a/src/domains/citizen-auth-common/README.md
+++ b/src/domains/citizen-auth-common/README.md
@@ -83,6 +83,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_application_insights_name"></a> [application\_insights\_name](#input\_application\_insights\_name) | Specifies the name of the Application Insights. | `string` | n/a | yes |
+| <a name="input_citizen_auth_database"></a> [citizen\_auth\_database](#input\_citizen\_auth\_database) | n/a | <pre>map(<br>    object({<br>      max_throughput = number<br>      ttl            = number<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | n/a | yes |
 | <a name="input_enable_azdoa"></a> [enable\_azdoa](#input\_enable\_azdoa) | Specifies Azure Devops Agent enabling | `bool` | `true` | no |
 | <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |

--- a/src/domains/citizen-auth-common/env/prod/terraform.tfvars
+++ b/src/domains/citizen-auth-common/env/prod/terraform.tfvars
@@ -14,6 +14,15 @@ tags = {
   CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
 }
 
+### Cosmos DB
+
+citizen_auth_database = {
+  lollipop_pubkeys = {
+    max_throughput = 3000
+    ttl            = -1
+  }
+}
+
 ### External resources
 
 monitor_resource_group_name                 = "io-p-rg-common"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Increase `max_throughput` from `1000` to `3000` for `lollipop-pubkeys` collection on Cosmos DB
`max_throughput` and `ttl` for citizen_auth cosmos database are configured via vars.

<!--- Describe your changes in detail -->

### Motivation and context
The production load generated by IO App logins require more RU for cosmos in lollipop database collection.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
