### PR TITLE
fix: Added IoServicesConfigurationId env variable to io-sign-user-func

### DIFF
--- a/src/domains/sign/io_sign_user_func.tf
+++ b/src/domains/sign/io_sign_user_func.tf
@@ -18,6 +18,7 @@ locals {
       userValidatedBlobContainerName    = azurerm_storage_container.validated_documents.name
       IoServicesApiBasePath             = "https://api.io.pagopa.it"
       IoServicesSubscriptionKey         = module.key_vault_secrets.values["IoServicesSubscriptionKey"].value
+      IoServicesConfigurationId         = module.key_vault_secrets.values["io-services-configuration-id"].value
       PdvTokenizerApiBasePath           = "https://api.tokenizer.pdv.pagopa.it"
       PdvTokenizerApiKey                = module.key_vault_secrets.values["PdvTokenizerApiKey"].value
       NamirialApiBasePath               = "https://pagopa.namirial.com"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

The function app `io-p-sign-user-func` is unhealthy in the staging slot

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
