### PR TITLE
[#IOCOM-504] Enable canary for messages from view.

### DIFF
--- a/src/core/app_messages.tf
+++ b/src/core/app_messages.tf
@@ -38,9 +38,9 @@ locals {
       PN_SERVICE_ID = var.pn_service_id
 
       // View Features Flag
-      USE_FALLBACK          = false
-      FF_TYPE               = "canary"
-      FF_BETA_TESTER_LIST   = data.azurerm_key_vault_secret.fn_messages_APP_MESSAGES_BETA_FISCAL_CODES.value
+      USE_FALLBACK        = false
+      FF_TYPE             = "canary"
+      FF_BETA_TESTER_LIST = data.azurerm_key_vault_secret.fn_messages_APP_MESSAGES_BETA_FISCAL_CODES.value
       # Takes ~0,4% of users
       FF_CANARY_USERS_REGEX = "^([(0-9)|(a-f)|(A-F)]{62}00)$"
 

--- a/src/core/app_messages.tf
+++ b/src/core/app_messages.tf
@@ -39,9 +39,10 @@ locals {
 
       // View Features Flag
       USE_FALLBACK          = false
-      FF_TYPE               = "beta"
+      FF_TYPE               = "canary"
       FF_BETA_TESTER_LIST   = data.azurerm_key_vault_secret.fn_messages_APP_MESSAGES_BETA_FISCAL_CODES.value
-      FF_CANARY_USERS_REGEX = "XYZ"
+      # Takes ~0,4% of users
+      FF_CANARY_USERS_REGEX = "^([(0-9)|(a-f)|(A-F)]{62}00)$"
 
     }
     app_settings_1 = {


### PR DESCRIPTION
### List of changes
Moved FF to canary users, and made a regex that takes 0.4% of fiscal codes in production

### Motivation and context
We need to reach the whole user base in taking messages from the view calculated from fn-messages-cqrs.
After a year testing with betatesters we are ready to move to canary users.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?
Enabling canary users increases the impact of our tests, if something goes wrong will go back to betatester.
- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No
