### PR TITLE
Fix Policy on the audit log storage

### DIFF
--- a/src/domains/ioweb-common/03_storage.tf
+++ b/src/domains/ioweb-common/03_storage.tf
@@ -87,11 +87,13 @@ resource "azurerm_storage_container" "immutable_audit_logs" {
 
 
 # Policies
+
 resource "azurerm_storage_management_policy" "immutable_spid_logs_storage_management_policy" {
   depends_on = [module.immutable_spid_logs_storage, azurerm_storage_container.immutable_spid_logs]
 
   storage_account_id = module.immutable_spid_logs_storage.id
 
+  ## Spid Logs Retention Policy
   rule {
     name    = "deleteafter2yrs"
     enabled = true
@@ -113,14 +115,8 @@ resource "azurerm_storage_management_policy" "immutable_spid_logs_storage_manage
       }
     }
   }
-}
 
-## Policy ONLY for audit logs
-resource "azurerm_storage_management_policy" "immutable_audit_logs_storage_management_policy" {
-  depends_on = [module.immutable_spid_logs_storage, azurerm_storage_container.immutable_audit_logs]
-
-  storage_account_id = module.immutable_spid_logs_storage.id
-
+  ## Audit Logs Retention Policy
   rule {
     name    = "deleteafter2yrsplus1week"
     enabled = true

--- a/src/domains/ioweb-common/03_storage.tf
+++ b/src/domains/ioweb-common/03_storage.tf
@@ -89,7 +89,7 @@ resource "azurerm_storage_container" "immutable_audit_logs" {
 # Policies
 
 resource "azurerm_storage_management_policy" "immutable_spid_logs_storage_management_policy" {
-  depends_on = [module.immutable_spid_logs_storage, azurerm_storage_container.immutable_spid_logs]
+  depends_on = [module.immutable_spid_logs_storage, azurerm_storage_container.immutable_spid_logs, azurerm_storage_container.immutable_audit_logs]
 
   storage_account_id = module.immutable_spid_logs_storage.id
 

--- a/src/domains/ioweb-common/README.md
+++ b/src/domains/ioweb-common/README.md
@@ -46,7 +46,6 @@
 | [azurerm_resource_group.storage_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_container.immutable_audit_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.immutable_spid_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
-| [azurerm_storage_management_policy.immutable_audit_logs_storage_management_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
 | [azurerm_storage_management_policy.immutable_spid_logs_storage_management_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
 | [tls_private_key.jwt](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
<!--- Describe your changes in detail -->
Use only one resource for the two rule of Azure Storage Management Policy.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
Using two different Azure Storage Management Policy for different rule create a conflict where only one is created, and the second will override the first declare. This PR add the two rules inside the same policy.

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [X] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
