### PR TITLE
[#IOPID-859] Add new locked profiles storage

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -150,6 +150,7 @@
 | <a name="module_github_runner"></a> [github\_runner](#module\_github\_runner) | git::https://github.com/pagopa/terraform-azurerm-v3.git//container_app_environment | v6.15.0 |
 | <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault) | git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault | v4.1.15 |
 | <a name="module_key_vault_common"></a> [key\_vault\_common](#module\_key\_vault\_common) | git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault | v4.1.15 |
+| <a name="module_locked_profiles_storage"></a> [locked\_profiles\_storage](#module\_locked\_profiles\_storage) | git::https://github.com/pagopa/terraform-azurerm-v3//storage_account | v6.1.0 |
 | <a name="module_nat_gateway"></a> [nat\_gateway](#module\_nat\_gateway) | git::https://github.com/pagopa/terraform-azurerm-v3.git//nat_gateway | v6.1.0 |
 | <a name="module_private_endpoints_subnet"></a> [private\_endpoints\_subnet](#module\_private\_endpoints\_subnet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v4.1.4 |
 | <a name="module_redis_cgn"></a> [redis\_cgn](#module\_redis\_cgn) | git::https://github.com/pagopa/terraform-azurerm-v3.git//redis_cache | v4.1.15 |
@@ -416,6 +417,7 @@
 | [azurerm_private_dns_zone_virtual_network_link.table_core_private_vnet_prod01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.table_core_private_vnet_prod02](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_endpoint.cgn_legalbackup_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.locked_profiles_storage_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_public_ip.appgateway_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_public_ip.public_ip_apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_resource_group.admin_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
@@ -466,6 +468,7 @@
 | [azurerm_storage_table.fnelterrors_messages](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
 | [azurerm_storage_table.fnelterrors_notification_status](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
 | [azurerm_storage_table.fneltexports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
+| [azurerm_storage_table.locked_profiles](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
 | [azurerm_storage_table.storage_api_faileduserdataprocessing](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
 | [azurerm_storage_table.storage_api_subscriptionsfeedbyday](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
 | [azurerm_storage_table.storage_api_validationtokens](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |

--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -136,6 +136,8 @@ locals {
       PUSH_NOTIFICATIONS_STORAGE_CONNECTION_STRING = data.azurerm_storage_account.push_notifications_storage.primary_connection_string
       PUSH_NOTIFICATIONS_QUEUE_NAME                = local.storage_account_notifications_queue_push_notifications
 
+      LOCKED_PROFILES_STORAGE_CONNECTION_STRING = module.locked_profiles_storage.primary_connection_string
+      LOCKED_PROFILES_TABLE_NAME                = azurerm_storage_table.locked_profiles.name
 
       // USERSLOGIN
       USERS_LOGIN_QUEUE_NAME                = local.storage_account_notifications_queue_userslogin

--- a/src/core/storage_locked_profiles.tf
+++ b/src/core/storage_locked_profiles.tf
@@ -26,7 +26,7 @@ resource "azurerm_private_endpoint" "locked_profiles_storage_table" {
   name                = "${module.locked_profiles_storage.name}-table-endpoint"
   location            = azurerm_resource_group.rg_internal.location
   resource_group_name = azurerm_resource_group.rg_internal.location
-  subnet_id           = var.internal_storage.private_endpoint_subnet_id
+  subnet_id           =  module.private_endpoints_subnet.id
 
   private_service_connection {
     name                           = "${module.locked_profiles_storage.name}-table"

--- a/src/core/storage_locked_profiles.tf
+++ b/src/core/storage_locked_profiles.tf
@@ -25,7 +25,7 @@ resource "azurerm_private_endpoint" "locked_profiles_storage_table" {
   depends_on          = [module.locked_profiles_storage]
   name                = "${module.locked_profiles_storage.name}-table-endpoint"
   location            = azurerm_resource_group.rg_internal.location
-  resource_group_name = azurerm_resource_group.rg_internal.location
+  resource_group_name = azurerm_resource_group.rg_internal.name
   subnet_id           = module.private_endpoints_subnet.id
 
   private_service_connection {

--- a/src/core/storage_locked_profiles.tf
+++ b/src/core/storage_locked_profiles.tf
@@ -47,6 +47,6 @@ resource "azurerm_private_endpoint" "locked_profiles_storage_table" {
 # Tables
 resource "azurerm_storage_table" "locked_profiles" {
   depends_on           = [azurerm_private_endpoint.locked_profiles_storage_table]
-  name                 = "locked_profiles"
+  name                 = "lockedprofiles"
   storage_account_name = module.locked_profiles_storage.name
 }

--- a/src/core/storage_locked_profiles.tf
+++ b/src/core/storage_locked_profiles.tf
@@ -26,7 +26,7 @@ resource "azurerm_private_endpoint" "locked_profiles_storage_table" {
   name                = "${module.locked_profiles_storage.name}-table-endpoint"
   location            = azurerm_resource_group.rg_internal.location
   resource_group_name = azurerm_resource_group.rg_internal.location
-  subnet_id           =  module.private_endpoints_subnet.id
+  subnet_id           = module.private_endpoints_subnet.id
 
   private_service_connection {
     name                           = "${module.locked_profiles_storage.name}-table"

--- a/src/core/storage_profile_locked.tf
+++ b/src/core/storage_profile_locked.tf
@@ -1,0 +1,52 @@
+
+##############################
+# Locked User Profiles Storage
+##############################
+module "locked_profiles_storage" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3//storage_account?ref=v6.1.0"
+
+  name                          = replace(format("%s-locked-profiles-st", local.project), "-", "")
+  domain                        = "IO-AUTH"
+  account_kind                  = "StorageV2"
+  account_tier                  = "Standard"
+  access_tier                   = "Hot"
+  account_replication_type      = "GZRS"
+  resource_group_name           = azurerm_resource_group.rg_internal.name
+  location                      = azurerm_resource_group.rg_internal.location
+  advanced_threat_protection    = true
+  enable_identity               = true
+  public_network_access_enabled = false
+
+  tags = var.tags
+}
+
+
+resource "azurerm_private_endpoint" "locked_profiles_storage_table" {
+  depends_on          = [module.locked_profiles_storage]
+  name                = "${module.locked_profiles_storage.name}-table-endpoint"
+  location            = azurerm_resource_group.rg_internal.location
+  resource_group_name = azurerm_resource_group.rg_internal.location
+  subnet_id           = var.internal_storage.private_endpoint_subnet_id
+
+  private_service_connection {
+    name                           = "${module.locked_profiles_storage.name}-table"
+    private_connection_resource_id = module.locked_profiles_storage.id
+    is_manual_connection           = false
+    subresource_names              = ["table"]
+  }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-group"
+    private_dns_zone_ids = [azurerm_private_dns_zone.privatelink_table_core.id]
+  }
+
+  tags = var.tags
+}
+
+
+# Tables
+resource "azurerm_storage_table" "locked_profiles" {
+  depends_on           = [azurerm_private_endpoint.locked_profiles_storage_table]
+  name                 = "locked_profiles"
+  storage_account_name = module.locked_profiles_storage.name
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Add new locked profiles storage, with `lockedprofiles` table
- Update appbackend env variables with `LOCKED_PROFILES_STORAGE_CONNECTION_STRING` and `LOCKED_PROFILES_TABLE_NAME `

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Disable login for users with profile in lock state

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
