### PR TITLE
chore: Remove unused resources for `io-sign` and change qtsp url

### DIFF
--- a/src/domains/sign/apim.tf
+++ b/src/domains/sign/apim.tf
@@ -37,15 +37,6 @@ resource "azurerm_api_management_named_value" "io_fn_sign_support_key" {
   secret              = true
 }
 
-// TODO: need to remove
-resource "azurerm_api_management_named_value" "io_sign_ip_validated" {
-  name                = "io-sign-ip-validated"
-  api_management_name = data.azurerm_api_management.apim_api.name
-  resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
-  display_name        = "io-sign-ip-validated"
-  value               = "1"
-  secret              = true
-}
 
 resource "azurerm_api_management_named_value" "io_sign_cosmosdb_name" {
   name                = "io-sign-cosmosdb-name"
@@ -71,16 +62,6 @@ resource "azurerm_api_management_named_value" "io_sign_cosmosdb_issuer_container
   resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
   display_name        = "io-sign-cosmosdb-issuer-container-name"
   value               = module.cosmosdb_sql_database_issuer.name
-  secret              = false
-}
-
-// TODO: need to remove
-resource "azurerm_api_management_named_value" "io_sign_cosmosdb_issuer_whitelist_collection_name" {
-  name                = "io-sign-cosmosdb-issuer-whitelist-ip-collection-name"
-  api_management_name = data.azurerm_api_management.apim_api.name
-  resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
-  display_name        = "io-sign-cosmosdb-issuer-whitelist-ip-collection-name"
-  value               = module.cosmosdb_sql_container_issuer-issuers-whitelist.name
   secret              = false
 }
 

--- a/src/domains/sign/io_sign_user_func.tf
+++ b/src/domains/sign/io_sign_user_func.tf
@@ -24,7 +24,7 @@ locals {
       IoServicesSubscriptionKey                       = module.key_vault_secrets.values["IoServicesSubscriptionKey"].value
       PdvTokenizerApiBasePath                         = "https://api.uat.tokenizer.pdv.pagopa.it"
       PdvTokenizerApiKey                              = module.key_vault_secrets.values["TokenizerApiSubscriptionKey"].value
-      NamirialApiBasePath                             = "https://pagopa.demo.bit4id.org"
+      NamirialApiBasePath                             = "https://pagopa.namirial.com"
       NamirialUsername                                = "api"
       NamirialPassword                                = module.key_vault_secrets.values["NamirialPassword"].value
       NamirialTestApiBasePath                         = "https://pagopa-test.namirial.com"

--- a/src/domains/sign/io_sign_user_func.tf
+++ b/src/domains/sign/io_sign_user_func.tf
@@ -27,10 +27,9 @@ locals {
       NamirialApiBasePath                             = "https://pagopa.demo.bit4id.org"
       NamirialUsername                                = "api"
       NamirialPassword                                = module.key_vault_secrets.values["NamirialPassword"].value
-      NamirialTestApiBasePath                         = "https://pagopa-test.namirial.com/"
+      NamirialTestApiBasePath                         = "https://pagopa-test.namirial.com"
       NamirialTestUsername                            = "api"
       NamirialTestPassword                            = module.key_vault_secrets.values["NamirialTestPassword"].value
-      SpidAssertionMock                               = module.key_vault_secrets.values["SpidAssertionMock"].value
       AnalyticsEventHubConnectionString               = module.event_hub.keys["analytics.io-sign-func-user"].primary_connection_string
       BillingEventHubConnectionString                 = module.event_hub.keys["billing.io-sign-func-issuer"].primary_connection_string
       SelfCareEventHubConnectionString                = module.key_vault_secrets.values["SelfCareEventHubConnectionString"].value

--- a/src/domains/sign/key_vault.tf
+++ b/src/domains/sign/key_vault.tf
@@ -11,7 +11,6 @@ module "key_vault_secrets" {
     "io-fn-sign-support-key",
     "NamirialPassword",
     "NamirialTestPassword",
-    "SpidAssertionMock",
     "SelfCareEventHubConnectionString",
     "SelfCareApiKey",
     "SlackWebhookUrl",


### PR DESCRIPTION
### List of changes
- Removed unused `SpidAssertionMock` var
- Fixed Namirial endpoint

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
