### PR TITLE
[EC-217] Move eucovidcert resource group to their own configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -53,3 +53,7 @@ automation:
 selfcare:
   - changed-files:
     - any-glob-to-any-file: ['.src/domains/selfcare/**']
+
+eucovidcert:
+  - changed-files:
+    - any-glob-to-any-file: ['.src/domains/eucovidcert/**']

--- a/.github/workflows/eucovidcert_cd.yaml
+++ b/.github/workflows/eucovidcert_cd.yaml
@@ -1,0 +1,18 @@
+name: Continuous Delivery on eucovidcert
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/domains/eucovidcert**"
+
+jobs:
+  release_prod:
+    uses: ./.github/workflows/call_release.yaml
+    name: Terraform Apply
+    secrets: inherit
+    with:
+      environment: prod
+      dir: "src/domains/eucovidcert/prod/westeurope"

--- a/.github/workflows/eucovidcert_cd.yaml
+++ b/.github/workflows/eucovidcert_cd.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - "src/domains/eucovidcert**"
+      - "src/domains/eucovidcert/**"
 
 jobs:
   release_prod:

--- a/.github/workflows/eucovidcert_ci.yaml
+++ b/.github/workflows/eucovidcert_ci.yaml
@@ -1,0 +1,23 @@
+name: Continuous Integration on eucovidcert
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - "src/domains/eucovidcert/**"
+      - ".github/workflows/eucovidcert_**"
+
+jobs:
+  code_review_prod:
+    uses: ./.github/workflows/call_code_review.yaml
+    name: Terraform Plan
+    secrets: inherit
+    with:
+      environment: prod
+      dir: "src/domains/eucovidcert/prod/westeurope"

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -323,7 +323,6 @@
 | [azurerm_resource_group.data](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.default_roleassignment_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.elt_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.eucovidcert_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.event_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.grafana_dashboard_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.pblevtdispatcher_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
@@ -493,6 +492,7 @@
 | [azurerm_linux_web_app.appservice_selfcare_be](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_web_app) | data source |
 | [azurerm_linux_web_app.cms_backoffice_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_web_app) | data source |
 | [azurerm_linux_web_app.firmaconio_selfcare_web_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_web_app) | data source |
+| [azurerm_resource_group.eucovidcert_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.notifications_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account.citizen_auth_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.iopstapp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |

--- a/src/core/function_eucovidcert.tf
+++ b/src/core/function_eucovidcert.tf
@@ -151,7 +151,7 @@ module "function_eucovidcert_snet" {
   source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v7.61.0"
   name                                      = format("%s-eucovidcert-snet", local.project)
   address_prefixes                          = var.cidr_subnet_eucovidcert
-  resource_group_name                       = data.azurerm_resource_group.rg_common.name
+  resource_group_name                       = azurerm_resource_group.rg_common.name
   virtual_network_name                      = module.vnet_common.name
   private_endpoint_network_policies_enabled = false
 

--- a/src/core/function_eucovidcert.tf
+++ b/src/core/function_eucovidcert.tf
@@ -65,11 +65,8 @@ data "azurerm_key_vault_secret" "fn_eucovidcert_FNSERVICES_API_KEY" {
 #
 # RESOUCE GROUP
 #
-resource "azurerm_resource_group" "eucovidcert_rg" {
-  name     = format("%s-rg-eucovidcert", local.project)
-  location = var.location
-
-  tags = var.tags
+data "azurerm_resource_group" "eucovidcert_rg" {
+  name = format("%s-rg-eucovidcert", local.project)
 }
 
 #
@@ -84,8 +81,8 @@ module "eucovidcert_storage_account" {
   access_tier                     = "Hot"
   blob_versioning_enabled         = false
   account_replication_type        = "GZRS"
-  resource_group_name             = azurerm_resource_group.eucovidcert_rg.name
-  location                        = azurerm_resource_group.eucovidcert_rg.location
+  resource_group_name             = data.azurerm_resource_group.eucovidcert_rg.name
+  location                        = data.azurerm_resource_group.eucovidcert_rg.location
   advanced_threat_protection      = false
   allow_nested_items_to_be_public = false
   public_network_access_enabled   = true
@@ -154,7 +151,7 @@ module "function_eucovidcert_snet" {
   source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v7.61.0"
   name                                      = format("%s-eucovidcert-snet", local.project)
   address_prefixes                          = var.cidr_subnet_eucovidcert
-  resource_group_name                       = azurerm_resource_group.rg_common.name
+  resource_group_name                       = data.azurerm_resource_group.rg_common.name
   virtual_network_name                      = module.vnet_common.name
   private_endpoint_network_policies_enabled = false
 
@@ -181,7 +178,7 @@ resource "azurerm_subnet_nat_gateway_association" "function_eucovidcert_snet" {
 module "function_eucovidcert" {
   source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app?ref=v7.61.0"
 
-  resource_group_name = azurerm_resource_group.eucovidcert_rg.name
+  resource_group_name = data.azurerm_resource_group.eucovidcert_rg.name
   name                = format("%s-eucovidcert-fn", local.project)
   location            = var.location
   health_check_path   = "/api/v1/info"
@@ -231,7 +228,7 @@ module "function_eucovidcert_staging_slot" {
 
   name                = "staging"
   location            = var.location
-  resource_group_name = azurerm_resource_group.eucovidcert_rg.name
+  resource_group_name = data.azurerm_resource_group.eucovidcert_rg.name
   function_app_id     = module.function_eucovidcert.id
   app_service_plan_id = module.function_eucovidcert.app_service_plan_id
   health_check_path   = "/api/v1/info"
@@ -267,7 +264,7 @@ module "function_eucovidcert_staging_slot" {
 
 resource "azurerm_monitor_autoscale_setting" "function_eucovidcert" {
   name                = format("%s-autoscale", module.function_eucovidcert.name)
-  resource_group_name = azurerm_resource_group.eucovidcert_rg.name
+  resource_group_name = data.azurerm_resource_group.eucovidcert_rg.name
   location            = var.location
   target_resource_id  = module.function_eucovidcert.app_service_plan_id
 
@@ -375,7 +372,7 @@ resource "azurerm_monitor_autoscale_setting" "function_eucovidcert" {
 resource "azurerm_monitor_metric_alert" "function_eucovidcert_health_check" {
 
   name                = "${module.function_eucovidcert.name}-health-check-failed"
-  resource_group_name = azurerm_resource_group.eucovidcert_rg.name
+  resource_group_name = data.azurerm_resource_group.eucovidcert_rg.name
   scopes              = [module.function_eucovidcert.id]
   description         = "${module.function_eucovidcert.name} health check failed"
   severity            = 1

--- a/src/domains/eucovidcert/_modules/resource_groups/main.tf
+++ b/src/domains/eucovidcert/_modules/resource_groups/main.tf
@@ -1,0 +1,8 @@
+terraform {
+
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}

--- a/src/domains/eucovidcert/_modules/resource_groups/outputs.tf
+++ b/src/domains/eucovidcert/_modules/resource_groups/outputs.tf
@@ -1,0 +1,7 @@
+output "resource_group_eucovidcert" {
+  value = {
+    id       = azurerm_resource_group.eucovidcert.id
+    name     = azurerm_resource_group.eucovidcert.name
+    location = azurerm_resource_group.eucovidcert.location
+  }
+}

--- a/src/domains/eucovidcert/_modules/resource_groups/resource_group_eucovidcert.tf
+++ b/src/domains/eucovidcert/_modules/resource_groups/resource_group_eucovidcert.tf
@@ -1,0 +1,6 @@
+resource "azurerm_resource_group" "eucovidcert" {
+  name     = "${var.project}-rg-eucovidcert"
+  location = var.location
+
+  tags = var.tags
+}

--- a/src/domains/eucovidcert/_modules/resource_groups/variables.tf
+++ b/src/domains/eucovidcert/_modules/resource_groups/variables.tf
@@ -1,0 +1,14 @@
+variable "project" {
+  type        = string
+  description = "IO prefix and short environment"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region"
+}
+
+variable "tags" {
+  type        = map(any)
+  description = "Resource tags"
+}

--- a/src/domains/eucovidcert/prod/westeurope/.terraform.lock.hcl
+++ b/src/domains/eucovidcert/prod/westeurope/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.96.0"
+  constraints = "<= 3.96.0"
+  hashes = [
+    "h1:o1BGLLHL33WaMjlUYSCr6zo7nuw4mKrpcLee14fSLc0=",
+    "zh:2fb3f3c309bc8b040cd63f3a5711d4a6fc107e653a760063ec3ee6417912d14d",
+    "zh:45b83f492bd371c837df6d68e96ee3ab89faa00f740bca915187b344fd795ae3",
+    "zh:4a8b9f31da14ae824b2358fe772bb03ee79283d3294985f2acb48a0d4cd950bb",
+    "zh:4ab3c38b6141a0bd52d9216383d256771c0bfdc1869dccf52f414ed04290ed35",
+    "zh:6772d182dde23ff3fe10497f104a866cfc1cb848988f830100247363f9dd9ef7",
+    "zh:85875de128bc2d119c63f16116773594345ad5d0e8a3b464f7612479900df640",
+    "zh:9cd696005f4cfab4662d7db81039a64fc4c66d6eeedddf0808f2e97bc8af25f4",
+    "zh:bdc8921161253d3bff8f951cbf63f73f856bbda0ee2e9f51af60d74464059d21",
+    "zh:d7320767f7cde3796906f453a99ba80284fe8479ce127a4703ecf45dd9ef1321",
+    "zh:e0c28b79c0bf5004a9d094a68ec0c887c7df307f2cedeed2cbbef567c61443c6",
+    "zh:f069aa8e951508ea812cb8fef73f79594212864014eb85db39cdea2c648f69ee",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/src/domains/eucovidcert/prod/westeurope/README.md
+++ b/src/domains/eucovidcert/prod/westeurope/README.md
@@ -1,0 +1,26 @@
+<!-- markdownlint-disable -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.96.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_resource_groups"></a> [resource\_groups](#module\_resource\_groups) | ../../_modules/resource_groups | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/src/domains/eucovidcert/prod/westeurope/locals.tf
+++ b/src/domains/eucovidcert/prod/westeurope/locals.tf
@@ -6,10 +6,10 @@ locals {
   location = "westeurope"
 
   tags = {
-    CostCenter     = "TS310 - PAGAMENTI & SERVIZI"
-    CreatedBy      = "Terraform"
-    Environment    = "Prod"
-    Owner          = "IO"
-    Source         = "https://github.com/pagopa/io-infra/blob/main/src/domains/eucovidcert/prod/westeurope"
+    CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
+    CreatedBy   = "Terraform"
+    Environment = "Prod"
+    Owner       = "IO"
+    Source      = "https://github.com/pagopa/io-infra/blob/main/src/domains/eucovidcert/prod/westeurope"
   }
 }

--- a/src/domains/eucovidcert/prod/westeurope/locals.tf
+++ b/src/domains/eucovidcert/prod/westeurope/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  prefix    = "io"
+  env_short = "p"
+  project   = "${local.prefix}-${local.env_short}"
+
+  location = "westeurope"
+
+  tags = {
+    CostCenter     = "TS310 - PAGAMENTI & SERVIZI"
+    CreatedBy      = "Terraform"
+    Environment    = "Prod"
+    Owner          = "IO"
+    ManagementTeam = "IO Comunicazione"
+    Source         = "https://github.com/pagopa/io-infra/blob/main/src/domains/eucovidcert/prod/westeurope"
+  }
+}

--- a/src/domains/eucovidcert/prod/westeurope/locals.tf
+++ b/src/domains/eucovidcert/prod/westeurope/locals.tf
@@ -10,7 +10,6 @@ locals {
     CreatedBy      = "Terraform"
     Environment    = "Prod"
     Owner          = "IO"
-    ManagementTeam = "IO Comunicazione"
     Source         = "https://github.com/pagopa/io-infra/blob/main/src/domains/eucovidcert/prod/westeurope"
   }
 }

--- a/src/domains/eucovidcert/prod/westeurope/main.tf
+++ b/src/domains/eucovidcert/prod/westeurope/main.tf
@@ -1,0 +1,20 @@
+terraform {
+
+  backend "azurerm" {
+    resource_group_name  = "terraform-state-rg"
+    storage_account_name = "tfinfprodio"
+    container_name       = "terraform-state"
+    key                  = "io-infra.eucovidcert.tfstate"
+  }
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "<= 3.96.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/src/domains/eucovidcert/prod/westeurope/resource_groups.tf
+++ b/src/domains/eucovidcert/prod/westeurope/resource_groups.tf
@@ -1,0 +1,8 @@
+module "resource_groups" {
+  source = "../../_modules/resource_groups"
+
+  location = local.location
+  project  = local.project
+
+  tags = local.tags
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Move resource group
CI/CD workflows

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Core refactoring

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
