### PR TITLE
[EC-6] Upgrade Azure DevOps agent modules

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -65,10 +65,10 @@
 | <a name="module_appservice_devportal_be"></a> [appservice\_devportal\_be](#module\_appservice\_devportal\_be) | git::https://github.com/pagopa/terraform-azurerm-v3.git//app_service | v7.28.0 |
 | <a name="module_appservice_selfcare_be"></a> [appservice\_selfcare\_be](#module\_appservice\_selfcare\_be) | git::https://github.com/pagopa/terraform-azurerm-v3.git//app_service | v6.0.0 |
 | <a name="module_assets_cdn"></a> [assets\_cdn](#module\_assets\_cdn) | git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account | v7.28.0 |
-| <a name="module_azdoa_li"></a> [azdoa\_li](#module\_azdoa\_li) | git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent | v4.1.15 |
-| <a name="module_azdoa_li_infra"></a> [azdoa\_li\_infra](#module\_azdoa\_li\_infra) | git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent | v6.20.0 |
-| <a name="module_azdoa_loadtest_li"></a> [azdoa\_loadtest\_li](#module\_azdoa\_loadtest\_li) | git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent | v4.1.15 |
-| <a name="module_azdoa_snet"></a> [azdoa\_snet](#module\_azdoa\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v4.1.15 |
+| <a name="module_azdoa_li"></a> [azdoa\_li](#module\_azdoa\_li) | git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent | v7.28.0 |
+| <a name="module_azdoa_li_infra"></a> [azdoa\_li\_infra](#module\_azdoa\_li\_infra) | git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent | v7.28.0 |
+| <a name="module_azdoa_loadtest_li"></a> [azdoa\_loadtest\_li](#module\_azdoa\_loadtest\_li) | git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent | v7.28.0 |
+| <a name="module_azdoa_snet"></a> [azdoa\_snet](#module\_azdoa\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v7.28.0 |
 | <a name="module_cgn_cosmos_db"></a> [cgn\_cosmos\_db](#module\_cgn\_cosmos\_db) | git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_sql_database | v7.28.0 |
 | <a name="module_cgn_cosmosdb_containers"></a> [cgn\_cosmosdb\_containers](#module\_cgn\_cosmosdb\_containers) | git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_sql_container | v7.28.0 |
 | <a name="module_cgn_legalbackup_storage"></a> [cgn\_legalbackup\_storage](#module\_cgn\_legalbackup\_storage) | git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account | v7.28.0 |

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -65,7 +65,6 @@
 | <a name="module_appservice_devportal_be"></a> [appservice\_devportal\_be](#module\_appservice\_devportal\_be) | git::https://github.com/pagopa/terraform-azurerm-v3.git//app_service | v7.28.0 |
 | <a name="module_appservice_selfcare_be"></a> [appservice\_selfcare\_be](#module\_appservice\_selfcare\_be) | git::https://github.com/pagopa/terraform-azurerm-v3.git//app_service | v6.0.0 |
 | <a name="module_assets_cdn"></a> [assets\_cdn](#module\_assets\_cdn) | git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account | v7.28.0 |
-| <a name="module_azdoa_li"></a> [azdoa\_li](#module\_azdoa\_li) | git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent | v7.28.0 |
 | <a name="module_azdoa_li_infra"></a> [azdoa\_li\_infra](#module\_azdoa\_li\_infra) | git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent | v7.28.0 |
 | <a name="module_azdoa_loadtest_li"></a> [azdoa\_loadtest\_li](#module\_azdoa\_loadtest\_li) | git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent | v7.28.0 |
 | <a name="module_azdoa_snet"></a> [azdoa\_snet](#module\_azdoa\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v7.28.0 |

--- a/src/core/azure_devops_agent.tf
+++ b/src/core/azure_devops_agent.tf
@@ -21,21 +21,6 @@ module "azdoa_snet" {
   ]
 }
 
-module "azdoa_li" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=v7.28.0"
-  count               = var.enable_azdoa ? 1 : 0
-  name                = format("%s-azdoa-vmss-li", local.project)
-  resource_group_name = azurerm_resource_group.azdo_rg[0].name
-  subnet_id           = module.azdoa_snet[0].id
-  subscription_name   = data.azurerm_subscription.current.display_name
-  subscription_id     = data.azurerm_subscription.current.subscription_id
-  location            = var.location
-  source_image_name   = var.azdoa_image_name
-  vm_sku              = "Standard_B1s"
-
-  tags = var.tags
-}
-
 module "azdoa_li_infra" {
   source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=v7.28.0"
   count               = var.enable_azdoa ? 1 : 0

--- a/src/core/azure_devops_agent.tf
+++ b/src/core/azure_devops_agent.tf
@@ -8,7 +8,7 @@ resource "azurerm_resource_group" "azdo_rg" {
 
 module "azdoa_snet" {
   count  = var.enable_azdoa ? 1 : 0
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v4.1.15"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v7.28.0"
 
   name                                      = "azure-devops"
   address_prefixes                          = var.cidr_subnet_azdoa
@@ -22,18 +22,22 @@ module "azdoa_snet" {
 }
 
 module "azdoa_li" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=v4.1.15"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=v7.28.0"
   count               = var.enable_azdoa ? 1 : 0
   name                = format("%s-azdoa-vmss-li", local.project)
   resource_group_name = azurerm_resource_group.azdo_rg[0].name
   subnet_id           = module.azdoa_snet[0].id
-  subscription        = data.azurerm_subscription.current.display_name
+  subscription_name   = data.azurerm_subscription.current.display_name
+  subscription_id     = data.azurerm_subscription.current.subscription_id
+  location            = var.location
+  source_image_name   = var.azdoa_image_name
+  vm_sku              = "Standard_B1s"
 
   tags = var.tags
 }
 
 module "azdoa_li_infra" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=v6.20.0"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=v7.28.0"
   count               = var.enable_azdoa ? 1 : 0
   name                = "${local.project}-azdoa-vmss-li-infra"
   resource_group_name = azurerm_resource_group.azdo_rg[0].name
@@ -48,12 +52,15 @@ module "azdoa_li_infra" {
 }
 
 module "azdoa_loadtest_li" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=v4.1.15"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=v7.28.0"
   count               = var.enable_azdoa ? 1 : 0
   name                = format("%s-azdoa-vmss-loadtest-li", local.project)
   resource_group_name = azurerm_resource_group.azdo_rg[0].name
   subnet_id           = module.azdoa_snet[0].id
-  subscription        = data.azurerm_subscription.current.display_name
+  subscription_name   = data.azurerm_subscription.current.display_name
+  subscription_id     = data.azurerm_subscription.current.subscription_id
+  location            = var.location
+  source_image_name   = var.azdoa_image_name
   vm_sku              = "Standard_D8ds_v5"
 
   tags = var.tags


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Upgrade modules of Azure DevOps agents

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Upgrading all core modules

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [X] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
`azdoa_li`:
The resource doesn't exist on Azure, however it is stored in the actual state file. Behind the scene, this was a `null_resource` in v4.1.15 but now it's `azurerm`. Terraform will try to recreate it

`azdoa_li_infra`:
no changes

`azdoa_loadtest_li`:
Same as `azdoa_li`, but it does actually exist on Azure, so Terraform wants to replace it.


If these diffs are ok, before merging I shall remove from state the 2 null resources and:
- create `azdoa_li`
- import `azdoa_loadtest_li` into the state - if possible

EDIT:
Importing `azdoa_loadtest_li` doesn't prevent the recreation of the resource. It seems that lot of properties would change:

<details>
<summary>Terraform Plan</summary>

# module.azdoa_loadtest_li[0].azurerm_linux_virtual_machine_scale_set.this must be replaced
-/+ resource "azurerm_linux_virtual_machine_scale_set" "this" {
      ~ admin_username                                    = "azureuser" -> "adminuser" # forces replacement
      ~ computer_name_prefix                              = "iopaz5ae6" -> (known after apply)
      - encryption_at_host_enabled                        = false -> null
      ~ extension_operations_enabled                      = true -> (known after apply)
      ~ id                                                = "/subscriptions/ec285037-c673-4f58-b594-d7c480da4e8b/resourceGroups/IO-P-AZDOA-RG/providers/Microsoft.Compute/virtualMachineScaleSets/io-p-azdoa-vmss-loadtest-li" -> (known after apply)
      ~ instances                                         = 0 -> 1
        name                                              = "io-p-azdoa-vmss-loadtest-li"
      ~ resource_group_name                               = "IO-P-AZDOA-RG" -> "io-p-azdoa-rg" # forces replacement
      ~ scale_in_policy                                   = "Default" -> (known after apply)
      - secure_boot_enabled                               = false -> null
      + source_image_id                                   = "/subscriptions/ec285037-c673-4f58-b594-d7c480da4e8b/resourceGroups/io-p-azdoa-rg/providers/Microsoft.Compute/images/azdo-agent-ubuntu2204-image-v2"
      - tags                                              = {
          - "__AzureDevOpsElasticPool"          = "io-prod-loadtest-linux"
          - "__AzureDevOpsElasticPoolTimeStamp" = "12/4/2023 10:10:45 AM"
        } -> null
      ~ unique_id                                         = "fc6557d6-0983-48ad-b282-35a8d35e6e62" -> (known after apply)
      - vtpm_enabled                                      = false -> null
      - zones                                             = [] -> null
        # (13 unchanged attributes hidden)

      - admin_ssh_key {
          - public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTvHKIh07aF0Q98fJGuQfG9u8YvSmaewwg38q2mZKnelcE4OqQMWWEW5k/aQwLgdDOdybjyDhzhlViu/QicY+EOKCo0+X5ZKyGmoAGjmh5ZJ8ZwXMlaxPqjKc1OgYERrKoG1KimY4Kjtfb/hrP6SIx2ivBcAKVgAF1lLm6ukfsMGFAzTBsWxi1d5ds+0k9espza+6zDqABaAwtBMD8tJsHE3dQuIjt1k5+ubI7uxur8s7veGugmQ69I2vKysmQKeNOQkdoKjMacOl3d/0fVPLv+38ALKRw0OWtneAJZp+8u/Hc0D/D9MI8clijXQmXvqAQ/fdkWpp11eLWqPkIn0N5" -> null
          - username   = "azureuser" -> null
        }
      + admin_ssh_key {
          + public_key = (known after apply)
          + username   = "adminuser"
        }

      - automatic_instance_repair {
          - enabled      = false -> null
          - grace_period = "PT30M" -> null
        }

      - extension {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }
      - extension {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }

      ~ network_interface {
          - dns_servers                   = [] -> null
          ~ name                          = "iopaz5ae6Nic" -> "io-p-azdoa-vmss-loadtest-li-Nic" # forces replacement
            # (3 unchanged attributes hidden)

          ~ ip_configuration {
              - application_gateway_backend_address_pool_ids = [] -> null
              - application_security_group_ids               = [] -> null
              - load_balancer_backend_address_pool_ids       = [] -> null
              - load_balancer_inbound_nat_rules_ids          = [] -> null
              ~ name                                         = "iopaz5ae6IPConfig" -> "io-p-azdoa-vmss-loadtest-li-IPc"
              ~ primary                                      = false -> true
                # (2 unchanged attributes hidden)
            }
        }

      ~ os_disk {
          ~ disk_size_gb              = 30 -> (known after apply)
            # (3 unchanged attributes hidden)
        }

      - rolling_upgrade_policy { # forces replacement
          - cross_zone_upgrades_enabled             = false -> null
          - max_batch_instance_percent              = 20 -> null
          - max_unhealthy_instance_percent          = 20 -> null
          - max_unhealthy_upgraded_instance_percent = 20 -> null
          - pause_time_between_batches              = "PT0S" -> null
          - prioritize_unhealthy_instances_enabled  = false -> null
        }

      - source_image_reference {
          - offer     = "UbuntuServer" -> null # forces replacement
          - publisher = "Canonical" -> null # forces replacement
          - sku       = "18.04-LTS" -> null
          - version   = "latest" -> null
        }

      - timeouts {}
    }

  # module.azdoa_loadtest_li[0].azurerm_ssh_public_key.this_public_key will be created
  + resource "azurerm_ssh_public_key" "this_public_key" {
      + id                  = (known after apply)
      + location            = "westeurope"
      + name                = "io-p-azdoa-vmss-loadtest-li-admin-access-key"
      + public_key          = (known after apply)
      + resource_group_name = "io-p-azdoa-rg"
    }

  # module.azdoa_loadtest_li[0].tls_private_key.this_key will be created
  + resource "tls_private_key" "this_key" {
      + algorithm                     = "RSA"
      + ecdsa_curve                   = "P224"
      + id                            = (known after apply)
      + private_key_openssh           = (sensitive value)
      + private_key_pem               = (sensitive value)
      + private_key_pem_pkcs8         = (sensitive value)
      + public_key_fingerprint_md5    = (known after apply)
      + public_key_fingerprint_sha256 = (known after apply)
      + public_key_openssh            = (known after apply)
      + public_key_pem                = (known after apply)
      + rsa_bits                      = 4096
    }

</details>

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
