### PR TITLE
Add GitHub runner on container apps for io-sign

### DIFF
--- a/src/core/00_github_runner.tf
+++ b/src/core/00_github_runner.tf
@@ -32,9 +32,10 @@ module "github_runner" {
 }
 
 locals {
-  repo_owner = "PagoPA"
-  repo_name  = "io-infra"
-  image_name = "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:ed51ac419d78b6410be96ecaa8aa8dbe645aa0309374132886412178e2739a47"
+  repo_owner         = "pagopa"
+  io_infra_repo_name = "io-infra"
+  io_sign_repo_name  = "io-sign"
+  image_name         = "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:ed51ac419d78b6410be96ecaa8aa8dbe645aa0309374132886412178e2739a47"
 }
 
 data "azurerm_key_vault_secret" "github_pat_io_infra" {
@@ -68,7 +69,7 @@ resource "azapi_resource" "github_runner_job" {
                   github_runner             = "https://api.github.com"
                   owner                     = local.repo_owner
                   runnerScope               = "repo"
-                  repos                     = local.repo_name
+                  repos                     = local.io_infra_repo_name
                   targetWorkflowQueueLength = "1"
                 }
                 auth = [
@@ -100,11 +101,88 @@ resource "azapi_resource" "github_runner_job" {
               },
               {
                 name  = "REPO_URL"
-                value = "https://github.com/${local.repo_owner}/${local.repo_name}"
+                value = "https://github.com/${local.repo_owner}/${local.io_infra_repo_name}"
               },
               {
                 name  = "REGISTRATION_TOKEN_API_URL"
-                value = "https://api.github.com/repos/${local.repo_owner}/${local.repo_name}/actions/runners/registration-token"
+                value = "https://api.github.com/repos/${local.repo_owner}/${local.io_infra_repo_name}/actions/runners/registration-token"
+              }
+            ]
+            image = local.image_name
+            name  = "github-actions-runner-job"
+            resources = {
+              cpu    = 0.5
+              memory = "1Gi"
+            }
+          }
+      ] }
+    }
+  })
+}
+
+resource "azapi_resource" "github_runner_job_io_sign" {
+  type      = "Microsoft.App/jobs@2023-05-01"
+  name      = "${local.project}-sign-github-runner-job"
+  location  = var.location
+  parent_id = azurerm_resource_group.github_runner.id
+
+  body = jsonencode({
+    properties = {
+      configuration = {
+        replicaRetryLimit = 1
+        replicaTimeout    = 1800
+        eventTriggerConfig = {
+          parallelism            = 1
+          replicaCompletionCount = 1
+          scale = {
+            maxExecutions   = 10
+            minExecutions   = 0
+            pollingInterval = 20
+            rules = [
+              {
+                name = "github-runner"
+                type = "github-runner"
+                metadata = {
+                  github_runner             = "https://api.github.com"
+                  owner                     = local.repo_owner
+                  runnerScope               = "repo"
+                  repos                     = local.io_sign_repo_name
+                  targetWorkflowQueueLength = "1"
+                }
+                auth = [
+                  {
+                    secretRef        = "personal-access-token"
+                    triggerParameter = "personalAccessToken"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        secrets = [
+          {
+            name  = "personal-access-token"
+            value = "${data.azurerm_key_vault_secret.github_pat_io_infra.value}"
+          }
+        ]
+        triggerType = "Event"
+      }
+      environmentId = module.github_runner.id
+      template = {
+        containers = [
+          {
+            env = [
+              {
+                name      = "GITHUB_PAT"
+                secretRef = "personal-access-token"
+              },
+              {
+                name  = "REPO_URL"
+                value = "https://github.com/${local.repo_owner}/${local.io_sign_repo_name}"
+              },
+              {
+                name  = "REGISTRATION_TOKEN_API_URL"
+                value = "https://api.github.com/repos/${local.repo_owner}/${local.io_sign_repo_name}/actions/runners/registration-token"
               }
             ]
             image = local.image_name

--- a/src/core/00_github_runner.tf
+++ b/src/core/00_github_runner.tf
@@ -35,11 +35,11 @@ locals {
   repo_owner         = "pagopa"
   io_infra_repo_name = "io-infra"
   io_sign_repo_name  = "io-sign"
-  image_name         = "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:ed51ac419d78b6410be96ecaa8aa8dbe645aa0309374132886412178e2739a47"
+  image_name         = "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:3fdfa88297d5c3509f87c37109766578ceb1f69a86642149bd70fb0c4f6974ce"
 }
 
-data "azurerm_key_vault_secret" "github_pat_io_infra" {
-  name         = "github-pat-io-infra"
+data "azurerm_key_vault_secret" "github_runner_pat" {
+  name         = "github-runner-pat"
   key_vault_id = module.key_vault_common.id
 }
 
@@ -85,7 +85,7 @@ resource "azapi_resource" "github_runner_job" {
         secrets = [
           {
             name  = "personal-access-token"
-            value = "${data.azurerm_key_vault_secret.github_pat_io_infra.value}"
+            value = "${data.azurerm_key_vault_secret.github_runner_pat.value}"
           }
         ]
         triggerType = "Event"
@@ -162,7 +162,7 @@ resource "azapi_resource" "github_runner_job_io_sign" {
         secrets = [
           {
             name  = "personal-access-token"
-            value = "${data.azurerm_key_vault_secret.github_pat_io_infra.value}"
+            value = "${data.azurerm_key_vault_secret.github_runner_pat.value}"
           }
         ]
         triggerType = "Event"

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -180,6 +180,7 @@
 | Name | Type |
 |------|------|
 | [azapi_resource.github_runner_job](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) | resource |
+| [azapi_resource.github_runner_job_io_sign](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) | resource |
 | [azurerm_api_management_api_operation_policy.submit_message_for_user_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.submit_message_for_user_policy_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.submit_message_for_user_with_fiscalcode_in_body_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -612,7 +612,7 @@
 | [azurerm_key_vault_secret.fn_services_sandbox_fiscal_code](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.fn_services_webhook_channel_aks_url](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.fn_services_webhook_channel_url](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.github_pat_io_infra](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.github_runner_pat](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.io_fn3_admin_key_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.io_fn3_admin_key_secret_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.io_fn3_eucovidcert_key_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add a container job for io-sign repository

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
A single PAT owned by `io-pagopa-github-bot` account, can handle self hosted runners on both io-infra and io-sign repositories. This PR adds the infrastructure needed to run pipelines on io-sign repository

### Type of changes

- [X] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
