### PR TITLE
feat: [SFEQS-1532] Add whitelist-ip policy based on a single issuers to `io-sign` APIM

### DIFF
--- a/src/domains/sign/api_product/sign/_base_policy.xml
+++ b/src/domains/sign/api_product/sign/_base_policy.xml
@@ -5,56 +5,63 @@
             <when condition="@(context.Request.Headers.ContainsKey("X-Forwarded-For"))">
                 <set-variable name="originalXForwardedForValue" value="@(context.Request.Headers.GetValueOrDefault("X-Forwarded-For"))" />
                 <set-variable name="requestDateString" value="@(DateTime.UtcNow.ToString("r"))" />
-                <!-- Executes a query on CosmosDb via REST API to obtain the list of whitelisted IPs for each issuers (subscriptionId) -->
-                <send-request mode="new" response-variable-name="response" timeout="10" ignore-error="false">
-                    <set-url>https://{{io-sign-cosmosdb-name}}.documents.azure.com/dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-ip-collection-name}}/docs</set-url>
-                    <set-method>POST</set-method>
-                    <set-header name="Authorization" exists-action="override">
-                        <value>@{
-                            var verb = "post";
-                            var resourceType = "docs";
-                            var resourceLink = "dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-ip-collection-name}}";
-                            var key = "{{io-sign-cosmosdb-primary-key}}";
-                            var keyType = "master";
-                            var tokenVersion = "1.0";
-                            var date = context.Variables.GetValueOrDefault<string>("requestDateString");
+                <cache-lookup-value key="@(context.Subscription.Id+"_whitelist")" variable-name="issuerWhitelist" />
+                <choose>
+                    <when condition="@(!context.Variables.ContainsKey("issuerWhitelist"))">
+                        <!-- Executes a query on CosmosDb via REST API to obtain the list of whitelisted IPs for each issuers (subscriptionId) -->
+                        <send-request mode="new" response-variable-name="response" timeout="10" ignore-error="false">
+                            <set-url>https://{{io-sign-cosmosdb-name}}.documents.azure.com/dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-ip-collection-name}}/docs</set-url>
+                            <set-method>POST</set-method>
+                            <set-header name="Authorization" exists-action="override">
+                                <value>@{
+                                    var verb = "post";
+                                    var resourceType = "docs";
+                                    var resourceLink = "dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-ip-collection-name}}";
+                                    var key = "{{io-sign-cosmosdb-primary-key}}";
+                                    var keyType = "master";
+                                    var tokenVersion = "1.0";
+                                    var date = context.Variables.GetValueOrDefault<string>("requestDateString");
 
-                            var hmacSha256 = new System.Security.Cryptography.HMACSHA256 { Key = Convert.FromBase64String(key) };
+                                    var hmacSha256 = new System.Security.Cryptography.HMACSHA256 { Key = Convert.FromBase64String(key) };
 
-                            string payLoad = string.Format("{0}\n{1}\n{2}\n{3}\n{4}\n",
-                                    verb.ToLowerInvariant(),
-                                    resourceType.ToLowerInvariant(),
-                                    resourceLink,
-                                    date.ToLowerInvariant(),
-                                    ""
-                            );
+                                    string payLoad = string.Format("{0}\n{1}\n{2}\n{3}\n{4}\n",
+                                            verb.ToLowerInvariant(),
+                                            resourceType.ToLowerInvariant(),
+                                            resourceLink,
+                                            date.ToLowerInvariant(),
+                                            ""
+                                    );
 
-                            byte[] hashPayLoad = hmacSha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payLoad));
-                            string signature = Convert.ToBase64String(hashPayLoad);
+                                    byte[] hashPayLoad = hmacSha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payLoad));
+                                    string signature = Convert.ToBase64String(hashPayLoad);
 
