### PR TITLE
[#IOPAE-348] Open IO Backoffice Manage Key to everyone

### DIFF
--- a/src/core/devportal.tf
+++ b/src/core/devportal.tf
@@ -145,10 +145,8 @@ module "appservice_devportal_be" {
     # All users not listed below, will not be able to get (and also create) the manage subscription.
     # The "Manage Flow" allows the use of a specific subscription (Manage Subscription) keys as API Key for Service create/update.
     # Note: The list below is for the user IDs only, not the full path APIM.id.
-    MANAGE_FLOW_ENABLE_USER_LIST = join(",", [
-      "01GC77MF2WYY52DCSQXVEDCE74", # IDPay
-      "01GJMF341BZQBP71Q39S1EHBH6"  # Di Pinto Giuseppe Antonio
-    ])
+    # UPDATE: The new feature is that "If one of such strings is "*", we suddenly open the feature to everyone.".
+    MANAGE_FLOW_ENABLE_USER_LIST = join(",", ["*"])
   }
 
   allowed_subnets = [module.appgateway_snet.id]

--- a/src/core/devportal.tf
+++ b/src/core/devportal.tf
@@ -146,7 +146,7 @@ module "appservice_devportal_be" {
     # The "Manage Flow" allows the use of a specific subscription (Manage Subscription) keys as API Key for Service create/update.
     # Note: The list below is for the user IDs only, not the full path APIM.id.
     # UPDATE: The new feature is that "If one of such strings is "*", we suddenly open the feature to everyone.".
-    MANAGE_FLOW_ENABLE_USER_LIST = join(",", ["*"])
+    MANAGE_FLOW_ENABLE_USER_LIST = "*"
   }
 
   allowed_subnets = [module.appgateway_snet.id]

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -243,6 +243,15 @@ module "appservice_selfcare_be" {
 
     SUBSCRIPTION_MIGRATIONS_URL    = format("https://%s.azurewebsites.net/api/v1", module.function_subscriptionmigrations.name)
     SUBSCRIPTION_MIGRATIONS_APIKEY = data.azurerm_key_vault_secret.selfcare_subsmigrations_apikey.value
+
+    # Feature Flags
+    #
+    # List of (comma separated) APIM userId for whom we want to enable Manage Flow on Service Management.
+    # All users not listed below, will not be able to get (and also create) the manage subscription.
+    # The "Manage Flow" allows the use of a specific subscription (Manage Subscription) keys as API Key for Service create/update.
+    # Note: The list below is for the user IDs only, not the full path APIM.id.
+    # UPDATE: The new feature is that "If one of such strings is "*", we suddenly open the feature to everyone.".
+    MANAGE_FLOW_ENABLE_USER_LIST = join(",", ["*"])
   }
 
   allowed_subnets = [module.appgateway_snet.id]

--- a/src/core/selfcare.tf
+++ b/src/core/selfcare.tf
@@ -251,7 +251,7 @@ module "appservice_selfcare_be" {
     # The "Manage Flow" allows the use of a specific subscription (Manage Subscription) keys as API Key for Service create/update.
     # Note: The list below is for the user IDs only, not the full path APIM.id.
     # UPDATE: The new feature is that "If one of such strings is "*", we suddenly open the feature to everyone.".
-    MANAGE_FLOW_ENABLE_USER_LIST = join(",", ["*"])
+    MANAGE_FLOW_ENABLE_USER_LIST = "*"
   }
 
   allowed_subnets = [module.appgateway_snet.id]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
We have a feature _(manage key)_ that we'll enable for all IO Backoffice users _(Developer Portal and Selfcare)._
Changing _**MANAGE_FLOW_ENABLE_USER_LIST**_ config key to "*" value, we will open the feature to everyone.

This PR is intended to make that change.

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
