### PR TITLE
Reduce `appgateway` response time alert sensibility to `Medium` 

### DIFF
--- a/src/core/appgateway.tf
+++ b/src/core/appgateway.tf
@@ -797,7 +797,7 @@ module "app_gw" {
     response_time = {
       description   = "Backends response time is too high. See Dimension value to check the Listener unhealty."
       frequency     = "PT5M"
-      window_size   = "PT5M"
+      window_size   = "PT15M"
       severity      = 2
       auto_mitigate = true
 

--- a/src/core/appgateway.tf
+++ b/src/core/appgateway.tf
@@ -807,7 +807,7 @@ module "app_gw" {
           aggregation              = "Average"
           metric_name              = "BackendLastByteResponseTime"
           operator                 = "GreaterThan"
-          alert_sensitivity        = "High"
+          alert_sensitivity        = "Medium"
           evaluation_total_count   = 2
           evaluation_failure_count = 2
           dimension = [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- [reduce response time sensibility to Medium](https://github.com/pagopa/io-infra/commit/be5065b56ce1f64be7a9c47b287d525c1fa0822a)
- [increase window size to 15M](https://github.com/pagopa/io-infra/pull/901/commits/313d56bf7bb405e2bccb400c0959f882f8aa4bf8)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
False alert are triggered for some listeners.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