-                            return System.Uri.EscapeDataString(String.Format("type={0}&ver={1}&sig={2}",
-                                keyType,
-                                tokenVersion,
-                                signature));
-                            }</value>
-                    </set-header>
-                    <set-header name="Content-Type" exists-action="override">
-                        <value>application/query+json</value>
-                    </set-header>
-                    <set-header name="x-ms-documentdb-isquery" exists-action="override">
-                        <value>True</value>
-                    </set-header>
-                    <set-header name="x-ms-date" exists-action="override">
-                        <value>@(context.Variables.GetValueOrDefault<string>("requestDateString"))</value>
-                    </set-header>
-                    <set-header name="x-ms-version" exists-action="override">
-                        <value>2018-12-31</value>
-                    </set-header>
-                    <set-body>@("{\"query\": \"SELECT w.cidrs FROM whitelist w WHERE w.id = @id\", " +
-                                    "\"parameters\": [{ \"name\": \"@id\", \"value\": \"" + context.Subscription.Id + "\"}]}")</set-body>
-                </send-request>
-                <!-- Save response in issuerWhitelist var -->
-                <set-variable name="issuerWhitelist" value="@(((IResponse)context.Variables["response"]).Body.As<JObject>())" />
+                                    return System.Uri.EscapeDataString(String.Format("type={0}&ver={1}&sig={2}",
+                                        keyType,
+                                        tokenVersion,
+                                        signature));
+                                    }</value>
+                            </set-header>
+                            <set-header name="Content-Type" exists-action="override">
+                                <value>application/query+json</value>
+                            </set-header>
+                            <set-header name="x-ms-documentdb-isquery" exists-action="override">
+                                <value>True</value>
+                            </set-header>
+                            <set-header name="x-ms-date" exists-action="override">
+                                <value>@(context.Variables.GetValueOrDefault<string>("requestDateString"))</value>
+                            </set-header>
+                            <set-header name="x-ms-version" exists-action="override">
+                                <value>2018-12-31</value>
+                            </set-header>
+                            <set-body>@("{\"query\": \"SELECT w.cidrs FROM whitelist w WHERE w.id = @id\", " +
+                                            "\"parameters\": [{ \"name\": \"@id\", \"value\": \"" + context.Subscription.Id + "\"}]}")</set-body>
+                        </send-request>
+                        <!-- Save response in issuerWhitelist var -->
+                        <set-variable name="issuerWhitelist" value="@(((IResponse)context.Variables["response"]).Body.As<JObject>())" />
+                        <!-- Cache the query result for 60s to avoid another call to cosmosDB -->
+                        <cache-store-value key="@(context.Subscription.Id+"_whitelist")" value="@((JObject)context.Variables["issuerWhitelist"])" duration="60" />
+                    </when>
+                </choose>
                 <!-- Get the client ip from the X-Forwarded-For header and check if it is in the issuer's whitelist -->
                 <set-header name="X-Forwarded-For" exists-action="override">
                     <value>@{

--- a/src/domains/sign/api_product/sign/_base_policy.xml
+++ b/src/domains/sign/api_product/sign/_base_policy.xml
@@ -63,7 +63,7 @@
                     </when>
                 </choose>
                 <check-header name="X-Forwarded-For" failed-check-httpcode="403" failed-check-error-message="Forbidden" ignore-case="true">
-                     <!--
+                    <!--
                         Get the client ip from the X-Forwarded-For header and check if it is in the issuer's whitelist.
                         In the positive case it returns the same source ip otherwise localhost ip: 127.0.0.1.
                         (The choice to return 127.0.0.1 in the negative case is not mandatory, it is possible to return any string that differs from the source IP).
@@ -134,8 +134,6 @@
                         return "127.0.0.1";
                     }</value>
                 </check-header>
-
-
                 <rate-limit-by-key calls="150" renewal-period="5" counter-key="@(context.Subscription.Id)" retry-after-header-name="x-rate-limit-retry-after" remaining-calls-header-name="x-rate-limit-remaining" />
             </when>
             <otherwise>

--- a/src/domains/sign/api_product/sign/_base_policy.xml
+++ b/src/domains/sign/api_product/sign/_base_policy.xml
@@ -5,6 +5,7 @@
             <when condition="@(context.Request.Headers.ContainsKey("X-Forwarded-For"))">
                 <set-variable name="originalXForwardedForValue" value="@(context.Request.Headers.GetValueOrDefault("X-Forwarded-For"))" />
                 <set-variable name="requestDateString" value="@(DateTime.UtcNow.ToString("r"))" />
+                <!-- Check if the IP whitelist is in cache -->
                 <cache-lookup-value key="@(context.Subscription.Id+"_whitelist")" variable-name="issuerWhitelist" />
                 <choose>
                     <when condition="@(!context.Variables.ContainsKey("issuerWhitelist"))">

