### PR TITLE
[#IOPID-1470] Add new env var `INSTANT_DELETE_ENABLED_USERS`

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -506,6 +506,7 @@
 | [azurerm_key_vault_secret.devportalservicedata_db_server_fndevportalservicedata_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.fn_admin_ASSETS_URL](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.fn_admin_AZURE_SUBSCRIPTION_ID](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.fn_admin_INSTANT_DELETE_ENABLED_USERS](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.fn_app_AZURE_NH_ENDPOINT](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.fn_app_PUBLIC_API_KEY](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.fn_app_SPID_LOGS_PUBLIC_KEY](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |

--- a/src/core/function_admin.tf
+++ b/src/core/function_admin.tf
@@ -12,6 +12,11 @@ data "azurerm_key_vault_secret" "fn_admin_AZURE_SUBSCRIPTION_ID" {
   key_vault_id = module.key_vault_common.id
 }
 
+data "azurerm_key_vault_secret" "fn_admin_INSTANT_DELETE_ENABLED_USERS" {
+  name         = "fn-admin-INSTANT-DELETE-ENABLED-USERS"
+  key_vault_id = module.key_vault_common.id
+}
+
 data "azurerm_key_vault_secret" "adb2c_TENANT_NAME" {
   name         = "adb2c-TENANT-NAME"
   key_vault_id = module.key_vault_common.id
@@ -151,6 +156,9 @@ locals {
 
       PROFILE_EMAILS_STORAGE_CONNECTION_STRING = data.azurerm_storage_account.citizen_auth_common.primary_connection_string
       PROFILE_EMAILS_TABLE_NAME                = "profileEmails"
+
+      # Instant delete
+      INSTANT_DELETE_ENABLED_USERS = data.azurerm_key_vault_secret.fn_admin_INSTANT_DELETE_ENABLED_USERS.value
     }
   }
 }

--- a/src/core/function_admin.tf
+++ b/src/core/function_admin.tf
@@ -158,7 +158,7 @@ locals {
       PROFILE_EMAILS_TABLE_NAME                = "profileEmails"
 
       # Instant delete
-      INSTANT_DELETE_ENABLED_USERS = data.azurerm_key_vault_secret.fn_admin_INSTANT_DELETE_ENABLED_USERS.value
+      INSTANT_DELETE_ENABLED_USERS = join(",", [data.azurerm_key_vault_secret.fn_admin_INSTANT_DELETE_ENABLED_USERS.value, local.test_users])
     }
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
[add new env var INSTANT_DELETE_ENABLED_USERS](https://github.com/pagopa/io-infra/commit/8f2da616c6ba4a7ef6e120ca8b50e1bf30a3f2c0)


### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Enable instant delete of allowed users

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

⚠️  The update of `ALLOW_PAGOPA_IP_SOURCE_RANGE` is a deliberate and desired update

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
