### PR TITLE
Remove create service policy resource from apim

### DIFF
--- a/src/core/.terraform.lock.hcl
+++ b/src/core/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/azure/azapi" {
   constraints = "<= 1.9.0"
   hashes = [
     "h1:Ow1rr5fYBGSkplH/kcXeWz9y2wA81BnhZ7vTBzJfAAg=",
+    "h1:shpEoqcAbf+p6AvspiYO1YrX//8l1LV/owEcQpujWHw=",
     "zh:349569471fbf387feaaf8b88da1690669e201147c342f905e5eb03df42b3cf87",
     "zh:54346d5fb78cbad3eb7cfd96e1dd7ce4f78666cabaaccfec6ee9437476330018",
     "zh:64b799da915ea3a9a58ac7a926c6a31c59fd0d911687804d8e815eda88c5580b",

--- a/src/core/.terraform.lock.hcl
+++ b/src/core/.terraform.lock.hcl
@@ -7,6 +7,8 @@ provider "registry.terraform.io/azure/azapi" {
   hashes = [
     "h1:Ow1rr5fYBGSkplH/kcXeWz9y2wA81BnhZ7vTBzJfAAg=",
     "h1:shpEoqcAbf+p6AvspiYO1YrX//8l1LV/owEcQpujWHw=",
+    "h1:yIJQVdnmGZdvS3yrw0M8ke9KiB/c0tjZ7KUXC46Hjx0=",
+    "h1:zaLH2Owmj61RX2G1Cy6VDy8Ttfzx+lDsSCyiu5cXkm4=",
     "zh:349569471fbf387feaaf8b88da1690669e201147c342f905e5eb03df42b3cf87",
     "zh:54346d5fb78cbad3eb7cfd96e1dd7ce4f78666cabaaccfec6ee9437476330018",
     "zh:64b799da915ea3a9a58ac7a926c6a31c59fd0d911687804d8e815eda88c5580b",

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -180,8 +180,6 @@
 | Name | Type |
 |------|------|
 | [azapi_resource.github_runner_job](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) | resource |
-| [azurerm_api_management_api_operation_policy.create_service_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
-| [azurerm_api_management_api_operation_policy.create_service_policy_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.submit_message_for_user_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.submit_message_for_user_policy_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.submit_message_for_user_with_fiscalcode_in_body_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |

--- a/src/core/apim_io_services_api.tf
+++ b/src/core/apim_io_services_api.tf
@@ -31,15 +31,6 @@ resource "azurerm_api_management_api_operation_policy" "submit_message_for_user_
   xml_content = file("./api/io_services/v1/post_submitmessageforuserwithfiscalcodeinbody_policy/policy.xml")
 }
 
-resource "azurerm_api_management_api_operation_policy" "create_service_policy" {
-  api_name            = "io-services-api"
-  api_management_name = module.apim.name
-  resource_group_name = module.apim.resource_group_name
-  operation_id        = "createService"
-
-  xml_content = file("./api/io_services/v1/post_createservice_policy/policy.xml")
-}
-
 # Named Value fn3-services
 resource "azurerm_api_management_named_value" "io_fn3_services_url" {
   name                = "io-fn3-services-url"

--- a/src/core/apim_v2_io_services_api.tf
+++ b/src/core/apim_v2_io_services_api.tf
@@ -31,15 +31,6 @@ resource "azurerm_api_management_api_operation_policy" "submit_message_for_user_
   xml_content = file("./api/io_services/v1/post_submitmessageforuserwithfiscalcodeinbody_policy/policy.xml")
 }
 
-resource "azurerm_api_management_api_operation_policy" "create_service_policy_v2" {
-  api_name            = "io-services-api"
-  api_management_name = module.apim_v2.name
-  resource_group_name = module.apim_v2.resource_group_name
-  operation_id        = "createService"
-
-  xml_content = file("./api/io_services/v1/post_createservice_policy/policy.xml")
-}
-
 # Named Value fn3-services
 resource "azurerm_api_management_named_value" "io_fn3_services_url_v2" {
   name                = "io-fn3-services-url"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
We recently removed the deprecated createService API and now we are removing the limit policy that was connected to that API
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [x] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