--- a/src/domains/sign/api_product/sign/_base_policy.xml
+++ b/src/domains/sign/api_product/sign/_base_policy.xml
@@ -63,10 +63,10 @@
                     </when>
                 </choose>
                 <!--
-                    Get the client ip from the X-Forwarded-For header and check if it is in the issuer's whitelist
-                    then set the support header X-ClientIp-Allowed
+                    Get the client ip from the X-Forwarded-For header and check if it is in the issuer's whitelist.
+                    In the positive case it returns the same source ip otherwise it returns 127.0.0.1
                 -->
-                <set-header name="X-ClientIp-Allowed" exists-action="override">
+                <check-header name="X-Forwarded-For" failed-check-httpcode="403" failed-check-error-message="Forbidden" ignore-case="true">
                     <value>@{
                         int HostToNetworkOrder(int host) {
                             return (((int)HostToNetworkOrderShort((short)host) & 0xFFFF) << 16)
@@ -96,8 +96,7 @@
                                             string cidrAddress = (string)cidr;
                                             // Avoid checking in this case because all IPs are enabled
                                             if(cidrAddress=="0.0.0.0/0"){
-                                                // The return value for the header value must be a string
-                                                return "true";
+                                                return ipAddress;
                                             }
 
                                             string[] cidrParts = cidrAddress.Split('/');
@@ -122,7 +121,7 @@
                                                 var mask = HostToNetworkOrder(host);
 
                                                 if (((ipAddr & mask) == (cidrAddr & mask))) {
-                                                    return "true";
+                                                    return ipAddress;
                                                 }
                                             }
                                         }
@@ -131,15 +130,10 @@
                             }
                         }
 
-                        return "false";
+                        return "127.0.0.1";
                     }</value>
-                </set-header>
-                <!-- Check if the ip is authorized (X-ClientIp-Allowed=="true") -->
-                <check-header name="X-ClientIp-Allowed" failed-check-httpcode="403" failed-check-error-message="Forbidden" ignore-case="true">
-                    <value>true</value>
                 </check-header>
-                <!-- Remove the support header X-ClientIp-Allowed -->
-                <set-header name="X-ClientIp-Allowed" exists-action="delete" />
+
 
                 <rate-limit-by-key calls="150" renewal-period="5" counter-key="@(context.Subscription.Id)" retry-after-header-name="x-rate-limit-retry-after" remaining-calls-header-name="x-rate-limit-remaining" />
             </when>

--- a/src/domains/sign/api_product/sign/_base_policy.xml
+++ b/src/domains/sign/api_product/sign/_base_policy.xml
@@ -3,23 +3,65 @@
         <choose>
             <!-- When called from the outside -->
             <when condition="@(context.Request.Headers.ContainsKey("X-Forwarded-For"))">
