### PR TITLE
[IO-PID] 685: Enable CORS policy on IO Web - Bff API group

### DIFF
--- a/src/domains/ioweb-app/api/bff/policy.xml
+++ b/src/domains/ioweb-app/api/bff/policy.xml
@@ -4,6 +4,20 @@
     <set-header name="x-functions-key" exists-action="override">
       <value>{{ioweb-profile-api-key}}</value>
     </set-header>
+    <cors>
+      <allowed-origins>
+        <origin>https://ioapp.it/</origin>
+      </allowed-origins>
+      <allowed-methods preflight-result-max-age="300">
+        <method>OPTIONS</method>
+        <method>GET</method>
+        <method>POST</method>
+      </allowed-methods>
+      <allowed-headers>
+        <header>Content-Type</header>
+        <header>Authorization</header>
+      </allowed-headers>
+    </cors>
   </inbound>
   <outbound>
     <base />


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add an inbound policy to `IO Web - Bff` API group on `APIM v2`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Client needs to perform requests with CORS policy enabled

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
