### PR TITLE
feat: [SFEQS-1543] Add APIM policy to `getSignerByFiscalCode`

### DIFF
--- a/src/domains/sign/api/issuer/v1/get_signer_by_fiscal_code_policy/policy.xml
+++ b/src/domains/sign/api/issuer/v1/get_signer_by_fiscal_code_policy/policy.xml
@@ -4,7 +4,7 @@
         <choose>
             <when condition="@(!context.Variables.ContainsKey("issuerWhitelistFiscalCodes"))">
                 <set-variable name="requestDateString" value="@(DateTime.UtcNow.ToString("r"))" />
-                <send-request mode="new" response-variable-name="response" timeout="10" ignore-error="false">
+                <send-request mode="new" response-variable-name="response" timeout="1" ignore-error="false">
                     <set-url>https://{{io-sign-cosmosdb-name}}.documents.azure.com/dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-collection-name}}/docs</set-url>
                     <set-method>POST</set-method>
                     <set-header name="Authorization" exists-action="override">
@@ -61,7 +61,7 @@
         <choose>
             <when condition="@(!context.Variables.ContainsKey("issuerEnvironment"))">
                 <set-variable name="requestDateString" value="@(DateTime.UtcNow.ToString("r"))" />
-                <send-request mode="new" response-variable-name="response" timeout="10" ignore-error="false">
+                <send-request mode="new" response-variable-name="response" timeout="1" ignore-error="false">
                     <set-url>https://{{io-sign-cosmosdb-name}}.documents.azure.com/dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-issuers-name}}/docs</set-url>
                     <set-method>POST</set-method>
                     <set-header name="Authorization" exists-action="override">