-                <!-- Save the X-Forwarded-For value -->
-                <set-variable
-                    name="originalXForwardedForValue"
-                    value="@(context.Request.Headers.GetValueOrDefault("X-Forwarded-For"))"
-                />
+                <set-variable name="originalXForwardedForValue" value="@(context.Request.Headers.GetValueOrDefault("X-Forwarded-For"))" />
+                <set-variable name="requestDateString" value="@(DateTime.UtcNow.ToString("r"))" />
+                <!-- Executes a query on CosmosDb via REST API to obtain the list of whitelisted IPs for each issuers (subscriptionId) -->
+                <send-request mode="new" response-variable-name="response" timeout="10" ignore-error="false">
+                    <set-url>https://{{io-sign-cosmosdb-name}}.documents.azure.com/dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-ip-collection-name}}/docs</set-url>
+                    <set-method>POST</set-method>
+                    <set-header name="Authorization" exists-action="override">
+                        <value>@{
+                            var verb = "post";
+                            var resourceType = "docs";
+                            var resourceLink = "dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-ip-collection-name}}";
+                            var key = "{{io-sign-cosmosdb-primary-key}}";
+                            var keyType = "master";
+                            var tokenVersion = "1.0";
+                            var date = context.Variables.GetValueOrDefault<string>("requestDateString");
 
-                <!-- Check the client IP value in the X-Forwarded-For header -->
-                <set-header
-                    name="X-Forwarded-For"
-                    exists-action="override"
-                >
+                            var hmacSha256 = new System.Security.Cryptography.HMACSHA256 { Key = Convert.FromBase64String(key) };
+
+                            string payLoad = string.Format("{0}\n{1}\n{2}\n{3}\n{4}\n",
+                                    verb.ToLowerInvariant(),
+                                    resourceType.ToLowerInvariant(),
+                                    resourceLink,
+                                    date.ToLowerInvariant(),
+                                    ""
+                            );
+
+                            byte[] hashPayLoad = hmacSha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payLoad));
+                            string signature = Convert.ToBase64String(hashPayLoad);
+
+                            return System.Uri.EscapeDataString(String.Format("type={0}&ver={1}&sig={2}",
+                                keyType,
+                                tokenVersion,
+                                signature));
+                            }</value>
+                    </set-header>
+                    <set-header name="Content-Type" exists-action="override">
+                        <value>application/query+json</value>
+                    </set-header>
+                    <set-header name="x-ms-documentdb-isquery" exists-action="override">
+                        <value>True</value>
+                    </set-header>
+                    <set-header name="x-ms-date" exists-action="override">
+                        <value>@(context.Variables.GetValueOrDefault<string>("requestDateString"))</value>
+                    </set-header>
+                    <set-header name="x-ms-version" exists-action="override">
+                        <value>2018-12-31</value>
+                    </set-header>
+                    <set-body>@("{\"query\": \"SELECT w.cidrs FROM whitelist w WHERE w.id = @id\", " +
+                                    "\"parameters\": [{ \"name\": \"@id\", \"value\": \"" + context.Subscription.Id + "\"}]}")</set-body>
+                </send-request>
+                <!-- Save response in issuerWhitelist var -->
+                <set-variable name="issuerWhitelist" value="@(((IResponse)context.Variables["response"]).Body.As<JObject>())" />
+                <!-- Get the client ip from the X-Forwarded-For header and check if it is in the issuer's whitelist -->
+                <set-header name="X-Forwarded-For" exists-action="override">
                     <value>@{
                         int HostToNetworkOrder(int host) {
                             return (((int)HostToNetworkOrderShort((short)host) & 0xFFFF) << 16)
                                 | ((int)HostToNetworkOrderShort((short)(host >> 16)) & 0xFFFF);
                         }
-
                         short HostToNetworkOrderShort(short host) {
                             return (short)((((int)host & 0xFF) << 8) | (int)((host >> 8) & 0xFF));
                         }
@@ -32,53 +74,48 @@
                                 ipAddress = tokens[0];
                             }
 
