### PR TITLE
[#IOPID-1125] Add ENV in fn-admin to Lock Profile table storage

### DIFF
--- a/src/core/app_messages.tf
+++ b/src/core/app_messages.tf
@@ -175,7 +175,7 @@ module "app_messages_function" {
   storage_account_info = {
     account_kind                      = "StorageV2"
     account_tier                      = "Standard"
-    account_replication_type          = "GRS"
+    account_replication_type          = count.index == 0 ? "GZRS" : "GRS"
     access_tier                       = "Hot"
     advanced_threat_protection_enable = true
   }

--- a/src/core/function_admin.tf
+++ b/src/core/function_admin.tf
@@ -140,6 +140,10 @@ locals {
       __DISABLED__SENDGRID_API_KEY = data.azurerm_key_vault_secret.common_SENDGRID_APIKEY.value
       MAILUP_USERNAME              = data.azurerm_key_vault_secret.common_MAILUP_USERNAME.value
       MAILUP_SECRET                = data.azurerm_key_vault_secret.common_MAILUP_SECRET.value
+
+      # Locked Profile Storage
+      LOCKED_PROFILES_STORAGE_CONNECTION_STRING = module.locked_profiles_storage.primary_connection_string
+      LOCKED_PROFILES_TABLE_NAME                = azurerm_storage_table.locked_profiles.name
     }
   }
 }

--- a/src/core/function_eucovidcert.tf
+++ b/src/core/function_eucovidcert.tf
@@ -83,7 +83,7 @@ module "eucovidcert_storage_account" {
   account_tier                    = "Standard"
   access_tier                     = "Hot"
   blob_versioning_enabled         = false
-  account_replication_type        = "GRS"
+  account_replication_type        = "GZRS"
   resource_group_name             = azurerm_resource_group.eucovidcert_rg.name
   location                        = azurerm_resource_group.eucovidcert_rg.location
   advanced_threat_protection      = false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add 2 new envs to allow fn-admin to connect Lock Profile storage

<!--- Describe your changes in detail -->

### Motivation and context
The fn-admin must delete the profile locks when a delete profile operation was requested.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

**This PR was applied locally only on target resources `module.function_admin` and `module.function_admin_staging_slot`**. The other misconfigured resources will be fixed on another PR.

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
