### PR TITLE
feat: [SFEQS-1645] Add Access-Control-Allow-Origin header on Assets CDN

### DIFF
--- a/src/core/assets_cdn.tf
+++ b/src/core/assets_cdn.tf
@@ -125,6 +125,7 @@ resource "azurerm_cdn_endpoint" "assets_cdn_endpoint" {
     url_path_condition {
       operator     = "BeginsWith"
       match_values = ["/sign"]
+      transforms   = "Lowercase"
     }
     modify_response_header_action {
       action = "Append"

--- a/src/core/assets_cdn.tf
+++ b/src/core/assets_cdn.tf
@@ -126,7 +126,7 @@ resource "azurerm_cdn_endpoint" "assets_cdn_endpoint" {
       operator     = "BeginsWith"
       match_values = ["/sign"]
     }
-    modify_request_header_action {
+    modify_response_header_action {
       action = "Append"
       name   = "Access-Control-Allow-Origin"
       value  = "*"

--- a/src/core/assets_cdn.tf
+++ b/src/core/assets_cdn.tf
@@ -119,6 +119,20 @@ resource "azurerm_cdn_endpoint" "assets_cdn_endpoint" {
     }
   }
 
+  delivery_rule {
+    name  = "sign"
+    order = 5
+    url_path_condition {
+      operator     = "BeginsWith"
+      match_values = ["/sign"]
+    }
+    modify_request_header_action {
+      action = "Append"
+      name   = "Access-Control-Allow-Origin"
+      value  = "*"
+    }
+  }
+
   tags = var.tags
 }
 

--- a/src/core/assets_cdn.tf
+++ b/src/core/assets_cdn.tf
@@ -125,7 +125,7 @@ resource "azurerm_cdn_endpoint" "assets_cdn_endpoint" {
     url_path_condition {
       operator     = "BeginsWith"
       match_values = ["/sign"]
-      transforms   = "Lowercase"
+      transforms   = ["Lowercase"]
     }
     modify_response_header_action {
       action = "Append"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

1. Set `Access-Control-Allow-Origin` header to `*` for resources served from `/sign` path

<!--- Describe your changes in detail -->

### Motivation and context

the `io-sign` files, served by our CDN, will be embedded in issuers websites, so they should be downloadable from all origins

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
