### PR TITLE
feat: Add Namirial test environment for `io-sign`

### DIFF
--- a/src/domains/sign/io_sign_user_func.tf
+++ b/src/domains/sign/io_sign_user_func.tf
@@ -27,7 +27,7 @@ locals {
       NamirialApiBasePath                             = "https://pagopa.demo.bit4id.org"
       NamirialUsername                                = "api"
       NamirialPassword                                = module.key_vault_secrets.values["NamirialPassword"].value
-      NamirialTestApiBasePath                         = "https://pagopa.demo.bit4id.org"
+      NamirialTestApiBasePath                         = "https://pagopa-test.namirial.com/"
       NamirialTestUsername                            = "api"
       NamirialTestPassword                            = module.key_vault_secrets.values["NamirialTestPassword"].value
       SpidAssertionMock                               = module.key_vault_secrets.values["SpidAssertionMock"].value

--- a/src/domains/sign/io_sign_user_func.tf
+++ b/src/domains/sign/io_sign_user_func.tf
@@ -27,6 +27,9 @@ locals {
       NamirialApiBasePath                             = "https://pagopa.demo.bit4id.org"
       NamirialUsername                                = "api"
       NamirialPassword                                = module.key_vault_secrets.values["NamirialPassword"].value
+      NamirialTestApiBasePath                         = "https://pagopa.demo.bit4id.org"
+      NamirialTestUsername                            = "api"
+      NamirialTestPassword                            = module.key_vault_secrets.values["NamirialTestPassword"].value
       SpidAssertionMock                               = module.key_vault_secrets.values["SpidAssertionMock"].value
       AnalyticsEventHubConnectionString               = module.event_hub.keys["analytics.io-sign-func-user"].primary_connection_string
       BillingEventHubConnectionString                 = module.event_hub.keys["billing.io-sign-func-issuer"].primary_connection_string

--- a/src/domains/sign/key_vault.tf
+++ b/src/domains/sign/key_vault.tf
@@ -10,6 +10,7 @@ module "key_vault_secrets" {
     "io-fn-sign-issuer-key",
     "io-fn-sign-support-key",
     "NamirialPassword",
+    "NamirialTestPassword"
     "SpidAssertionMock",
     "SelfCareEventHubConnectionString",
     "SelfCareApiKey",

--- a/src/domains/sign/key_vault.tf
+++ b/src/domains/sign/key_vault.tf
@@ -10,7 +10,7 @@ module "key_vault_secrets" {
     "io-fn-sign-issuer-key",
     "io-fn-sign-support-key",
     "NamirialPassword",
-    "NamirialTestPassword"
+    "NamirialTestPassword",
     "SpidAssertionMock",
     "SelfCareEventHubConnectionString",
     "SelfCareApiKey",


### PR DESCRIPTION
Add Namirial (QTSP) test environment to `io-sign`

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Depends on #502 

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
