### PR TITLE
[#IOCOM-728] Added cosmos db for remote content

### DIFF
--- a/src/domains/messages-common/03_database.tf
+++ b/src/domains/messages-common/03_database.tf
@@ -225,7 +225,7 @@ module "cosmosdb_account_remote_content" {
   public_network_access_enabled     = false
   private_endpoint_enabled          = true
   subnet_id                         = data.azurerm_subnet.private_endpoints_subnet.id
-  private_dns_zone_ids              = [data.azurerm_private_dns_zone.privatelink_documents_azure_com.id]
+  private_dns_zone_ids              = []
   is_virtual_network_filter_enabled = false
 
   main_geo_location_location       = azurerm_resource_group.data_rg.location

--- a/src/domains/messages-common/03_database.tf
+++ b/src/domains/messages-common/03_database.tf
@@ -214,7 +214,7 @@ resource "azurerm_key_vault_secret" "reminder_mysql_db_server_url" {
 module "cosmosdb_account_remote_content" {
   source = "git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_account?ref=v4.3.1"
 
-  name                = "${local.product}-${var.domain}-remote_content-account"
+  name                = "${local.product}-${var.domain}-remote-content-account"
   domain              = upper(var.domain)
   location            = azurerm_resource_group.data_rg.location
   resource_group_name = azurerm_resource_group.data_rg.name
@@ -256,7 +256,7 @@ module "cosmosdb_account_remote_content" {
 
 module "cosmosdb_sql_database_remote_content" {
   source              = "git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_sql_database?ref=v4.3.1"
-  name                = "remote_content"
+  name                = "remote-content"
   resource_group_name = azurerm_resource_group.data_rg.name
   account_name        = module.cosmosdb_account_remote_content.name
 }

--- a/src/domains/messages-common/03_database.tf
+++ b/src/domains/messages-common/03_database.tf
@@ -214,7 +214,7 @@ resource "azurerm_key_vault_secret" "reminder_mysql_db_server_url" {
 module "cosmosdb_account_remote_content" {
   source = "git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_account?ref=v4.3.1"
 
-  name                = "${local.product}-${var.domain}-remote-content-account"
+  name                = "${local.product}-${var.domain}-remote-content"
   domain              = upper(var.domain)
   location            = azurerm_resource_group.data_rg.location
   resource_group_name = azurerm_resource_group.data_rg.name

--- a/src/domains/messages-common/03_database.tf
+++ b/src/domains/messages-common/03_database.tf
@@ -206,3 +206,84 @@ resource "azurerm_key_vault_secret" "reminder_mysql_db_server_url" {
   content_type = "text/plain"
   key_vault_id = module.key_vault.id
 }
+
+
+############################
+# REMOTE CONTENT COSMOS
+############################
+module "cosmosdb_account_remote_content" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_account?ref=v4.3.1"
+
+  name                = "${local.product}-${var.domain}-remote_content-account"
+  domain              = upper(var.domain)
+  location            = azurerm_resource_group.data_rg.location
+  resource_group_name = azurerm_resource_group.data_rg.name
+  offer_type          = "Standard"
+  enable_free_tier    = false
+  kind                = "GlobalDocumentDB"
+
+  public_network_access_enabled     = false
+  private_endpoint_enabled          = true
+  subnet_id                         = data.azurerm_subnet.private_endpoints_subnet.id
+  private_dns_zone_ids              = [data.azurerm_private_dns_zone.privatelink_documents_azure_com.id]
+  is_virtual_network_filter_enabled = false
+
+  main_geo_location_location       = azurerm_resource_group.data_rg.location
+  main_geo_location_zone_redundant = true
+
+  additional_geo_locations = [{
+    location          = "northeurope"
+    failover_priority = 1
+    zone_redundant    = false
+  }]
+
+  consistency_policy = {
+    consistency_level       = "Session"
+    max_interval_in_seconds = null
+    max_staleness_prefix    = null
+  }
+
+  # Action groups for alerts
+  action = [
+    {
+      action_group_id    = data.azurerm_monitor_action_group.error_action_group.id
+      webhook_properties = {}
+    }
+  ]
+
+  tags = var.tags
+}
+
+module "cosmosdb_sql_database_remote_content" {
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_sql_database?ref=v4.3.1"
+  name                = "remote_content"
+  resource_group_name = azurerm_resource_group.data_rg.name
+  account_name        = module.cosmosdb_account_remote_content.name
+}
+
+resource "azurerm_cosmosdb_sql_container" "remote_content_configuration" {
+
+  name                = "remote-content-configuration"
+  resource_group_name = azurerm_resource_group.data_rg.name
+  account_name        = module.cosmosdb_account_remote_content.name
+  database_name       = module.cosmosdb_sql_database_remote_content.name
+
+  partition_key_path    = "/serviceId"
+  partition_key_version = 2
+
+  autoscale_settings {
+    max_throughput = 2000
+  }
+
+  indexing_policy {
+    indexing_mode = "consistent"
+
+    included_path {
+      path = "/*"
+    }
+
+    excluded_path {
+      path = "/\"_etag\"/?"
+    }
+  }
+}

--- a/src/domains/messages-common/README.md
+++ b/src/domains/messages-common/README.md
@@ -15,6 +15,8 @@
 | <a name="module_apim_v2_product_notifications"></a> [apim\_v2\_product\_notifications](#module\_apim\_v2\_product\_notifications) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_product | v4.1.5 |
 | <a name="module_apim_v2_service_messages_api_v1"></a> [apim\_v2\_service\_messages\_api\_v1](#module\_apim\_v2\_service\_messages\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v4.1.5 |
 | <a name="module_cosmosdb_account_mongodb_reminder"></a> [cosmosdb\_account\_mongodb\_reminder](#module\_cosmosdb\_account\_mongodb\_reminder) | git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_account | v4.1.5 |
+| <a name="module_cosmosdb_account_remote_content"></a> [cosmosdb\_account\_remote\_content](#module\_cosmosdb\_account\_remote\_content) | git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_account | v4.3.1 |
+| <a name="module_cosmosdb_sql_database_remote_content"></a> [cosmosdb\_sql\_database\_remote\_content](#module\_cosmosdb\_sql\_database\_remote\_content) | git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_sql_database | v4.3.1 |
 | <a name="module_io-backend_notification_v2_api_v1"></a> [io-backend\_notification\_v2\_api\_v1](#module\_io-backend\_notification\_v2\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v4.1.5 |
 | <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault) | git::https://github.com/pagopa/terraform-azurerm-v3//key_vault | v4.1.5 |
 | <a name="module_mongdb_collection_reminder"></a> [mongdb\_collection\_reminder](#module\_mongdb\_collection\_reminder) | git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_mongodb_collection | v4.1.5 |
@@ -38,6 +40,7 @@
 | [azurerm_api_management_subscription.reminder_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_subscription) | resource |
 | [azurerm_api_management_user.reminder_user_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_user) | resource |
 | [azurerm_cosmosdb_mongo_database.db_reminder](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_mongo_database) | resource |
+| [azurerm_cosmosdb_sql_container.remote_content_configuration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_container) | resource |
 | [azurerm_key_vault_access_policy.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azdevops_platform_iac_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |


### PR DESCRIPTION
### List of changes

Added a new cosmosdb to store remote content related data.

### Motivation and context

We need to segregate remote content related data in another db, on which we will restrict access and enable cryptography at rest.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
