### PR TITLE
[#IOPID-1217] Enable CIE prod environment on ioapp.it

### DIFF
--- a/src/domains/ioweb-common/10_spid_login.tf
+++ b/src/domains/ioweb-common/10_spid_login.tf
@@ -66,8 +66,8 @@ module "spid_login" {
 
     SPID_ATTRIBUTES = "name,familyName,fiscalNumber"
 
-    # Commented for using pre-prod environment
-    #CIE_URL          = "https://api.is.eng.pagopa.it/idp-keys/cie/latest"
+    # Comment for using CIE pre-prod environment
+    CIE_URL          = "https://api.is.eng.pagopa.it/idp-keys/cie/latest"
     IDP_METADATA_URL = "https://api.is.eng.pagopa.it/idp-keys/spid/latest"
 
     REQUIRED_ATTRIBUTES_SERVICE_NAME = "IO Web Onboarding Portal"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Set CIE_URL on ioapp authentication service

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Enable CIE prod environment on ioapp.it

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
