### PR TITLE
[EC-68] Force TF init in CD pipelines

### DIFF
--- a/.github/workflows/ioweb_prod_cd.yml
+++ b/.github/workflows/ioweb_prod_cd.yml
@@ -92,6 +92,13 @@ jobs:
         # https://github.com/pagopa/terraform-install-action/commits/main
         uses: pagopa/terraform-install-action@1f76f593176e58c423b88d72273a612ba7ba430b
 
+      - name: Terraform Init
+        id: terraform_init_common
+        working-directory: ${{ env.DIR }}-common
+        shell: bash
+        run: |
+          bash ./terraform.sh init prod
+
       - name: Terraform apply common
         # from https://github.com/pagopa/terraform-apply-azure-action/commits/main
         uses: pagopa/terraform-apply-azure-action@87efc4aa9b093b99ae5fd1915977e29cd80861ab
@@ -101,6 +108,13 @@ jobs:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           dir: ${{ env.DIR }}-common
           azure_environment: prod
+
+      - name: Terraform Init
+        id: terraform_init_weu-prod01
+        working-directory: ${{ env.DIR }}-app
+        shell: bash
+        run: |
+          bash ./terraform.sh init weu-prod01
 
       - name: Terraform apply app (weu-prod01)
         # from https://github.com/pagopa/terraform-apply-azure-action/commits/main

--- a/.github/workflows/prod_cd_citizen-auth.yml
+++ b/.github/workflows/prod_cd_citizen-auth.yml
@@ -2,7 +2,6 @@ name: Continuous Delivery on prod citizen-auth
 
 on:
   workflow_dispatch:
-  # Trigger the workflow on push on the main branch
   push:
     branches:
       - main
@@ -24,7 +23,9 @@ jobs:
     name: Terraform Pre Apply
     runs-on: self-hosted
     environment: prod-ci
+
     steps:
+
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
@@ -82,7 +83,9 @@ jobs:
     runs-on: self-hosted
     environment: prod-cd
     needs: [terraform_preapply_job]
+
     steps:
+
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
@@ -100,6 +103,13 @@ jobs:
         # https://github.com/pagopa/terraform-install-action/commits/main
         uses: pagopa/terraform-install-action@1f76f593176e58c423b88d72273a612ba7ba430b
 
+      - name: Terraform Init
+        id: terraform_init_common
+        working-directory: ${{ env.DIR }}-common
+        shell: bash
+        run: |
+          bash ./terraform.sh init prod
+
       - name: Terraform apply common
         # from https://github.com/pagopa/terraform-apply-azure-action/commits/main
         uses: pagopa/terraform-apply-azure-action@87efc4aa9b093b99ae5fd1915977e29cd80861ab
@@ -110,6 +120,13 @@ jobs:
           dir: ${{ env.DIR }}-common
           azure_environment: prod
 
+      - name: Terraform Init
+        id: terraform_init_weu-beta
+        working-directory: ${{ env.DIR }}-app
+        shell: bash
+        run: |
+          bash ./terraform.sh init weu-beta
+
       - name: Terraform apply weu-beta
         # from https://github.com/pagopa/terraform-apply-azure-action/commits/main
         uses: pagopa/terraform-apply-azure-action@87efc4aa9b093b99ae5fd1915977e29cd80861ab
@@ -119,6 +136,13 @@ jobs:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           dir: ${{ env.DIR }}-app
           azure_environment: weu-beta
+
+      - name: Terraform Init
+        id: terraform_init_weu-prod01
+        working-directory: ${{ env.DIR }}-app
+        shell: bash
+        run: |
+          bash ./terraform.sh init weu-prod01
 
       - name: Terraform apply weu-prod01
         # from https://github.com/pagopa/terraform-apply-azure-action/commits/main


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add steps to perform TF init

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
TF wasn't initialized was missing due to ephemeral runners

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