-                            //Place IP Ranges into this list in CIDR notation
-                            // (e.g. "0.0.0.0/0") and separate with commas
-                            List<string> cidrList = new List<string>(){
-                                // Dev Innovation
-                                "51.144.224.93/32",
-                                "51.145.159.13/32",
-                                "52.136.236.15/32",
-                                "52.178.92.96/32",
-                                "52.232.4.132/32",
-                                "52.232.64.246/32",
-                                "52.232.70.142/32",
+                            var queryResponse = context.Variables.GetValueOrDefault<JObject>("issuerWhitelist");
+                            if (queryResponse != null && queryResponse.ContainsKey("Documents"))
+                            {
+                                JArray documents = (JArray) queryResponse["Documents"];
+                                if (documents.Count > 0){
+                                    JObject firstDocument = (JObject) documents[0];
+                                    if(firstDocument.ContainsKey("cidrs")){
+                                        JArray whiteListCidrs = (JArray)firstDocument["cidrs"];
+                                        foreach (var cidr in whiteListCidrs) {
+                                            string cidrAddress = (string)cidr;
+                                            // Avoid checking in this case because all IPs are enabled
+                                            if(cidrAddress=="0.0.0.0/0"){
+                                                // This is the allowed ip set in the next rule
+                                                return "127.0.0.1";
+                                            }
 
-                                // UniMiB
-                                "51.144.182.201/32",
-                                "149.132.187.0/24",
+                                            string[] cidrParts = cidrAddress.Split('/');
+                                            string[] inputIPParts = ipAddress.Split('.');
+                                            string[] cidrIPArray = cidrParts[0].Split('.');
 
-                                // UniBo
-                                "137.204.0.0/16",
+                                            if (inputIPParts.Length == 4 && cidrIPArray.Length == 4) {
+                                                byte[] inputIPBytes = new byte[] {Convert.ToByte(int.Parse(inputIPParts[0])),
+                                                    Convert.ToByte(int.Parse(inputIPParts[1])),
+                                                    Convert.ToByte(int.Parse(inputIPParts[2])),
+                                                    Convert.ToByte(int.Parse(inputIPParts[3])), };
+                                                byte[] cidrIPBytes = new byte[] {Convert.ToByte(int.Parse(cidrIPArray[0])),
+                                                    Convert.ToByte(int.Parse(cidrIPArray[1])),
+                                                    Convert.ToByte(int.Parse(cidrIPArray[2])),
+                                                    Convert.ToByte(int.Parse(cidrIPArray[3])), };
 
-                                // PoliMi
-                                "131.175.148.35/32"
-                            };
+                                                int cidrAddr = BitConverter.ToInt32(inputIPBytes,0);
+                                                int ipAddr = BitConverter.ToInt32(cidrIPBytes,0);
 
-                            foreach (string cidrAddress in cidrList) {
-                                string[] cidrParts = cidrAddress.Split('/');
-                                string[] inputIPParts = ipAddress.Split('.');
-                                string[] cidrIPArray = cidrParts[0].Split('.');
+                                                var host = int.Parse(cidrParts[1]);
+                                                host = -1 << (32-host);
+                                                var mask = HostToNetworkOrder(host);
 
-                                if (inputIPParts.Length == 4 && cidrIPArray.Length == 4) {
-                                    byte[] inputIPBytes = new byte[] {Convert.ToByte(int.Parse(inputIPParts[0])),
-                                        Convert.ToByte(int.Parse(inputIPParts[1])),
-                                        Convert.ToByte(int.Parse(inputIPParts[2])),
-                                        Convert.ToByte(int.Parse(inputIPParts[3])), };
-                                    byte[] cidrIPBytes = new byte[] {Convert.ToByte(int.Parse(cidrIPArray[0])),
-                                        Convert.ToByte(int.Parse(cidrIPArray[1])),
-                                        Convert.ToByte(int.Parse(cidrIPArray[2])),
-                                        Convert.ToByte(int.Parse(cidrIPArray[3])), };
-
-                                    int cidrAddr = BitConverter.ToInt32(inputIPBytes,0);
-                                    int ipAddr = BitConverter.ToInt32(cidrIPBytes,0);
-
-                                    var host = int.Parse(cidrParts[1]);
-                                    host = -1 << (32-host);
-                                    var mask = HostToNetworkOrder(host);
-
-                                    if (((ipAddr & mask) == (cidrAddr & mask))) {
-                                        return "{{io-sign-ip-validated}}";
+                                                if (((ipAddr & mask) == (cidrAddr & mask))) {
+                                                    return "127.0.0.1";
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -87,32 +124,17 @@
                         return ipAddress;
                     }</value>
                 </set-header>
-
-                <check-header
-                    name="x-forwarded-for"
-                    failed-check-httpcode="403"
-                    failed-check-error-message="Forbidden"
-                    ignore-case="true"
-                >
-                    <value>{{io-sign-ip-validated}}</value>
+                <check-header name="x-forwarded-for" failed-check-httpcode="403" failed-check-error-message="Forbidden" ignore-case="true">
+                    <value>127.0.0.1</value>
                 </check-header>
-
                 <!-- Revert X-Forwarded-For to its original value -->
                 <set-header name="X-Forwarded-For" exists-action="override">
                     <value>@{
                             return context.Variables.GetValueOrDefault<string>("originalXForwardedForValue");
-                        }
-                    </value>
+                        }</value>
                 </set-header>
-
-                <rate-limit-by-key
-                    calls="150"
-                    renewal-period="5"
-                    remaining-calls-header-name="x-rate-limit-remaining" retry-after-header-name="x-rate-limit-retry-after"
-                    counter-key="@(context.Subscription.Id)"
-                />
+                <rate-limit-by-key calls="150" renewal-period="5" counter-key="@(context.Subscription.Id)" retry-after-header-name="x-rate-limit-retry-after" remaining-calls-header-name="x-rate-limit-remaining" />
             </when>
-
             <otherwise>
                 <!-- Allow direct call only from internal -->
                 <ip-filter action="allow">
@@ -120,7 +142,6 @@
                 </ip-filter>
             </otherwise>
         </choose>
-
         <base />
     </inbound>
     <backend>

--- a/src/domains/sign/api_product/sign/_base_policy.xml
+++ b/src/domains/sign/api_product/sign/_base_policy.xml
@@ -3,13 +3,12 @@
         <choose>
             <!-- When called from the outside -->
             <when condition="@(context.Request.Headers.ContainsKey("X-Forwarded-For"))">
-                <set-variable name="originalXForwardedForValue" value="@(context.Request.Headers.GetValueOrDefault("X-Forwarded-For"))" />
-                <set-variable name="requestDateString" value="@(DateTime.UtcNow.ToString("r"))" />
                 <!-- Check if the IP whitelist is in cache -->
                 <cache-lookup-value key="@(context.Subscription.Id+"_whitelist")" variable-name="issuerWhitelist" />
                 <choose>
                     <when condition="@(!context.Variables.ContainsKey("issuerWhitelist"))">
                         <!-- Executes a query on CosmosDb via REST API to obtain the list of whitelisted IPs for each issuers (subscriptionId) -->
+                        <set-variable name="requestDateString" value="@(DateTime.UtcNow.ToString("r"))" />
                         <send-request mode="new" response-variable-name="response" timeout="10" ignore-error="false">
                             <set-url>https://{{io-sign-cosmosdb-name}}.documents.azure.com/dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-ip-collection-name}}/docs</set-url>
                             <set-method>POST</set-method>
@@ -63,8 +62,11 @@
                         <cache-store-value key="@(context.Subscription.Id+"_whitelist")" value="@((JObject)context.Variables["issuerWhitelist"])" duration="60" />
                     </when>
                 </choose>
-                <!-- Get the client ip from the X-Forwarded-For header and check if it is in the issuer's whitelist -->
-                <set-header name="X-Forwarded-For" exists-action="override">
+                <!--
+                    Get the client ip from the X-Forwarded-For header and check if it is in the issuer's whitelist
+                    then set the support header X-ClientIp-Allowed
+                -->
+                <set-header name="X-ClientIp-Allowed" exists-action="override">
                     <value>@{
                         int HostToNetworkOrder(int host) {
                             return (((int)HostToNetworkOrderShort((short)host) & 0xFFFF) << 16)
@@ -94,8 +96,8 @@
                                             string cidrAddress = (string)cidr;
                                             // Avoid checking in this case because all IPs are enabled
                                             if(cidrAddress=="0.0.0.0/0"){
-                                                // This is the allowed ip set in the next rule
-                                                return "127.0.0.1";
+                                                // The return value for the header value must be a string
+                                                return "true";
                                             }
 
                                             string[] cidrParts = cidrAddress.Split('/');
@@ -120,7 +122,7 @@
                                                 var mask = HostToNetworkOrder(host);
 
                                                 if (((ipAddr & mask) == (cidrAddr & mask))) {
-                                                    return "127.0.0.1";
+                                                    return "true";
                                                 }
                                             }
                                         }
@@ -129,18 +131,16 @@
                             }
                         }
 
-                        return ipAddress;
+                        return "false";
                     }</value>
                 </set-header>
-                <check-header name="x-forwarded-for" failed-check-httpcode="403" failed-check-error-message="Forbidden" ignore-case="true">
-                    <value>127.0.0.1</value>
+                <!-- Check if the ip is authorized (X-ClientIp-Allowed=="true") -->
+                <check-header name="X-ClientIp-Allowed" failed-check-httpcode="403" failed-check-error-message="Forbidden" ignore-case="true">
+                    <value>true</value>
                 </check-header>
-                <!-- Revert X-Forwarded-For to its original value -->
-                <set-header name="X-Forwarded-For" exists-action="override">
-                    <value>@{
-                            return context.Variables.GetValueOrDefault<string>("originalXForwardedForValue");
-                        }</value>
-                </set-header>
+                <!-- Remove the support header X-ClientIp-Allowed -->
+                <set-header name="X-ClientIp-Allowed" exists-action="delete" />
+
                 <rate-limit-by-key calls="150" renewal-period="5" counter-key="@(context.Subscription.Id)" retry-after-header-name="x-rate-limit-retry-after" remaining-calls-header-name="x-rate-limit-remaining" />
             </when>
             <otherwise>

--- a/src/domains/sign/api_product/sign/_base_policy.xml
+++ b/src/domains/sign/api_product/sign/_base_policy.xml
@@ -62,11 +62,11 @@
                         <cache-store-value key="@(context.Subscription.Id+"_whitelist")" value="@((JObject)context.Variables["issuerWhitelist"])" duration="60" />
                     </when>
                 </choose>
-                <!--
-                    Get the client ip from the X-Forwarded-For header and check if it is in the issuer's whitelist.
-                    In the positive case it returns the same source ip otherwise it returns 127.0.0.1
-                -->
                 <check-header name="X-Forwarded-For" failed-check-httpcode="403" failed-check-error-message="Forbidden" ignore-case="true">
+                     <!--
+                        Get the client ip from the X-Forwarded-For header and check if it is in the issuer's whitelist.
+                        In the positive case it returns the same source ip otherwise it returns 127.0.0.1
+                    -->
                     <value>@{
                         int HostToNetworkOrder(int host) {
                             return (((int)HostToNetworkOrderShort((short)host) & 0xFFFF) << 16)

--- a/src/domains/sign/api_product/sign/_base_policy.xml
+++ b/src/domains/sign/api_product/sign/_base_policy.xml
@@ -17,7 +17,7 @@
                                     var verb = "post";
                                     var resourceType = "docs";
                                     var resourceLink = "dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-ip-collection-name}}";
-                                    var key = "{{io-sign-cosmosdb-primary-key}}";
+                                    var key = "{{io-sign-cosmosdb-key}}";
                                     var keyType = "master";
                                     var tokenVersion = "1.0";
                                     var date = context.Variables.GetValueOrDefault<string>("requestDateString");

--- a/src/domains/sign/api_product/sign/_base_policy.xml
+++ b/src/domains/sign/api_product/sign/_base_policy.xml
@@ -3,9 +3,9 @@
         <choose>
             <!-- When called from the outside -->
             <when condition="@(context.Request.Headers.ContainsKey("X-Forwarded-For"))">
-                <!-- Check if the IP whitelist is in cache -->
                 <cache-lookup-value key="@(context.Subscription.Id+"_whitelist")" variable-name="issuerWhitelist" />
                 <choose>
+                    <!-- Check if the IP whitelist is in cache -->
                     <when condition="@(!context.Variables.ContainsKey("issuerWhitelist"))">
                         <!-- Executes a query on CosmosDb via REST API to obtain the list of whitelisted IPs for each issuers (subscriptionId) -->
                         <set-variable name="requestDateString" value="@(DateTime.UtcNow.ToString("r"))" />

--- a/src/domains/sign/api_product/sign/_base_policy.xml
+++ b/src/domains/sign/api_product/sign/_base_policy.xml
@@ -65,7 +65,8 @@
                 <check-header name="X-Forwarded-For" failed-check-httpcode="403" failed-check-error-message="Forbidden" ignore-case="true">
                      <!--
                         Get the client ip from the X-Forwarded-For header and check if it is in the issuer's whitelist.
-                        In the positive case it returns the same source ip otherwise it returns 127.0.0.1
+                        In the positive case it returns the same source ip otherwise localhost ip: 127.0.0.1.
+                        (The choice to return 127.0.0.1 in the negative case is not mandatory, it is possible to return any string that differs from the source IP).
                     -->
                     <value>@{
                         int HostToNetworkOrder(int host) {

--- a/src/domains/sign/apim.tf
+++ b/src/domains/sign/apim.tf
@@ -29,11 +29,11 @@ resource "azurerm_api_management_named_value" "io_sign_cosmosdb_name" {
   secret              = false
 }
 
-resource "azurerm_api_management_named_value" "io_sign_cosmosdb_primary_key" {
-  name                = "io-sign-cosmosdb-primary-key"
+resource "azurerm_api_management_named_value" "io_sign_cosmosdb_key" {
+  name                = "io-sign-cosmosdb-key"
   api_management_name = data.azurerm_api_management.apim_api.name
   resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
-  display_name        = "io-sign-cosmosdb-primary-key"
+  display_name        = "io-sign-cosmosdb-key"
   value               = module.cosmosdb_account.primary_readonly_key
   secret              = true
 }

--- a/src/domains/sign/apim.tf
+++ b/src/domains/sign/apim.tf
@@ -34,7 +34,7 @@ resource "azurerm_api_management_named_value" "io_sign_cosmosdb_primary_key" {
   api_management_name = data.azurerm_api_management.apim_api.name
   resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
   display_name        = "io-sign-cosmosdb-primary-key"
-  value               = module.cosmosdb_account.primary_key
+  value               = module.cosmosdb_account.primary_readonly_key
   secret              = true
 }
 

--- a/src/domains/sign/apim.tf
+++ b/src/domains/sign/apim.tf
@@ -20,13 +20,40 @@ resource "azurerm_api_management_named_value" "io_fn_sign_issuer_key" {
   secret              = true
 }
 
-resource "azurerm_api_management_named_value" "io_sign_ip_validated" {
-  name                = "io-sign-ip-validated"
+resource "azurerm_api_management_named_value" "io_sign_cosmosdb_name" {
+  name                = "io-sign-cosmosdb-name"
   api_management_name = data.azurerm_api_management.apim_api.name
   resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
-  display_name        = "io-sign-ip-validated"
-  value               = "1"
+  display_name        = "io-sign-cosmosdb-name"
+  value               = module.cosmosdb_account.name
+  secret              = false
+}
+
+resource "azurerm_api_management_named_value" "io_sign_cosmosdb_primary_key" {
+  name                = "io-sign-cosmosdb-primary-key"
+  api_management_name = data.azurerm_api_management.apim_api.name
+  resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
+  display_name        = "io-sign-cosmosdb-primary-key"
+  value               = module.cosmosdb_account.primary_key
   secret              = true
+}
+
+resource "azurerm_api_management_named_value" "io_sign_cosmosdb_issuer_container_name" {
+  name                = "io-sign-cosmosdb-issuer-container-name"
+  api_management_name = data.azurerm_api_management.apim_api.name
+  resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
+  display_name        = "io-sign-cosmosdb-issuer-container-name"
+  value               = module.cosmosdb_sql_database_issuer.name
+  secret              = false
+}
+
+resource "azurerm_api_management_named_value" "io_sign_cosmosdb_issuer_whitelist_collection_name" {
+  name                = "io-sign-cosmosdb-issuer-whitelist-ip-collection-name"
+  api_management_name = data.azurerm_api_management.apim_api.name
+  resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
+  display_name        = "io-sign-cosmosdb-issuer-whitelist-ip-collection-name"
+  value               = module.cosmosdb_sql_container_issuer-issuers-ip-whitelist.name
+  secret              = false
 }
 
 module "apim_io_sign_product" {

--- a/src/domains/sign/cosmos_issuer.tf
+++ b/src/domains/sign/cosmos_issuer.tf
@@ -79,3 +79,18 @@ module "cosmosdb_sql_container_issuer-issuers-by-vat-number" {
 
   default_ttl = var.io_sign_database_issuer.issuers.ttl
 }
+
+module "cosmosdb_sql_container_issuer-issuers-ip-whitelist" {
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_sql_container?ref=v4.1.11"
+  name                = "issuers-ip-whitelist"
+  resource_group_name = azurerm_resource_group.data_rg.name
+  account_name        = module.cosmosdb_account.name
+  database_name       = module.cosmosdb_sql_database_issuer.name
+  partition_key_path  = "/id"
+
+  autoscale_settings = {
+    max_throughput = var.io_sign_database_issuer.uploads.max_throughput
+  }
+
+  default_ttl = var.io_sign_database_issuer.issuers.ttl
+}


### PR DESCRIPTION
This PR modifies the policy to filter source IPs on the io-sign APIM by reading an ip whitelist directly from cosmosDB.

### List of changes
1. Changed the policy for the `io-sign` APIM
2. Added `issuers-ip-whitelist` collection on issuer DB
3. Added the necessary named values to the APIM

### Motivation and context
We don't want to have a static list of IPs allowed to access APIM, but to have a whitelist for each issuer (`subscriptionId`)

### Type of changes

- [X] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
4. select PR branch
5. wait for approval
