### PR TITLE
[#IOPID-207] Remove Redis V4 cache fn-app-messages

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -130,7 +130,6 @@
 | <a name="module_redis_common"></a> [redis\_common](#module\_redis\_common) | git::https://github.com/pagopa/terraform-azurerm-v3.git//redis_cache | v6.3.0 |
 | <a name="module_redis_common_backup"></a> [redis\_common\_backup](#module\_redis\_common\_backup) | git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account | v6.3.0 |
 | <a name="module_redis_common_snet"></a> [redis\_common\_snet](#module\_redis\_common\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v6.3.0 |
-| <a name="module_redis_messages"></a> [redis\_messages](#module\_redis\_messages) | git::https://github.com/pagopa/terraform-azurerm-v3.git//redis_cache | v4.1.15 |
 | <a name="module_redis_messages_v6"></a> [redis\_messages\_v6](#module\_redis\_messages\_v6) | git::https://github.com/pagopa/terraform-azurerm-v3.git//redis_cache | v6.11.2 |
 | <a name="module_selfcare_be_common_snet"></a> [selfcare\_be\_common\_snet](#module\_selfcare\_be\_common\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v4.1.15 |
 | <a name="module_selfcare_cdn"></a> [selfcare\_cdn](#module\_selfcare\_cdn) | git::https://github.com/pagopa/terraform-azurerm-v3.git//cdn | v4.1.15 |

--- a/src/core/app_messages.tf
+++ b/src/core/app_messages.tf
@@ -31,9 +31,9 @@ locals {
       FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
       // REDIS
-      REDIS_URL      = module.redis_messages.hostname
-      REDIS_PORT     = module.redis_messages.ssl_port
-      REDIS_PASSWORD = module.redis_messages.primary_access_key
+      REDIS_URL      = module.redis_messages_v6.hostname
+      REDIS_PORT     = module.redis_messages_v6.ssl_port
+      REDIS_PASSWORD = module.redis_messages_v6.primary_access_key
 
       PN_SERVICE_ID = var.pn_service_id
 
@@ -49,55 +49,6 @@ locals {
     app_settings_2 = {
     }
   }
-}
-
-/**
-* [OLD REDIS V4]
-* Will be removed after the binding with the function-app-messages
-* migrate to the new Redis V6 instance.
-*/
-module "redis_messages" {
-  source                = "git::https://github.com/pagopa/terraform-azurerm-v3.git//redis_cache?ref=v4.1.15"
-  name                  = format("%s-redis-app-messages-std", local.project)
-  resource_group_name   = azurerm_resource_group.app_messages_common_rg.name
-  location              = azurerm_resource_group.app_messages_common_rg.location
-  capacity              = 0
-  family                = "C"
-  sku_name              = "Standard"
-  enable_authentication = true
-
-  // when azure can apply patch?
-  patch_schedules = [{
-    day_of_week    = "Sunday"
-    start_hour_utc = 23
-    },
-    {
-      day_of_week    = "Monday"
-      start_hour_utc = 23
-    },
-    {
-      day_of_week    = "Tuesday"
-      start_hour_utc = 23
-    },
-    {
-      day_of_week    = "Wednesday"
-      start_hour_utc = 23
-    },
-    {
-      day_of_week    = "Thursday"
-      start_hour_utc = 23
-    },
-  ]
-
-
-  private_endpoint = {
-    enabled              = true
-    virtual_network_id   = module.vnet_common.id
-    subnet_id            = module.private_endpoints_subnet.id
-    private_dns_zone_ids = [azurerm_private_dns_zone.privatelink_redis_cache.id]
-  }
-
-  tags = var.tags
 }
 
 /**


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Update configuration for `fn-app-messages` pointing to the new Redis V6 cache
Remove old Redis V4 cache

<!--- Describe your changes in detail -->

### Motivation and context
The Redis V4 is deprecated by Microsoft Azure, we need to upgrade the Redis version to V6

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [X] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
