### PR TITLE
fix:[#IOPID-579] Enable vnet_integration for hub-spid-login app service

### DIFF
--- a/src/domains/ioweb-common/10_spid_login.tf
+++ b/src/domains/ioweb-common/10_spid_login.tf
@@ -109,7 +109,8 @@ module "spid_login" {
   allowed_subnets = [data.azurerm_subnet.azdoa_snet.id, data.azurerm_subnet.apim_v2_snet.id]
   allowed_ips     = []
 
-  subnet_id = module.spid_login_snet.id
+  subnet_id        = module.spid_login_snet.id
+  vnet_integration = true
 
   tags = var.tags
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- add `  vnet_integration = true` to app service configuration

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Enable vnet_integration for hub-spid-login app service for making it communicate with Redis

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
