### PR TITLE
[#IOPID-1279] Remove old mutable storage after migration

### DIFF
--- a/src/domains/citizen-auth-common/03_storage.tf
+++ b/src/domains/citizen-auth-common/03_storage.tf
@@ -87,65 +87,6 @@ resource "azurerm_storage_queue" "lollipop_assertions_storage_revoke_queue" {
   storage_account_name = module.lollipop_assertions_storage.name
 }
 
-###
-# LV Audit Log Storage
-###
-module "lv_audit_logs_storage" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3//storage_account?ref=v6.1.0"
-
-  name                          = replace(format("%s-lv-logs-st", local.product), "-", "")
-  domain                        = upper(var.domain)
-  account_kind                  = "StorageV2"
-  account_tier                  = "Standard"
-  access_tier                   = "Hot"
-  account_replication_type      = "GZRS"
-  resource_group_name           = azurerm_resource_group.data_rg.name
-  location                      = var.location
-  advanced_threat_protection    = true
-  enable_identity               = true
-  public_network_access_enabled = false
-
-  tags = var.tags
-}
-
-module "lv_audit_logs_storage_customer_managed_key" {
-  source               = "git::https://github.com/pagopa/terraform-azurerm-v3//storage_account_customer_managed_key?ref=v4.3.1"
-  tenant_id            = data.azurerm_subscription.current.tenant_id
-  location             = var.location
-  resource_group_name  = azurerm_resource_group.data_rg.name
-  key_vault_id         = module.key_vault.id
-  key_name             = format("%s-key", module.lv_audit_logs_storage.name)
-  storage_id           = module.lv_audit_logs_storage.id
-  storage_principal_id = module.lv_audit_logs_storage.identity.0.principal_id
-}
-
-resource "azurerm_private_endpoint" "lv_audit_logs_storage_blob" {
-  name                = "${module.lv_audit_logs_storage.name}-blob-endpoint"
-  location            = var.location
-  resource_group_name = azurerm_resource_group.data_rg.name
-  subnet_id           = data.azurerm_subnet.private_endpoints_subnet.id
-
-  private_service_connection {
-    name                           = "${module.lv_audit_logs_storage.name}-blob"
-    private_connection_resource_id = module.lv_audit_logs_storage.id
-    is_manual_connection           = false
-    subresource_names              = ["blob"]
-  }
-
-  private_dns_zone_group {
-    name                 = "private-dns-zone-group"
-    private_dns_zone_ids = [data.azurerm_private_dns_zone.privatelink_blob_core_windows_net.id]
-  }
-
-  tags = var.tags
-}
-
-resource "azurerm_storage_container" "lv_audit_logs_storage_logs" {
-  name                  = "logs"
-  storage_account_name  = module.lv_audit_logs_storage.name
-  container_access_type = "private"
-}
-
 
 
 ###

