### PR TITLE
[EC-217] Move EUCovidCert storage accounts to their own module

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -67,7 +67,6 @@
 | <a name="module_db_subscription_profileemails_container"></a> [db\_subscription\_profileemails\_container](#module\_db\_subscription\_profileemails\_container) | git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_sql_container | v7.61.0 |
 | <a name="module_dns_forwarder"></a> [dns\_forwarder](#module\_dns\_forwarder) | git::https://github.com/pagopa/terraform-azurerm-v3.git//dns_forwarder | v7.61.0 |
 | <a name="module_dns_forwarder_snet"></a> [dns\_forwarder\_snet](#module\_dns\_forwarder\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v7.61.0 |
-| <a name="module_eucovidcert_storage_account"></a> [eucovidcert\_storage\_account](#module\_eucovidcert\_storage\_account) | git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account | v7.61.0 |
 | <a name="module_event_hub"></a> [event\_hub](#module\_event\_hub) | git::https://github.com/pagopa/terraform-azurerm-v3.git//eventhub | v7.61.0 |
 | <a name="module_eventhub_snet"></a> [eventhub\_snet](#module\_eventhub\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v7.61.0 |
 | <a name="module_function_admin"></a> [function\_admin](#module\_function\_admin) | git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app | v7.61.0 |
@@ -500,6 +499,7 @@
 | [azurerm_storage_account.lollipop_assertions_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.notifications](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.push_notifications_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
+| [azurerm_storage_account.steucovid](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.storage_apievents](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.userbackups](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.userdatadownload](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |

--- a/src/core/function_eucovidcert.tf
+++ b/src/core/function_eucovidcert.tf
@@ -69,25 +69,9 @@ data "azurerm_resource_group" "eucovidcert_rg" {
   name = format("%s-rg-eucovidcert", local.project)
 }
 
-#
-# STORAGE
-#
-module "eucovidcert_storage_account" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v7.61.0"
-
-  name                            = "${replace(local.project, "-", "")}steucovidcert"
-  account_kind                    = "StorageV2"
-  account_tier                    = "Standard"
-  access_tier                     = "Hot"
-  blob_versioning_enabled         = false
-  account_replication_type        = "GZRS"
-  resource_group_name             = data.azurerm_resource_group.eucovidcert_rg.name
-  location                        = data.azurerm_resource_group.eucovidcert_rg.location
-  advanced_threat_protection      = false
-  allow_nested_items_to_be_public = false
-  public_network_access_enabled   = true
-
-  tags = var.tags
+data "azurerm_storage_account" "steucovid" {
+  name                = "${replace(local.project, "-", "")}steucovidcert"
+  resource_group_name = "${local.project}-rg-eucovidcert"
 }
 
 #
@@ -132,11 +116,11 @@ locals {
       DGC_LOAD_TEST_SERVER_CA   = trimspace(data.azurerm_key_vault_secret.fn_eucovidcert_DGC_LOAD_TEST_SERVER_CA.value)
 
       // Events configs
-      EventsQueueStorageConnection                    = module.eucovidcert_storage_account.primary_connection_string
+      EventsQueueStorageConnection                    = data.azurerm_storage_account.steucovid.primary_connection_string
       EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME          = "eucovidcert-profile-created"
-      QueueStorageConnection                          = module.eucovidcert_storage_account.primary_connection_string
+      QueueStorageConnection                          = data.azurerm_storage_account.steucovid.primary_connection_string
       EUCOVIDCERT_NOTIFY_NEW_PROFILE_QUEUE_NAME       = "notify-new-profile"
-      TableStorageConnection                          = module.eucovidcert_storage_account.primary_connection_string
+      TableStorageConnection                          = data.azurerm_storage_account.steucovid.primary_connection_string
       EUCOVIDCERT_TRACE_NOTIFY_NEW_PROFILE_TABLE_NAME = "TraceNotifyNewProfile"
 
       FNSERVICES_API_URL = join(",", formatlist("https://%s/api/v1", module.function_services.*.default_hostname))

--- a/src/domains/eucovidcert/_modules/storage_accounts/main.tf
+++ b/src/domains/eucovidcert/_modules/storage_accounts/main.tf
@@ -1,0 +1,8 @@
+terraform {
+
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}

--- a/src/domains/eucovidcert/_modules/storage_accounts/outputs.tf
+++ b/src/domains/eucovidcert/_modules/storage_accounts/outputs.tf
@@ -1,0 +1,7 @@
+output "storage_account_eucovidcert" {
+  value = {
+    id                  = module.storage_account_eucovidcert.id
+    name                = module.storage_account_eucovidcert.name
+    resource_group_name = var.resource_group_name
+  }
+}

--- a/src/domains/eucovidcert/_modules/storage_accounts/storage_account_eucovidcert.tf
+++ b/src/domains/eucovidcert/_modules/storage_accounts/storage_account_eucovidcert.tf
@@ -1,0 +1,17 @@
+module "storage_account_eucovidcert" {
+  source = "github.com/pagopa/terraform-azurerm-v3//storage_account?ref=v7.69.1"
+
+  name                            = "${replace(var.project, "-", "")}steucovidcert"
+  account_kind                    = "StorageV2"
+  account_tier                    = "Standard"
+  access_tier                     = "Hot"
+  blob_versioning_enabled         = false
+  account_replication_type        = "GZRS"
+  resource_group_name             = var.resource_group_name
+  location                        = var.location
+  advanced_threat_protection      = false
+  allow_nested_items_to_be_public = false
+  public_network_access_enabled   = true
+
+  tags = var.tags
+}

--- a/src/domains/eucovidcert/_modules/storage_accounts/variables.tf
+++ b/src/domains/eucovidcert/_modules/storage_accounts/variables.tf
@@ -1,0 +1,19 @@
+variable "project" {
+  type        = string
+  description = "IO prefix and short environment"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region"
+}
+
+variable "tags" {
+  type        = map(any)
+  description = "Resource tags"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group where resources will be created"
+}

--- a/src/domains/eucovidcert/prod/westeurope/.terraform.lock.hcl
+++ b/src/domains/eucovidcert/prod/westeurope/.terraform.lock.hcl
@@ -2,21 +2,46 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.96.0"
-  constraints = "<= 3.96.0"
+  version     = "3.94.0"
+  constraints = ">= 3.76.0, <= 3.94.0, <= 3.96.0"
   hashes = [
-    "h1:o1BGLLHL33WaMjlUYSCr6zo7nuw4mKrpcLee14fSLc0=",
-    "zh:2fb3f3c309bc8b040cd63f3a5711d4a6fc107e653a760063ec3ee6417912d14d",
-    "zh:45b83f492bd371c837df6d68e96ee3ab89faa00f740bca915187b344fd795ae3",
-    "zh:4a8b9f31da14ae824b2358fe772bb03ee79283d3294985f2acb48a0d4cd950bb",
-    "zh:4ab3c38b6141a0bd52d9216383d256771c0bfdc1869dccf52f414ed04290ed35",
-    "zh:6772d182dde23ff3fe10497f104a866cfc1cb848988f830100247363f9dd9ef7",
-    "zh:85875de128bc2d119c63f16116773594345ad5d0e8a3b464f7612479900df640",
-    "zh:9cd696005f4cfab4662d7db81039a64fc4c66d6eeedddf0808f2e97bc8af25f4",
-    "zh:bdc8921161253d3bff8f951cbf63f73f856bbda0ee2e9f51af60d74464059d21",
-    "zh:d7320767f7cde3796906f453a99ba80284fe8479ce127a4703ecf45dd9ef1321",
-    "zh:e0c28b79c0bf5004a9d094a68ec0c887c7df307f2cedeed2cbbef567c61443c6",
-    "zh:f069aa8e951508ea812cb8fef73f79594212864014eb85db39cdea2c648f69ee",
+    "h1:Kd1Vhk4bPbiP0ZWo1pDEW1De3oNbODgh2bhX9Y6AJ6I=",
+    "h1:a51ZYUp5uuboql399mflWZDrErlhhYz0ujJFsc9gjhg=",
+    "h1:a8L0H+sq8UBeArGs/jzQYEnJ2rNmR8Um3BOGBA1m1t8=",
+    "h1:t3fM/PO8PLAA5mK3esAypp01V6Vh75kjPnNqxQeVrV0=",
+    "zh:20d102bc63096ade82f8da81c91afaffa858aa56fe9a7ad02f24f5ae5618bc53",
+    "zh:3ddb9d6173a4fdb9b2352a76324ee321976915544ae66cbb863c7a60f0593f05",
+    "zh:4bc6c62142f67192d2def11f4fd419c54dddd89a5448af036bfc60b15eb0509a",
+    "zh:4c5120c2101a51524af32c4220c5e376f97a227730dd92ec0b06ac677e4b39f2",
+    "zh:585fa7ab876d09899cd2d842f12bc28c34556b4d47919eceadefab6fa47f909f",
+    "zh:59de7ea462470dee7088fc4deeff48e1ffd286eaca1185c219be68dadde745b8",
+    "zh:8421a46dd3bc4bc2eb56f7eb9b91cc84a66070b72195a805862c6022adee2da0",
+    "zh:a2fcb5a091d5944dc50f1e51f53fa4d370810a507fbf4122920d756083d8df19",
+    "zh:beb6b93a2a16942625bb6ac1e52bf26878e35f5562f3173279423ca66553b6d7",
+    "zh:c6846892ea68f49c838d90b75793d1f3a866871dd701ccb575b1eecccd4e7051",
+    "zh:ddd59492b6d5ce4c83f06a5b16c520048f3e9bb898bab4f3910042f5c01ffeda",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:m467k2tZ9cdFFgHW7LPBK2GLPH43LC6wc3ppxr8yvoE=",
+    "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
   ]
 }

--- a/src/domains/eucovidcert/prod/westeurope/README.md
+++ b/src/domains/eucovidcert/prod/westeurope/README.md
@@ -11,6 +11,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_resource_groups"></a> [resource\_groups](#module\_resource\_groups) | ../../_modules/resource_groups | n/a |
+| <a name="module_storage_accounts"></a> [storage\_accounts](#module\_storage\_accounts) | ../../_modules/storage_accounts | n/a |
 
 ## Resources
 

--- a/src/domains/eucovidcert/prod/westeurope/storage_accounts.tf
+++ b/src/domains/eucovidcert/prod/westeurope/storage_accounts.tf
@@ -1,0 +1,9 @@
+module "storage_accounts" {
+  source = "../../_modules/storage_accounts"
+
+  location            = local.location
+  project             = local.project
+  resource_group_name = module.resource_groups.resource_group_eucovidcert.name
+
+  tags = local.tags
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Move EUCovidCert storage accounts to their own module

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Core refactoring

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
