### PR TITLE
[SFEQS-2145] Added io-p-sign-rejected-test-requests alert rule and updated io-p-sign-rejected-requests

### DIFF
--- a/src/domains/sign/monitoring.tf
+++ b/src/domains/sign/monitoring.tf
@@ -95,6 +95,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "rejected_requests" {
   query = <<-QUERY
 customEvents
 | where name == "io.sign.signature_request.rejected"
+| where customDimensions.environment == "DEFAULT"
 | summarize AggregatedValue = count() by bin(timestamp, 30m)
 | where AggregatedValue > 1
   QUERY
@@ -113,6 +114,42 @@ customEvents
       azurerm_monitor_action_group.email_fci_tech.id,
       azurerm_monitor_action_group.slack_fci_tech.id,
       data.azurerm_monitor_action_group.error_action_group.id
+    ]
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "rejected_test_requests" {
+  name                = format("%s-rejected-test-requests", local.project)
+  resource_group_name = azurerm_resource_group.backend_rg.name
+  location            = azurerm_resource_group.backend_rg.location
+
+  data_source_id          = data.azurerm_application_insights.application_insights.id
+  description             = "[IO-SIGN] There are REJECTED signature requests in TEST environment"
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  query = <<-QUERY
+customEvents
+| where name == "io.sign.signature_request.rejected"
+| where customDimensions.environment == "TEST"
+| summarize AggregatedValue = count() by bin(timestamp, 30m)
+| where AggregatedValue > 1
+  QUERY
+
+  severity    = 3
+  frequency   = 30
+  time_window = 30
+
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 1
+  }
+
+  action {
+    action_group = [
+      azurerm_monitor_action_group.slack_fci_tech.id
     ]
   }
 

--- a/src/domains/sign/monitoring.tf
+++ b/src/domains/sign/monitoring.tf
@@ -126,7 +126,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "rejected_test_requests" 
   location            = azurerm_resource_group.backend_rg.location
 
   data_source_id          = data.azurerm_application_insights.application_insights.id
-  description             = "[IO-SIGN] There are REJECTED signature requests in TEST environment"
+  description             = "[IO-SIGN] There are REJECTED signature requests in TEST environment. No action required"
   enabled                 = true
   auto_mitigation_enabled = false
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Now the `io-p-sign-rejected-requests` alarm is triggered only for the rejected signature request in the production environment.
I've created the `io-p-sign-rejected-test-requests` alarm that is triggered only for those in testing and whose only action is to send a message to the FCI Slack group

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