--- a/src/domains/sign/api/issuer/v1/get_signer_by_fiscal_code_policy/policy.xml
+++ b/src/domains/sign/api/issuer/v1/get_signer_by_fiscal_code_policy/policy.xml
@@ -1,0 +1,178 @@
+<policies>
+    <inbound>
+        <cache-lookup-value key="@(context.Subscription.Id+"_whitelist_cf")" variable-name="issuerWhitelistFiscalCodes" />
+        <choose>
+            <when condition="@(!context.Variables.ContainsKey("issuerWhitelistFiscalCodes"))">
+                <set-variable name="requestDateString" value="@(DateTime.UtcNow.ToString("r"))" />
+                <send-request mode="new" response-variable-name="response" timeout="10" ignore-error="false">
+                    <set-url>https://{{io-sign-cosmosdb-name}}.documents.azure.com/dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-collection-name}}/docs</set-url>
+                    <set-method>POST</set-method>
+                    <set-header name="Authorization" exists-action="override">
+                        <value>@{
+                            var verb = "post";
+                            var resourceType = "docs";
+                            var resourceLink = "dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-collection-name}}";
+                            var key = "{{io-sign-cosmosdb-key}}";
+                            var keyType = "master";
+                            var tokenVersion = "1.0";
+                            var date = context.Variables.GetValueOrDefault<string>("requestDateString");
+
+                            var hmacSha256 = new System.Security.Cryptography.HMACSHA256 { Key = Convert.FromBase64String(key) };
+
+                            string payLoad = string.Format("{0}\n{1}\n{2}\n{3}\n{4}\n",
+                                    verb.ToLowerInvariant(),
+                                    resourceType.ToLowerInvariant(),
+                                    resourceLink,
+                                    date.ToLowerInvariant(),
+                                    ""
+                            );
+
+                            byte[] hashPayLoad = hmacSha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payLoad));
+                            string signature = Convert.ToBase64String(hashPayLoad);
+
+                            return System.Uri.EscapeDataString(String.Format("type={0}&ver={1}&sig={2}",
+                                keyType,
+                                tokenVersion,
+                                signature));
+                            }</value>
+                    </set-header>
+                    <set-header name="Content-Type" exists-action="override">
+                        <value>application/query+json</value>
+                    </set-header>
+                    <set-header name="x-ms-documentdb-isquery" exists-action="override">
+                        <value>True</value>
+                    </set-header>
+                    <set-header name="x-ms-date" exists-action="override">
+                        <value>@(context.Variables.GetValueOrDefault<string>("requestDateString"))</value>
+                    </set-header>
+                    <set-header name="x-ms-version" exists-action="override">
+                        <value>2018-12-31</value>
+                    </set-header>
+                    <set-body>@("{\"query\": \"SELECT w.test_fiscal_codes FROM whitelist w WHERE w.id = @id\", " +
+                                    "\"parameters\": [{ \"name\": \"@id\", \"value\": \"" + context.Subscription.Id + "\"}]}")</set-body>
+                </send-request>
+                <!-- Save response in issuerWhitelist var -->
+                <set-variable name="issuerWhitelistFiscalCodes" value="@(((IResponse)context.Variables["response"]).Body.As<JObject>())" />
+                <!-- Cache the query result for 60s to reduce the number of calls to cosmosDb -->
+                <cache-store-value key="@(context.Subscription.Id+"_whitelist_cf")" value="@((JObject)context.Variables["issuerWhitelistFiscalCodes"])" duration="60" />
+            </when>
+        </choose>
+        <cache-lookup-value key="@(context.Subscription.Id+"_issuer_environment")"  variable-name="issuerEnvironment" />
+        <choose>
+            <when condition="@(!context.Variables.ContainsKey("issuerEnvironment"))">
+                <set-variable name="requestDateString" value="@(DateTime.UtcNow.ToString("r"))" />
+                <send-request mode="new" response-variable-name="response" timeout="10" ignore-error="false">
+                    <set-url>https://{{io-sign-cosmosdb-name}}.documents.azure.com/dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-issuers-name}}/docs</set-url>
+                    <set-method>POST</set-method>
+                    <set-header name="Authorization" exists-action="override">
+                        <value>@{
+                            var verb = "post";
+                            var resourceType = "docs";
+                            var resourceLink = "dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-issuers-name}}";
+                            var key = "{{io-sign-cosmosdb-key}}";
+                            var keyType = "master";
+                            var tokenVersion = "1.0";
+                            var date = context.Variables.GetValueOrDefault<string>("requestDateString");
+
+                            var hmacSha256 = new System.Security.Cryptography.HMACSHA256 { Key = Convert.FromBase64String(key) };
+
+                            string payLoad = string.Format("{0}\n{1}\n{2}\n{3}\n{4}\n",
+                                    verb.ToLowerInvariant(),
+                                    resourceType.ToLowerInvariant(),
+                                    resourceLink,
+                                    date.ToLowerInvariant(),
+                                    ""
+                            );
+
+                            byte[] hashPayLoad = hmacSha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payLoad));
+                            string signature = Convert.ToBase64String(hashPayLoad);
+
+                            return System.Uri.EscapeDataString(String.Format("type={0}&ver={1}&sig={2}",
+                                keyType,
+                                tokenVersion,
+                                signature));
+                            }</value>
+                    </set-header>
+                    <set-header name="Content-Type" exists-action="override">
+                        <value>application/query+json</value>
+                    </set-header>
+                    <set-header name="x-ms-documentdb-isquery" exists-action="override">
+                        <value>True</value>
+                    </set-header>
+                    <set-header name="x-ms-date" exists-action="override">
+                        <value>@(context.Variables.GetValueOrDefault<string>("requestDateString"))</value>
+                    </set-header>
+                    <set-header name="x-ms-version" exists-action="override">
+                        <value>2018-12-31</value>
+                    </set-header>
+                    <set-body>@("{\"query\": \"SELECT i.environment FROM issuers i WHERE i.subscriptionId = @subscriptionId\", " +
+                                    "\"parameters\": [{ \"name\": \"@subscriptionId\", \"value\": \"" + context.Subscription.Id + "\"}]}")</set-body>
+                </send-request>
+                <!-- Save response in issuerWhitelist var -->
+                <set-variable name="issuerEnvironment" value="@(((IResponse)context.Variables["response"]).Body.As<JObject>())" />
+                <!-- Cache the query result for 60s to reduce the number of calls to cosmosDb -->
+                <cache-store-value key="@(context.Subscription.Id+"_issuer_environment")" value="@((JObject)context.Variables["issuerEnvironment"])" duration="60" />
+            </when>
+        </choose>
+        <set-header name="X-Allowed" exists-action="override">
+            <!--
+                Get the Fiscal Code from the request body and check if it is in the fiscal code's whitelist and also if the issuer use a TEST environment.
+                In the positive case it place "true" in the "X-Allowed" header otherwise "false"
+            -->
+            <value>@{
+                var environmentQueryResponse = context.Variables.GetValueOrDefault<JObject>("issuerEnvironment");
+                if (environmentQueryResponse != null && environmentQueryResponse.ContainsKey("Documents")){
+                    JArray envDocuments = (JArray) environmentQueryResponse["Documents"];
+                    if (envDocuments.Count > 0){
+                        JObject envFirstDocument = (JObject) envDocuments[0];
+                        if(envFirstDocument.ContainsKey("environment")){
+                            string issuerEnvironment = (string)envFirstDocument["environment"];
+
+                            //If the issuer is not in the TEST environment then I do not perform any checks
+                            if (issuerEnvironment!="TEST"){
+                                return "true";
+                            }
+                        }
+                    }
+                }
+
+                var whitelistFiscalCodeQueryResponse = context.Variables.GetValueOrDefault<JObject>("issuerWhitelistFiscalCodes");
+                JObject requestBody = context.Request.Body.As<JObject>();
+                if(requestBody.ContainsKey("fiscal_code")){
+                    string requestFiscalCodeString = (string)requestBody["fiscal_code"];
+                    if (whitelistFiscalCodeQueryResponse != null && whitelistFiscalCodeQueryResponse.ContainsKey("Documents")){
+                        JArray documents = (JArray) whitelistFiscalCodeQueryResponse["Documents"];
+                        if (documents.Count > 0){
+                            JObject firstDocument = (JObject) documents[0];
+                            if(firstDocument.ContainsKey("test_fiscal_codes")){
+                                JArray whiteListFiscalCodes = (JArray)firstDocument["test_fiscal_codes"];
+                                foreach (var fiscalCode in whiteListFiscalCodes) {
+                                    string fiscalCodeString = (string)fiscalCode;
+                                    if(fiscalCodeString==requestFiscalCodeString){
+                                        return "true";
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                return "false";
+            }</value>
+        </set-header>
+        <check-header name="X-Allowed" failed-check-httpcode="403" failed-check-error-message="Forbidden" ignore-case="true">
+            <value>true</value>
+        </check-header>
+        <!-- Delete temporary header -->
+        <set-header name="X-Allowed" exists-action="delete" />
+        <base />
+    </inbound>
+    <outbound>
+        <base />
+    </outbound>
+    <backend>
+        <base />
+    </backend>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/domains/sign/api_product/sign/_base_policy.xml
+++ b/src/domains/sign/api_product/sign/_base_policy.xml
@@ -12,7 +12,7 @@
                             The connection to cosmosdb is explained here: https://learn.microsoft.com/en-us/rest/api/cosmos-db/access-control-on-cosmosdb-resources
                         -->
                         <set-variable name="requestDateString" value="@(DateTime.UtcNow.ToString("r"))" />
-                        <send-request mode="new" response-variable-name="response" timeout="10" ignore-error="false">
+                        <send-request mode="new" response-variable-name="response" timeout="1" ignore-error="false">
                             <set-url>https://{{io-sign-cosmosdb-name}}.documents.azure.com/dbs/{{io-sign-cosmosdb-issuer-container-name}}/colls/{{io-sign-cosmosdb-issuer-whitelist-collection-name}}/docs</set-url>
                             <set-method>POST</set-method>
                             <set-header name="Authorization" exists-action="override">

--- a/src/domains/sign/apim.tf
+++ b/src/domains/sign/apim.tf
@@ -102,7 +102,7 @@ module "apim_io_sign_product" {
 }
 
 resource "azurerm_api_management_api_operation_policy" "get_signer_by_fiscal_code_policy" {
-  api_name            = "io-sign-api"
+  api_name            = module.apim_io_sign_issuer_api_v1.name
   api_management_name = data.azurerm_api_management.apim_api.name
   resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
   operation_id        = "getSignerByFiscalCode"

--- a/src/domains/sign/apim.tf
+++ b/src/domains/sign/apim.tf
@@ -103,8 +103,8 @@ module "apim_io_sign_product" {
 
 resource "azurerm_api_management_api_operation_policy" "get_signer_by_fiscal_code_policy" {
   api_name            = "io-sign-api"
-  api_management_name = module.apim.name
-  resource_group_name = module.apim.resource_group_name
+  api_management_name = data.azurerm_api_management.apim_api.name
+  resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
   operation_id        = "getSignerByFiscalCode"
 
   xml_content = file("./api/issuer/v1/get_signer_by_fiscal_code_policy/policy.xml")

--- a/src/domains/sign/apim.tf
+++ b/src/domains/sign/apim.tf
@@ -74,6 +74,16 @@ resource "azurerm_api_management_named_value" "io_sign_cosmosdb_issuer_whitelist
   secret              = false
 }
 
+resource "azurerm_api_management_named_value" "io_sign_cosmosdb_issuer_issuers_collection_name" {
+  name                = "io-sign-cosmosdb-issuer-issuers-name"
+  api_management_name = data.azurerm_api_management.apim_api.name
+  resource_group_name = data.azurerm_api_management.apim_api.resource_group_name
+  display_name        = "io-sign-cosmosdb-issuer-issuers-name"
+  value               = module.cosmosdb_sql_container_issuer-issuers.name
+  secret              = false
+}
+
+
 module "apim_io_sign_product" {
   source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_product?ref=v4.1.3"
 
@@ -89,6 +99,15 @@ module "apim_io_sign_product" {
   approval_required     = false
 
   policy_xml = file("./api_product/sign/_base_policy.xml")
+}
+
+resource "azurerm_api_management_api_operation_policy" "get_signer_by_fiscal_code_policy" {
+  api_name            = "io-sign-api"
+  api_management_name = module.apim.name
+  resource_group_name = module.apim.resource_group_name
+  operation_id        = "getSignerByFiscalCode"
+
+  xml_content = file("./api/issuer/v1/get_signer_by_fiscal_code_policy/policy.xml")
 }
 
 module "apim_io_sign_issuer_api_v1" {

--- a/src/domains/sign/io_sign_user_func.tf
+++ b/src/domains/sign/io_sign_user_func.tf
@@ -24,7 +24,7 @@ locals {
       IoServicesSubscriptionKey                       = module.key_vault_secrets.values["IoServicesSubscriptionKey"].value
       PdvTokenizerApiBasePath                         = "https://api.uat.tokenizer.pdv.pagopa.it"
       PdvTokenizerApiKey                              = module.key_vault_secrets.values["TokenizerApiSubscriptionKey"].value
-      NamirialApiBasePath                             = "https://pagopa.namirial.com"
+      NamirialApiBasePath                             = "https://pagopa.demo.bit4id.org"
       NamirialUsername                                = "api"
       NamirialPassword                                = module.key_vault_secrets.values["NamirialPassword"].value
       NamirialTestApiBasePath                         = "https://pagopa-test.namirial.com"


### PR DESCRIPTION
Adds a policy to the `getSignerByFiscalCode` endpoint to filter requests based on authorized fiscal codes. In particular, if the issuer uses a test environment, it can contact the `getSignerByFiscalCode` endpoint only with allowed fiscal code.

### List of changes
- Added `io-sign-cosmosdb-issuer-issuers-name` named value
- Added custom policy to `getSignerByFiscalCode`


### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
