### PR TITLE
[#IOCOM-1033] Added env var to map a fallback value from internal services to remote content configs

### DIFF
--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -1015,6 +1015,13 @@ variable "pn_service_id" {
   description = "The Service ID of PN service"
   default     = "01G40DWQGKY5GRWSNM4303VNRP"
 }
+
+variable "pn_remote_config_id" {
+  type        = string
+  description = "The Remote Content Config ID of PN service"
+  default     = "01HMVMHCZZ8D0VTFWMRHBM5D6F"
+}
+
 # PN Test Endpoint
 variable "pn_test_endpoint" {
   type        = string
@@ -1028,10 +1035,22 @@ variable "io_sign_service_id" {
   default     = "01GQQZ9HF5GAPRVKJM1VDAVFHM"
 }
 
+variable "io_sign_remote_config_id" {
+  type        = string
+  description = "The Remote Content Config ID of io-sign service"
+  default     = "01HMVMDTHXCESMZ72NA701EKGQ"
+}
+
 # io-receipt service
 variable "io_receipt_service_id" {
   type        = string
   description = "The Service ID of io-receipt service"
+}
+
+variable "io_receipt_remote_config_id" {
+  type        = string
+  description = "The Remote Content Config ID of io-receipt service"
+  default     = "01HMVM9W74RWH93NT1EYNKKNNR"
 }
 
 variable "io_receipt_service_url" {
@@ -1042,6 +1061,12 @@ variable "io_receipt_service_url" {
 variable "io_receipt_service_test_id" {
   type        = string
   description = "The Service ID of io-receipt service"
+}
+
+variable "io_receipt_remote_config_test_id" {
+  type        = string
+  description = "The Remote Content Config ID of io-receipt service"
+  default     = "01HMVMCDD3JFYTPKT4ZN4WQ73B"
 }
 
 variable "io_receipt_service_test_url" {
@@ -1183,6 +1208,12 @@ variable "third_party_mock_service_id" {
   type        = string
   description = "The Service ID of the Third Party Mock service"
   default     = "01GQQDPM127KFGG6T3660D5TXD"
+}
+
+variable "third_party_mock_remote_config_id" {
+  type        = string
+  description = "The Remote Content Config ID of the Third Party Mock service"
+  default     = "01HMVM4N4XFJ8VBR1FXYFZ9QFB"
 }
 
 # Citizen auth

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -742,10 +742,13 @@
 | <a name="input_function_services_sku_size"></a> [function\_services\_sku\_size](#input\_function\_services\_sku\_size) | App service plan sku size | `string` | `null` | no |
 | <a name="input_function_services_sku_tier"></a> [function\_services\_sku\_tier](#input\_function\_services\_sku\_tier) | App service plan sku tier | `string` | `null` | no |
 | <a name="input_function_services_subscription_cidrs_max_thoughput"></a> [function\_services\_subscription\_cidrs\_max\_thoughput](#input\_function\_services\_subscription\_cidrs\_max\_thoughput) | n/a | `number` | `1000` | no |
+| <a name="input_io_receipt_remote_config_id"></a> [io\_receipt\_remote\_config\_id](#input\_io\_receipt\_remote\_config\_id) | The Remote Content Config ID of io-receipt service | `string` | `"01HMVM9W74RWH93NT1EYNKKNNR"` | no |
+| <a name="input_io_receipt_remote_config_test_id"></a> [io\_receipt\_remote\_config\_test\_id](#input\_io\_receipt\_remote\_config\_test\_id) | The Remote Content Config ID of io-receipt service | `string` | `"01HMVMCDD3JFYTPKT4ZN4WQ73B"` | no |
 | <a name="input_io_receipt_service_id"></a> [io\_receipt\_service\_id](#input\_io\_receipt\_service\_id) | The Service ID of io-receipt service | `string` | n/a | yes |
 | <a name="input_io_receipt_service_test_id"></a> [io\_receipt\_service\_test\_id](#input\_io\_receipt\_service\_test\_id) | The Service ID of io-receipt service | `string` | n/a | yes |
 | <a name="input_io_receipt_service_test_url"></a> [io\_receipt\_service\_test\_url](#input\_io\_receipt\_service\_test\_url) | The endpoint of Receipt Service (test env) | `string` | n/a | yes |
 | <a name="input_io_receipt_service_url"></a> [io\_receipt\_service\_url](#input\_io\_receipt\_service\_url) | The endpoint of Receipt Service (prod env) | `string` | n/a | yes |
+| <a name="input_io_sign_remote_config_id"></a> [io\_sign\_remote\_config\_id](#input\_io\_sign\_remote\_config\_id) | The Remote Content Config ID of io-sign service | `string` | `"01HMVMDTHXCESMZ72NA701EKGQ"` | no |
 | <a name="input_io_sign_service_id"></a> [io\_sign\_service\_id](#input\_io\_sign\_service\_id) | The Service ID of io-sign service | `string` | `"01GQQZ9HF5GAPRVKJM1VDAVFHM"` | no |
 | <a name="input_law_daily_quota_gb"></a> [law\_daily\_quota\_gb](#input\_law\_daily\_quota\_gb) | The workspace daily quota for ingestion in GB. | `number` | `-1` | no |
 | <a name="input_law_retention_in_days"></a> [law\_retention\_in\_days](#input\_law\_retention\_in\_days) | The workspace data retention in days | `number` | `90` | no |
@@ -764,6 +767,7 @@
 | <a name="input_plan_shared_1_sku_capacity"></a> [plan\_shared\_1\_sku\_capacity](#input\_plan\_shared\_1\_sku\_capacity) | Shared functions app plan capacity | `number` | `1` | no |
 | <a name="input_plan_shared_1_sku_size"></a> [plan\_shared\_1\_sku\_size](#input\_plan\_shared\_1\_sku\_size) | App service plan sku size | `string` | `null` | no |
 | <a name="input_plan_shared_1_sku_tier"></a> [plan\_shared\_1\_sku\_tier](#input\_plan\_shared\_1\_sku\_tier) | App service plan sku tier | `string` | `null` | no |
+| <a name="input_pn_remote_config_id"></a> [pn\_remote\_config\_id](#input\_pn\_remote\_config\_id) | The Remote Content Config ID of PN service | `string` | `"01HMVMHCZZ8D0VTFWMRHBM5D6F"` | no |
 | <a name="input_pn_service_id"></a> [pn\_service\_id](#input\_pn\_service\_id) | The Service ID of PN service | `string` | `"01G40DWQGKY5GRWSNM4303VNRP"` | no |
 | <a name="input_pn_test_endpoint"></a> [pn\_test\_endpoint](#input\_pn\_test\_endpoint) | The endpoint of PN (test env) | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | `"io"` | no |
@@ -776,6 +780,7 @@
 | <a name="input_selfcare_plan_sku_size"></a> [selfcare\_plan\_sku\_size](#input\_selfcare\_plan\_sku\_size) | Selfcare app plan sku size | `string` | `"P1v3"` | no |
 | <a name="input_selfcare_plan_sku_tier"></a> [selfcare\_plan\_sku\_tier](#input\_selfcare\_plan\_sku\_tier) | Selfcare app plan sku tier | `string` | `"PremiumV3"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | <pre>{<br>  "CreatedBy": "Terraform"<br>}</pre> | no |
+| <a name="input_third_party_mock_remote_config_id"></a> [third\_party\_mock\_remote\_config\_id](#input\_third\_party\_mock\_remote\_config\_id) | The Remote Content Config ID of the Third Party Mock service | `string` | `"01HMVM4N4XFJ8VBR1FXYFZ9QFB"` | no |
 | <a name="input_third_party_mock_service_id"></a> [third\_party\_mock\_service\_id](#input\_third\_party\_mock\_service\_id) | The Service ID of the Third Party Mock service | `string` | `"01GQQDPM127KFGG6T3660D5TXD"` | no |
 | <a name="input_vnet_name"></a> [vnet\_name](#input\_vnet\_name) | Common Virtual network resource name. | `string` | `""` | no |
 | <a name="input_vpn_pip_sku"></a> [vpn\_pip\_sku](#input\_vpn\_pip\_sku) | VPN GW PIP SKU | `string` | `"Basic"` | no |

--- a/src/core/app_messages.tf
+++ b/src/core/app_messages.tf
@@ -24,11 +24,11 @@ locals {
 
       // Service to Remote Content configuration MAP
       SERVICE_TO_RC_CONFIGURATION_MAP = jsonencode({
-        var.pn_service_id               = var.pn_remote_config_id,
-        var.io_sign_service_id          = var.io_sign_remote_config_id,
-        var.io_receipt_service_test_id  = var.io_receipt_remote_config_test_id,
-        var.io_receipt_service_id       = var.io_receipt_remote_config_id,
-        var.third_party_mock_service_id = var.third_party_mock_remote_config_id
+        "${var.pn_service_id}"               = var.pn_remote_config_id,
+        "${var.io_sign_service_id}"          = var.io_sign_remote_config_id,
+        "${var.io_receipt_service_test_id}"  = var.io_receipt_remote_config_test_id,
+        "${var.io_receipt_service_id}"       = var.io_receipt_remote_config_id,
+        "${var.third_party_mock_service_id}" = var.third_party_mock_remote_config_id
       })
 
       MESSAGE_CONTAINER_NAME = local.message_content_container_name

--- a/src/core/app_messages.tf
+++ b/src/core/app_messages.tf
@@ -22,6 +22,15 @@ locals {
       REMOTE_CONTENT_COSMOSDB_URI  = data.azurerm_cosmosdb_account.cosmos_remote_content.endpoint
       REMOTE_CONTENT_COSMOSDB_KEY  = data.azurerm_cosmosdb_account.cosmos_remote_content.primary_key
 
+      // Service to Remote Content configuration MAP
+      SERVICE_TO_RC_CONFIGURATION_MAP = jsonencode({
+        var.pn_service_id               = var.pn_remote_config_id,
+        var.io_sign_service_id          = var.io_sign_remote_config_id,
+        var.io_receipt_service_test_id  = var.io_receipt_remote_config_test_id,
+        var.io_receipt_service_id       = var.io_receipt_remote_config_id,
+        var.third_party_mock_service_id = var.third_party_mock_remote_config_id
+      })
+
       MESSAGE_CONTAINER_NAME = local.message_content_container_name
       QueueStorageConnection = module.storage_api.primary_connection_string
 

--- a/src/core/assets_cdn.tf
+++ b/src/core/assets_cdn.tf
@@ -13,7 +13,7 @@ module "assets_cdn" {
   account_tier                    = "Standard"
   access_tier                     = "Hot"
   blob_versioning_enabled         = true
-  account_replication_type        = "GRS"
+  account_replication_type        = "GZRS"
   resource_group_name             = azurerm_resource_group.rg_common.name
   location                        = azurerm_resource_group.rg_common.location
   advanced_threat_protection      = false

--- a/src/core/function_devportal_service_data.tf
+++ b/src/core/function_devportal_service_data.tf
@@ -164,7 +164,7 @@ module "function_devportalservicedata" {
   storage_account_info = {
     account_kind                      = "StorageV2"
     account_tier                      = "Standard"
-    account_replication_type          = "GRS"
+    account_replication_type          = "GZRS"
     access_tier                       = "Hot"
     advanced_threat_protection_enable = true
   }


### PR DESCRIPTION
### List of changes

Added some env variables to functions-app-messages 

### Motivation and context

We added a map to get a default remote content configuration for all Remote Contents sent before February 2024.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

