### PR TITLE
Add autoscale capabilities to subscription_cidrs collection

### DIFF
--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -790,6 +790,11 @@ variable "function_services_autoscale_default" {
   default     = 1
 }
 
+variable "function_services_subscription_cidrs_max_thoughput" {
+  type    = number
+  default = 600
+}
+
 
 
 # Function App Async

--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -792,7 +792,7 @@ variable "function_services_autoscale_default" {
 
 variable "function_services_subscription_cidrs_max_thoughput" {
   type    = number
-  default = 600
+  default = 1000
 }
 
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -735,7 +735,7 @@
 | <a name="input_function_services_kind"></a> [function\_services\_kind](#input\_function\_services\_kind) | App service plan kind | `string` | `null` | no |
 | <a name="input_function_services_sku_size"></a> [function\_services\_sku\_size](#input\_function\_services\_sku\_size) | App service plan sku size | `string` | `null` | no |
 | <a name="input_function_services_sku_tier"></a> [function\_services\_sku\_tier](#input\_function\_services\_sku\_tier) | App service plan sku tier | `string` | `null` | no |
-| <a name="input_function_services_subscription_cidrs_max_thoughput"></a> [function\_services\_subscription\_cidrs\_max\_thoughput](#input\_function\_services\_subscription\_cidrs\_max\_thoughput) | n/a | `number` | `600` | no |
+| <a name="input_function_services_subscription_cidrs_max_thoughput"></a> [function\_services\_subscription\_cidrs\_max\_thoughput](#input\_function\_services\_subscription\_cidrs\_max\_thoughput) | n/a | `number` | `1000` | no |
 | <a name="input_io_receipt_service_id"></a> [io\_receipt\_service\_id](#input\_io\_receipt\_service\_id) | The Service ID of io-receipt service | `string` | n/a | yes |
 | <a name="input_io_receipt_service_test_id"></a> [io\_receipt\_service\_test\_id](#input\_io\_receipt\_service\_test\_id) | The Service ID of io-receipt service | `string` | n/a | yes |
 | <a name="input_io_receipt_service_test_url"></a> [io\_receipt\_service\_test\_url](#input\_io\_receipt\_service\_test\_url) | The endpoint of Receipt Service (test env) | `string` | n/a | yes |

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -735,6 +735,7 @@
 | <a name="input_function_services_kind"></a> [function\_services\_kind](#input\_function\_services\_kind) | App service plan kind | `string` | `null` | no |
 | <a name="input_function_services_sku_size"></a> [function\_services\_sku\_size](#input\_function\_services\_sku\_size) | App service plan sku size | `string` | `null` | no |
 | <a name="input_function_services_sku_tier"></a> [function\_services\_sku\_tier](#input\_function\_services\_sku\_tier) | App service plan sku tier | `string` | `null` | no |
+| <a name="input_function_services_subscription_cidrs_max_thoughput"></a> [function\_services\_subscription\_cidrs\_max\_thoughput](#input\_function\_services\_subscription\_cidrs\_max\_thoughput) | n/a | `number` | `600` | no |
 | <a name="input_io_receipt_service_id"></a> [io\_receipt\_service\_id](#input\_io\_receipt\_service\_id) | The Service ID of io-receipt service | `string` | n/a | yes |
 | <a name="input_io_receipt_service_test_id"></a> [io\_receipt\_service\_test\_id](#input\_io\_receipt\_service\_test\_id) | The Service ID of io-receipt service | `string` | n/a | yes |
 | <a name="input_io_receipt_service_test_url"></a> [io\_receipt\_service\_test\_url](#input\_io\_receipt\_service\_test\_url) | The endpoint of Receipt Service (test env) | `string` | n/a | yes |

--- a/src/core/function_services.tf
+++ b/src/core/function_services.tf
@@ -415,4 +415,8 @@ module "db_subscription_cidrs_container" {
   account_name        = format("%s-cosmos-api", local.project)
   database_name       = local.function_services.app_settings_common.COSMOSDB_NAME
   partition_key_path  = "/subscriptionId"
+
+  autoscale_settings {
+    max_throughput = var.function_services_subscription_cidrs_max_thoughput
+  }
 }

--- a/src/core/function_services.tf
+++ b/src/core/function_services.tf
@@ -416,7 +416,7 @@ module "db_subscription_cidrs_container" {
   database_name       = local.function_services.app_settings_common.COSMOSDB_NAME
   partition_key_path  = "/subscriptionId"
 
-  autoscale_settings {
+  autoscale_settings = {
     max_throughput = var.function_services_subscription_cidrs_max_thoughput
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add autoscale capabilities to CosmosDB collection `subscription-cidrs`
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
