### PR TITLE
fix: Add missing private endpoint to `iopweuiowebspidlogsst `

### DIFF
--- a/src/domains/ioweb-app/06_function_ioweb_profile.tf
+++ b/src/domains/ioweb-app/06_function_ioweb_profile.tf
@@ -154,6 +154,8 @@ module "function_ioweb_profile" {
     data.azurerm_subnet.function_app_snet[1].id,
   ]
 
+  enable_healthcheck = false
+
   # Action groups for alerts
   action = [
     {

--- a/src/domains/ioweb-common/01_network.tf
+++ b/src/domains/ioweb-common/01_network.tf
@@ -3,6 +3,12 @@ data "azurerm_virtual_network" "vnet_common" {
   resource_group_name = local.vnet_common_resource_group_name
 }
 
+data "azurerm_subnet" "private_endpoints_subnet" {
+  name                 = "pendpoints"
+  virtual_network_name = local.vnet_common_name
+  resource_group_name  = local.vnet_common_resource_group_name
+}
+
 data "azurerm_private_dns_zone" "privatelink_redis_cache" {
   name                = "privatelink.redis.cache.windows.net"
   resource_group_name = format("%s-rg-common", local.product)
@@ -13,6 +19,11 @@ data "azurerm_subnet" "azdoa_snet" {
   name                 = "azure-devops"
   virtual_network_name = local.vnet_common_name
   resource_group_name  = local.vnet_common_resource_group_name
+}
+
+data "azurerm_private_dns_zone" "privatelink_blob_core_windows_net" {
+  name                = "privatelink.blob.core.windows.net"
+  resource_group_name = local.vnet_common_resource_group_name
 }
 
 data "azurerm_subnet" "apim_v2_snet" {

--- a/src/domains/ioweb-common/03_storage.tf
+++ b/src/domains/ioweb-common/03_storage.tf
@@ -56,6 +56,7 @@ resource "azurerm_private_endpoint" "spid_logs_storage_blob" {
 
 # Containers
 resource "azurerm_storage_container" "spid_logs" {
+  depends_on            = [module.spid_logs_storage]
   name                  = "spidlogs"
   storage_account_name  = module.spid_logs_storage.name
   container_access_type = "private"

--- a/src/domains/ioweb-common/03_storage.tf
+++ b/src/domains/ioweb-common/03_storage.tf
@@ -32,9 +32,30 @@ module "spid_logs_storage_customer_managed_key" {
 }
 
 
+resource "azurerm_private_endpoint" "spid_logs_storage_blob" {
+  name                = "${module.spid_logs_storage.name}-blob-endpoint"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.storage_rg.name
+  subnet_id           = data.azurerm_subnet.private_endpoints_subnet.id
+
+  private_service_connection {
+    name                           = "${module.spid_logs_storage.name}-blob"
+    private_connection_resource_id = module.spid_logs_storage.id
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-group"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.privatelink_blob_core_windows_net.id]
+  }
+
+  tags = var.tags
+}
+
+
 # Containers
 resource "azurerm_storage_container" "spid_logs" {
-  depends_on            = [module.spid_logs_storage]
   name                  = "spidlogs"
   storage_account_name  = module.spid_logs_storage.name
   container_access_type = "private"

--- a/src/domains/ioweb-common/README.md
+++ b/src/domains/ioweb-common/README.md
@@ -45,6 +45,7 @@
 | [azurerm_key_vault_secret.appinsights_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appinsights_instrumentation_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.spid_login_jwt_pub_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_private_endpoint.spid_logs_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.common_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.fe_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
@@ -69,12 +70,14 @@
 | [azurerm_monitor_action_group.error_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.quarantine_error_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.slack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
+| [azurerm_private_dns_zone.privatelink_blob_core_windows_net](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.privatelink_redis_cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_resource_group.core_ext](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.monitor_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subnet.apim_v2_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.azdoa_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.ioweb_profile_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_subnet.private_endpoints_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 | [azurerm_virtual_network.vnet_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Add missing private endpoint to `iopweuiowebspidlogsst`, to allow gh action to access/edit containers 

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
