### PR TITLE
[#IOCOM-1035] Added support collection

### DIFF
--- a/src/domains/messages-common/03_database.tf
+++ b/src/domains/messages-common/03_database.tf
@@ -313,3 +313,29 @@ resource "azurerm_cosmosdb_sql_container" "message_configuration" {
     }
   }
 }
+
+resource "azurerm_cosmosdb_sql_container" "user_configurations" {
+  name                = "user-configurations"
+  resource_group_name = azurerm_resource_group.data_rg.name
+  account_name        = module.cosmosdb_account_remote_content.name
+  database_name       = module.cosmosdb_sql_database_remote_content.name
+
+  partition_key_path    = "/userId"
+  partition_key_version = 2
+
+  autoscale_settings {
+    max_throughput = 2000
+  }
+
+  indexing_policy {
+    indexing_mode = "consistent"
+
+    included_path {
+      path = "/*"
+    }
+
+    excluded_path {
+      path = "/\"_etag\"/?"
+    }
+  }
+}

--- a/src/domains/messages-common/README.md
+++ b/src/domains/messages-common/README.md
@@ -42,6 +42,7 @@
 | [azurerm_cosmosdb_mongo_database.db_reminder](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_mongo_database) | resource |
 | [azurerm_cosmosdb_sql_container.message_configuration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_container) | resource |
 | [azurerm_cosmosdb_sql_container.remote_content_configuration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_container) | resource |
+| [azurerm_cosmosdb_sql_container.user_configurations](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_container) | resource |
 | [azurerm_key_vault_access_policy.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azdevops_platform_iac_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |


### PR DESCRIPTION
### List of changes
Added the collection `user-configurations`

### Motivation and context
We need this collection to save the relation between users and configurations and avoid expensive cross partition queries during a list operation over the `message-configuration` collection that is versioned and partitioned by `configurationId`.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No