--- a/src/domains/citizen-auth-common/README.md
+++ b/src/domains/citizen-auth-common/README.md
@@ -25,8 +25,6 @@
 | <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault) | git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault | v4.1.3 |
 | <a name="module_lollipop_assertions_storage"></a> [lollipop\_assertions\_storage](#module\_lollipop\_assertions\_storage) | git::https://github.com/pagopa/terraform-azurerm-v3//storage_account | v6.1.0 |
 | <a name="module_lollipop_assertions_storage_customer_managed_key"></a> [lollipop\_assertions\_storage\_customer\_managed\_key](#module\_lollipop\_assertions\_storage\_customer\_managed\_key) | git::https://github.com/pagopa/terraform-azurerm-v3//storage_account_customer_managed_key | v4.3.1 |
-| <a name="module_lv_audit_logs_storage"></a> [lv\_audit\_logs\_storage](#module\_lv\_audit\_logs\_storage) | git::https://github.com/pagopa/terraform-azurerm-v3//storage_account | v6.1.0 |
-| <a name="module_lv_audit_logs_storage_customer_managed_key"></a> [lv\_audit\_logs\_storage\_customer\_managed\_key](#module\_lv\_audit\_logs\_storage\_customer\_managed\_key) | git::https://github.com/pagopa/terraform-azurerm-v3//storage_account_customer_managed_key | v4.3.1 |
 | <a name="module_redis_common"></a> [redis\_common](#module\_redis\_common) | git::https://github.com/pagopa/terraform-azurerm-v3.git//redis_cache | v7.14.0 |
 | <a name="module_redis_common_snet"></a> [redis\_common\_snet](#module\_redis\_common\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v7.14.0 |
 
@@ -61,13 +59,11 @@
 | [azurerm_private_endpoint.immutable_lv_audit_logs_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.lollipop_assertion_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.lollipop_assertion_storage_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
-| [azurerm_private_endpoint.lv_audit_logs_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.data_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_container.immutable_lv_audit_logs_storage_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.lollipop_assertions_storage_assertions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
-| [azurerm_storage_container.lv_audit_logs_storage_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_management_policy.immutable_lv_audit_logs_storage_management_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
 | [azurerm_storage_queue.lollipop_assertions_storage_revoke_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_table.profile_emails](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |

--- a/src/domains/ioweb-common/03_storage.tf
+++ b/src/domains/ioweb-common/03_storage.tf
@@ -2,69 +2,6 @@ locals {
   immutability_policy_days = 730
 }
 
-######################
-# SPID LOGS Storage
-######################
-module "spid_logs_storage" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3//storage_account?ref=v6.1.0"
-
-  name                          = replace(format("%s-spid-logs-st", local.project), "-", "")
-  domain                        = upper(var.domain)
-  account_kind                  = "StorageV2"
-  account_tier                  = "Standard"
-  access_tier                   = "Hot"
-  account_replication_type      = "GZRS"
-  resource_group_name           = azurerm_resource_group.storage_rg.name
-  location                      = var.location
-  advanced_threat_protection    = true
-  enable_identity               = true
-  public_network_access_enabled = false
-
-  tags = var.tags
-}
-
-module "spid_logs_storage_customer_managed_key" {
-  source               = "git::https://github.com/pagopa/terraform-azurerm-v3//storage_account_customer_managed_key?ref=v6.1.0"
-  tenant_id            = data.azurerm_subscription.current.tenant_id
-  location             = var.location
-  resource_group_name  = azurerm_resource_group.storage_rg.name
-  key_vault_id         = module.key_vault.id
-  key_name             = format("%s-key", module.spid_logs_storage.name)
-  storage_id           = module.spid_logs_storage.id
-  storage_principal_id = module.spid_logs_storage.identity.0.principal_id
-}
-
-
-resource "azurerm_private_endpoint" "spid_logs_storage_blob" {
-  name                = "${module.spid_logs_storage.name}-blob-endpoint"
-  location            = var.location
-  resource_group_name = azurerm_resource_group.storage_rg.name
-  subnet_id           = data.azurerm_subnet.private_endpoints_subnet.id
-
-  private_service_connection {
-    name                           = "${module.spid_logs_storage.name}-blob"
-    private_connection_resource_id = module.spid_logs_storage.id
-    is_manual_connection           = false
-    subresource_names              = ["blob"]
-  }
-
-  private_dns_zone_group {
-    name                 = "private-dns-zone-group"
-    private_dns_zone_ids = [data.azurerm_private_dns_zone.privatelink_blob_core_windows_net.id]
-  }
-
-  tags = var.tags
-}
-
-
-# Containers
-resource "azurerm_storage_container" "spid_logs" {
-  depends_on            = [module.spid_logs_storage]
-  name                  = "spidlogs"
-  storage_account_name  = module.spid_logs_storage.name
-  container_access_type = "private"
-}
-
 
 ######################
 # Immutable SPID LOGS Storage

--- a/src/domains/ioweb-common/06_cdn.tf
+++ b/src/domains/ioweb-common/06_cdn.tf
@@ -11,12 +11,13 @@ data "azurerm_dns_zone" "ioapp_it" {
 module "landing_cdn" {
   source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cdn?ref=v7.2.1"
 
-  name                  = "portal"
-  prefix                = local.project
-  resource_group_name   = azurerm_resource_group.fe_rg.name
-  location              = azurerm_resource_group.fe_rg.location
-  hostname              = "ioapp.it"
-  https_rewrite_enabled = true
+  name                             = "portal"
+  prefix                           = local.project
+  resource_group_name              = azurerm_resource_group.fe_rg.name
+  location                         = azurerm_resource_group.fe_rg.location
+  hostname                         = "ioapp.it"
+  https_rewrite_enabled            = true
+  storage_account_replication_type = "GZRS"
 
   index_document     = "index.html"
   error_404_document = "it/404/index.html"

--- a/src/domains/ioweb-common/README.md
+++ b/src/domains/ioweb-common/README.md
@@ -22,8 +22,6 @@
 | <a name="module_redis_spid_login_snet"></a> [redis\_spid\_login\_snet](#module\_redis\_spid\_login\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v4.1.15 |
 | <a name="module_spid_login"></a> [spid\_login](#module\_spid\_login) | git::https://github.com/pagopa/terraform-azurerm-v3.git//app_service | v4.1.15 |
 | <a name="module_spid_login_snet"></a> [spid\_login\_snet](#module\_spid\_login\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v4.1.15 |
-| <a name="module_spid_logs_storage"></a> [spid\_logs\_storage](#module\_spid\_logs\_storage) | git::https://github.com/pagopa/terraform-azurerm-v3//storage_account | v6.1.0 |
-| <a name="module_spid_logs_storage_customer_managed_key"></a> [spid\_logs\_storage\_customer\_managed\_key](#module\_spid\_logs\_storage\_customer\_managed\_key) | git::https://github.com/pagopa/terraform-azurerm-v3//storage_account_customer_managed_key | v6.1.0 |
 
 ## Resources
 
@@ -40,13 +38,11 @@
 | [azurerm_key_vault_secret.appinsights_instrumentation_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.spid_login_jwt_pub_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_private_endpoint.immutable_spid_logs_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
-| [azurerm_private_endpoint.spid_logs_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.common_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.fe_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.storage_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_container.immutable_spid_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
-| [azurerm_storage_container.spid_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_management_policy.immutable_spid_logs_storage_management_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
 | [tls_private_key.jwt](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Remove old mutable storage for:
- io-web spid logs
- LV audit log

<!--- Describe your changes in detail -->

### Motivation and context

The audit log are now stored in immutable storage. The old mutable storage can be deleted after the data migration.
The data migration was completed manually.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [X] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
