### PR TITLE
[#IOPID-1356] Restore minimum instances fn-app afeter seeding

### DIFF
--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -219,7 +219,7 @@ function_services_autoscale_default = 10
 function_app_async_kind              = "Linux"
 function_app_async_sku_tier          = "PremiumV3"
 function_app_async_sku_size          = "P1v3"
-function_app_async_autoscale_minimum = 8 # Update to 8 until unique email seeding is completed
+function_app_async_autoscale_minimum = 2 # 2 instance to achieve redundancy and failover
 function_app_async_autoscale_maximum = 30
 function_app_async_autoscale_default = 10
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Restore minimun instances for `fn-app-async` to 2 after seeding "Univocità Indirizzi Email"
<!--- Describe your changes in detail -->

### Motivation and context
After the seeding for the table storage of unique email is completed we restore the number of minimum instances of `fn-app-async` to reduce costs.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
The change was made by the Azure Portal because the current status of infra is disaligned on some resource (`app-gateway`)

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
