### PR TITLE
[#IOPID-1191] Disabled OnProfileUpdate function

### DIFF
--- a/src/core/function_app.tf
+++ b/src/core/function_app.tf
@@ -130,6 +130,9 @@ locals {
     }
     app_settings_2 = {
     }
+    staging_functions_disabled = [
+      "OnProfileUpdate"
+    ]
   }
 }
 
@@ -198,6 +201,9 @@ module "function_app" {
 
   app_settings = merge(
     local.function_app.app_settings_common,
+    {
+      "AzureWebJobs.OnProfileUpdate.Disabled" = "1"
+    }
   )
 
   internal_storage = {
@@ -248,6 +254,11 @@ module "function_app_staging_slot" {
 
   app_settings = merge(
     local.function_app.app_settings_common,
+    {
+      # Disabled functions on slot triggered by cosmosDB change feed
+      for to_disable in local.function_app.staging_functions_disabled :
+      format("AzureWebJobs.%s.Disabled", to_disable) => "1"
+    }
   )
 
   subnet_id = module.app_snet[count.index].id

--- a/src/domains/citizen-auth-common/03_storage.tf
+++ b/src/domains/citizen-auth-common/03_storage.tf
@@ -187,6 +187,6 @@ resource "azurerm_private_endpoint" "table" {
 
 resource "azurerm_storage_table" "unique_emails" {
   depends_on           = [module.io_citizen_auth_storage, azurerm_private_endpoint.table]
-  name                 = "uniqueEmails"
+  name                 = "profileEmails"
   storage_account_name = module.io_citizen_auth_storage.name
 }

--- a/src/domains/citizen-auth-common/03_storage.tf
+++ b/src/domains/citizen-auth-common/03_storage.tf
@@ -185,7 +185,7 @@ resource "azurerm_private_endpoint" "table" {
   tags = var.tags
 }
 
-resource "azurerm_storage_table" "unique_emails" {
+resource "azurerm_storage_table" "profile_emails" {
   depends_on           = [module.io_citizen_auth_storage, azurerm_private_endpoint.table]
   name                 = "profileEmails"
   storage_account_name = module.io_citizen_auth_storage.name

--- a/src/domains/citizen-auth-common/README.md
+++ b/src/domains/citizen-auth-common/README.md
@@ -65,7 +65,7 @@
 | [azurerm_storage_container.lollipop_assertions_storage_assertions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.lv_audit_logs_storage_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_queue.lollipop_assertions_storage_revoke_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
-| [azurerm_storage_table.unique_emails](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
+| [azurerm_storage_table.profile_emails](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

1. Updated `uniqueEmails` storage table name with `profileEmails`
2. Disabled `OnProfileUpdate` function both on staging and production slot

### Motivation and context

When triggered by cosmosDB change feed, the `OnProfileUpdate` function will populate the storage table `profileEmails`. So we need to disable the staging slot and enable the production slot only at the right moment

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
3. select PR branch
4. wait for approval
