### PR TITLE
[#IOPLT-232] Re-Enable routing through Beta AKS

### DIFF
--- a/src/domains/messages-common/api/io-backend-notification/v1/_base_policy.xml
+++ b/src/domains/messages-common/api/io-backend-notification/v1/_base_policy.xml
@@ -1,8 +1,7 @@
 <policies>
     <inbound>
         <base />
-        <set-backend-service base-url="https://weuprod01.messages.internal.io.pagopa.it/io-backend/api/v1" />
-        <!-- <choose>
+        <choose>
             <when condition="@(context.Request.Headers.GetValueOrDefault("environment", "false").Equals("beta"))">
                 <set-backend-service base-url="https://weubeta.messages.internal.io.pagopa.it/io-backend/api/v1" />
             </when>
@@ -10,7 +9,7 @@
                 <set-backend-service base-url="https://weuprod01.messages.internal.io.pagopa.it/io-backend/api/v1" />
             </when>
             <otherwise>
-                https://docs.microsoft.com/en-us/dotnet/api/system.random.next?view=net-6.0#system-random-next(system-int32-system-int32)
+                <!-- https://docs.microsoft.com/en-us/dotnet/api/system.random.next?view=net-6.0#system-random-next(system-int32-system-int32) -->
                 <set-variable name="urlWeight" value="@{
                   Random rnd = new Random();
                   int urlWeight = rnd.Next(1, 1001);
@@ -36,7 +35,7 @@
                     </otherwise>
                 </choose>
             </otherwise>
-        </choose> -->
+        </choose>
         <set-header name="x-user-groups" exists-action="override">
             <value>@(String.Join(",", context.User.Groups.Select(g => g.Name)))</value>
         </set-header>

--- a/src/domains/messages-common/api/service-messages/v1/_base_policy.xml
+++ b/src/domains/messages-common/api/service-messages/v1/_base_policy.xml
@@ -1,8 +1,7 @@
 <policies>
     <inbound>
         <base />
-        <set-backend-service base-url="https://weuprod01.messages.internal.io.pagopa.it/service-messages/api/v1" />
-        <!-- <choose>
+        <choose>
             <when condition="@(context.Request.Headers.GetValueOrDefault("environment", "false").Equals("beta"))">
                 <set-backend-service base-url="https://weubeta.messages.internal.io.pagopa.it/service-messages/api/v1" />
             </when>
@@ -10,7 +9,7 @@
                 <set-backend-service base-url="https://weuprod01.messages.internal.io.pagopa.it/service-messages/api/v1" />
             </when>
             <otherwise>
-                https://docs.microsoft.com/en-us/dotnet/api/system.random.next?view=net-6.0#system-random-next(system-int32-system-int32)
+                <!-- https://docs.microsoft.com/en-us/dotnet/api/system.random.next?view=net-6.0#system-random-next(system-int32-system-int32) -->
                 <set-variable name="urlWeight" value="@{
                   Random rnd = new Random();
                   int urlWeight = rnd.Next(1, 1001);
@@ -36,7 +35,7 @@
                     </otherwise>
                 </choose>
             </otherwise>
-        </choose> -->
+        </choose>
         <set-header name="x-user-groups" exists-action="override">
             <value>@(String.Join(",", context.User.Groups.Select(g => g.Name)))</value>
         </set-header>

--- a/src/domains/payments-common/api/payments_updater/v1/_base_policy.xml
+++ b/src/domains/payments-common/api/payments_updater/v1/_base_policy.xml
@@ -1,8 +1,7 @@
 <policies>
     <inbound>
         <base />
-        <set-backend-service base-url="https://weuprod01.payments.internal.io.pagopa.it/api/v1/payment" />
-        <!-- <choose>
+        <choose>
             <when condition="@(context.Request.Headers.GetValueOrDefault("environment", "false").Equals("beta"))">
                 <set-backend-service base-url="https://weubeta.payments.internal.io.pagopa.it/api/v1/payment" />
             </when>
@@ -10,7 +9,7 @@
                 <set-backend-service base-url="https://weuprod01.payments.internal.io.pagopa.it/api/v1/payment" />
             </when>
             <otherwise>
-                # https://docs.microsoft.com/en-us/dotnet/api/system.random.next?view=net-6.0#system-random-next(system-int32-system-int32)
+                <!-- # https://docs.microsoft.com/en-us/dotnet/api/system.random.next?view=net-6.0#system-random-next(system-int32-system-int32) -->
                 <set-variable name="urlWeight" value="@{
                   Random rnd = new Random();
                   int urlWeight = rnd.Next(1, 1001);
@@ -36,7 +35,7 @@
                     </otherwise>
                 </choose>
             </otherwise>
-        </choose> -->
+        </choose>
     </inbound>
     <outbound>
         <base />


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Re-Enabling weu-beta routing in `messages` domain
- Re-Enabling weu-beta routing in `payments` domain
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR is intended for re-enabling production traffic routing through weu-beta AKS cluster after the migration to Kubernetes LTS version.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
