### PR TITLE
fix: Add kv access policy to CI/CD pipelines

### DIFF
--- a/src/.template-common/02_security.tf
+++ b/src/.template-common/02_security.tf
@@ -42,3 +42,38 @@ resource "azurerm_key_vault_access_policy" "adgroup_developers" {
   storage_permissions     = []
   certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
 }
+
+# Access policy for CD pipeline
+data "azuread_service_principal" "github_action_iac_cd" {
+  display_name = "github-pagopa-io-infra-prod-cd"
+}
+
+resource "azurerm_key_vault_access_policy" "github_action_iac_cd_kv" {
+  key_vault_id = module.key_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azuread_service_principal.github_action_iac_cd.object_id
+
+  secret_permissions      = ["Get", "List", "Set", ]
+  storage_permissions     = []
+  certificate_permissions = ["SetIssuers", "DeleteIssuers", "Purge", "List", "Get", "ManageContacts", "Create", ]
+}
+
+
+# Access policy for CI pipeline
+data "azuread_service_principal" "github_action_iac_ci" {
+  display_name = "github-pagopa-io-infra-prod-ci"
+}
+
+resource "azurerm_key_vault_access_policy" "github_action_iac_ci_kv" {
+  key_vault_id = module.key_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azuread_service_principal.github_action_iac_ci.object_id
+
+  secret_permissions      = ["Get", "List", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", ]
+  key_permissions = [
+    "Get",
+  ]
+}
+

--- a/src/.template-common/README.md
+++ b/src/.template-common/README.md
@@ -27,6 +27,8 @@
 |------|------|
 | [azurerm_key_vault_access_policy.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.github_action_iac_cd_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.github_action_iac_ci_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_secret.appinsights_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appinsights_instrumentation_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
@@ -34,6 +36,8 @@
 | [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_service_principal.github_action_iac_cd](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
+| [azuread_service_principal.github_action_iac_ci](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
 | [azurerm_application_insights.application_insights](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/application_insights) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_log_analytics_workspace.log_analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->


### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Fix `.template-common` access policies to enable CI/CD to access kv. 

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

Template

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
