### PR TITLE
[EC-68] Fix Terraform Plan output paths

### DIFF
--- a/.github/workflows/ioweb_prod_cd.yml
+++ b/.github/workflows/ioweb_prod_cd.yml
@@ -59,9 +59,10 @@ jobs:
           dir: ${{ env.DIR }}-app
           azure_environment: weu-prod01
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392
         with:
           name: tfplan-output
+          if-no-files-found: error
           path: |
             **/tfplan-prod-*
             **/tfplan-weu-prod01-*
@@ -82,7 +83,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110
         with:
           name: tfplan-output
 

--- a/.github/workflows/ioweb_prod_cd.yml
+++ b/.github/workflows/ioweb_prod_cd.yml
@@ -23,7 +23,9 @@ jobs:
     name: Terraform Pre Apply
     runs-on: self-hosted
     environment: prod-ci
+
     steps:
+
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
@@ -60,14 +62,18 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: tfplan-output
-          path: tfplan-prod-*
+          path: |
+            **/tfplan-prod-*
+            **/tfplan-weu-prod01-*
 
   terraform_apply_job:
     name: Terraform Apply
     runs-on: self-hosted
     environment: prod-cd
     needs: [terraform_preapply_job]
+
     steps:
+
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
@@ -75,13 +81,16 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+
       - uses: actions/download-artifact@v2
         with:
           name: tfplan-output
+
       - name: Setup terraform
         id: setup-version
         # https://github.com/pagopa/terraform-install-action/commits/main
         uses: pagopa/terraform-install-action@1f76f593176e58c423b88d72273a612ba7ba430b
+
       - name: Terraform apply common
         # from https://github.com/pagopa/terraform-apply-azure-action/commits/main
         uses: pagopa/terraform-apply-azure-action@87efc4aa9b093b99ae5fd1915977e29cd80861ab

--- a/.github/workflows/prod_cd_citizen-auth.yml
+++ b/.github/workflows/prod_cd_citizen-auth.yml
@@ -68,10 +68,14 @@ jobs:
           dir: ${{ env.DIR }}-app
           azure_environment: weu-prod01
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392
         with:
           name: tfplan-output
-          path: tfplan-prod-*
+          if-no-files-found: error
+          path: |
+            **/tfplan-prod-*
+            **/tfplan-weu-beta-*
+            **/tfplan-weu-prod01-*
 
   terraform_apply_job:
     name: Terraform Apply
@@ -86,13 +90,16 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: actions/download-artifact@v2
+
+      - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110
         with:
           name: tfplan-output
+
       - name: Setup terraform
         id: setup-version
         # https://github.com/pagopa/terraform-install-action/commits/main
         uses: pagopa/terraform-install-action@1f76f593176e58c423b88d72273a612ba7ba430b
+
       - name: Terraform apply common
         # from https://github.com/pagopa/terraform-apply-azure-action/commits/main
         uses: pagopa/terraform-apply-azure-action@87efc4aa9b093b99ae5fd1915977e29cd80861ab


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Upload all TF plan files

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Plan outputs must be passed between jobs since they are arbitrary

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
