### PR TITLE
[#IOCOM-734] Added configuration properties to store Remote Content's cosmos connection data

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -415,6 +415,7 @@
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_cosmosdb_account.cosmos_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/cosmosdb_account) | data source |
 | [azurerm_cosmosdb_account.cosmos_cgn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/cosmosdb_account) | data source |
+| [azurerm_cosmosdb_account.cosmos_remote_content](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/cosmosdb_account) | data source |
 | [azurerm_eventhub_authorization_rule.io-p-messages-weu-prod01-evh-ns_message-status_io-fn-messages-cqrs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/eventhub_authorization_rule) | data source |
 | [azurerm_eventhub_authorization_rule.io-p-messages-weu-prod01-evh-ns_messages_io-fn-messages-cqrs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/eventhub_authorization_rule) | data source |
 | [azurerm_eventhub_authorization_rule.io-p-payments-weu-prod01-evh-ns_payment-updates_io-fn-messages-cqrs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/eventhub_authorization_rule) | data source |

--- a/src/core/app_messages.tf
+++ b/src/core/app_messages.tf
@@ -17,6 +17,11 @@ locals {
       COSMOSDB_KEY                 = data.azurerm_cosmosdb_account.cosmos_api.primary_key
       COSMOS_API_CONNECTION_STRING = format("AccountEndpoint=%s;AccountKey=%s;", data.azurerm_cosmosdb_account.cosmos_api.endpoint, data.azurerm_cosmosdb_account.cosmos_api.primary_key)
 
+      // Remote Content CosmosDB
+      REMOTE_CONTENT_COSMOSDB_NAME = "remote-content"
+      REMOTE_CONTENT_COSMOSDB_URI  = data.azurerm_cosmosdb_account.cosmos_remote_content.endpoint
+      REMOTE_CONTENT_COSMOSDB_KEY  = data.azurerm_cosmosdb_account.cosmos_remote_content.primary_key
+
       MESSAGE_CONTAINER_NAME = local.message_content_container_name
       QueueStorageConnection = module.storage_api.primary_connection_string
 
@@ -32,6 +37,9 @@ locals {
       REDIS_URL      = module.redis_messages_v6.hostname
       REDIS_PORT     = module.redis_messages_v6.ssl_port
       REDIS_PASSWORD = module.redis_messages_v6.primary_access_key
+
+      // CACHE TTLs
+      SERVICE_CACHE_TTL_DURATION = "28800" // 8 hours
 
       PN_SERVICE_ID = var.pn_service_id
 

--- a/src/core/data.tf
+++ b/src/core/data.tf
@@ -10,6 +10,11 @@ data "azurerm_cosmosdb_account" "cosmos_api" {
   resource_group_name = format("%s-rg-internal", local.project)
 }
 
+data "azurerm_cosmosdb_account" "cosmos_remote_content" {
+  name                = "io-p-messages-remote-content"
+  resource_group_name = "io-p-messages-data-rg"
+}
+
 #
 # Function cgn
 #

--- a/src/core/function_app.tf
+++ b/src/core/function_app.tf
@@ -44,7 +44,6 @@ locals {
   function_app = {
     app_settings_common = {
       FUNCTIONS_WORKER_RUNTIME       = "node"
-      WEBSITE_NODE_DEFAULT_VERSION   = "14.16.0"
       WEBSITE_RUN_FROM_PACKAGE       = "1"
       WEBSITE_VNET_ROUTE_ALL         = "1"
       WEBSITE_DNS_SERVER             = "168.63.129.16"

--- a/src/core/function_assets_cdn.tf
+++ b/src/core/function_assets_cdn.tf
@@ -2,7 +2,6 @@ locals {
   function_assets_cdn = {
     app_settings = {
       FUNCTIONS_WORKER_RUNTIME       = "node"
-      WEBSITE_NODE_DEFAULT_VERSION   = "14.16.0"
       WEBSITE_RUN_FROM_PACKAGE       = "1"
       WEBSITE_VNET_ROUTE_ALL         = "1"
       WEBSITE_DNS_SERVER             = "168.63.129.16"

--- a/src/core/function_cgn.tf
+++ b/src/core/function_cgn.tf
@@ -35,7 +35,6 @@ locals {
   function_cgn = {
     app_settings_common = {
       FUNCTIONS_WORKER_RUNTIME       = "node"
-      WEBSITE_NODE_DEFAULT_VERSION   = "14.16.0"
       WEBSITE_RUN_FROM_PACKAGE       = "1"
       WEBSITE_VNET_ROUTE_ALL         = "1"
       WEBSITE_DNS_SERVER             = "168.63.129.16"


### PR DESCRIPTION
### List of changes
Added 3 remote content cosmos properties
Added TTL for caching services data
Made some winter cleaning removing useless properties

### Motivation and context
We need to allow app-messages-fn to connect to a new DB and have a wait to change cache TTL without redeploying
 
### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

