### PR TITLE
[EC-43] Remove other repos federation from io-infra managed identity

### DIFF
--- a/.identity/04_github_identity.tf
+++ b/.identity/04_github_identity.tf
@@ -29,7 +29,7 @@ module "identity_ci" {
 }
 
 module "identity_cd" {
-  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=v7.28.0"
+  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=v7.35.0"
 
   prefix    = var.prefix
   env_short = var.env_short

--- a/.identity/04_github_identity.tf
+++ b/.identity/04_github_identity.tf
@@ -6,10 +6,11 @@ resource "azurerm_resource_group" "identity_rg" {
 }
 
 module "identity_ci" {
-  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=v7.34.0"
+  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=v7.35.0"
 
   prefix    = var.prefix
   env_short = var.env_short
+  domain    = var.domain
 
   identity_role = "ci"
 
@@ -28,10 +29,11 @@ module "identity_ci" {
 }
 
 module "identity_cd" {
-  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=v7.34.0"
+  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=v7.28.0"
 
   prefix    = var.prefix
   env_short = var.env_short
+  domain    = var.domain
 
   identity_role = "cd"
 

--- a/.identity/99_variables.tf
+++ b/.identity/99_variables.tf
@@ -19,6 +19,11 @@ variable "prefix" {
   }
 }
 
+variable "domain" {
+  type        = string
+  description = "Managed identities scope names"
+}
+
 variable "location" {
   type        = string
   description = "One of westeurope, northeurope"

--- a/.identity/env/prod/terraform.tfvars
+++ b/.identity/env/prod/terraform.tfvars
@@ -22,14 +22,6 @@ ci_github_federations = [
   {
     repository = "io-infra"
     subject    = "prod-ci"
-  },
-  {
-    repository = "io-sign" # TODO: move. https://github.com/pagopa/io-infra/pull/745#discussion_r1410721348
-    subject    = "prod-ci"
-  },
-  {
-    repository = "io-services-metadata"
-    subject    = "prod-ci"
   }
 ]
 
@@ -37,14 +29,6 @@ cd_github_federations = [
   {
     repository = "io-infra"
     subject    = "prod-ci"
-  },
-  {
-    repository = "io-sign" # TODO: move. https://github.com/pagopa/io-infra/pull/745#discussion_r1410721348
-    subject    = "prod-ci"
-  },
-  {
-    repository = "io-services-metadata"
-    subject    = "prod-cd"
   }
 ]
 

--- a/.identity/env/prod/terraform.tfvars
+++ b/.identity/env/prod/terraform.tfvars
@@ -2,6 +2,7 @@ prefix    = "io"
 env_short = "p"
 env       = "prod"
 location  = "westeurope"
+domain    = "infra"
 
 github_repository_environment_ci = {
   protected_branches     = false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
`io-infra` managed identity is now federated with `io-infra` repository only. Removed both `io-sign` and `io-services-metadata` as discussed [here](https://github.com/pagopa/io-infra/pull/745#discussion_r1410721348)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
`io-infra` requires a big set of permissions and these should be used by `io-infra` repository only

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
