### PR TITLE
[#IOCOM-1221] Enabled runner subnet on staging slot

### DIFF
--- a/src/domains/messages-app/12_function_service_messages.tf
+++ b/src/domains/messages-app/12_function_service_messages.tf
@@ -19,6 +19,12 @@ data "azurerm_key_vault_secret" "internal_user" {
   key_vault_id = data.azurerm_key_vault.kv.id
 }
 
+data "azurerm_subnet" "runner_subnet" {
+  name                 = "${local.product}-github-runner-snet"
+  virtual_network_name = local.vnet_common_name
+  resource_group_name  = local.vnet_common_resource_group_name
+}
+
 locals {
   function_service_messages = {
     app_settings = {
@@ -185,6 +191,7 @@ module "function_service_messages_staging_slot" {
   allowed_subnets = [
     module.function_service_messages_snet.id,
     data.azurerm_subnet.azdoa_snet.id,
+    data.azurerm_subnet.runner_subnet.id
   ]
 
   allowed_ips = concat(

--- a/src/domains/messages-app/README.md
+++ b/src/domains/messages-app/README.md
@@ -113,6 +113,7 @@
 | [azurerm_subnet.app_backendl2_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.azdoa_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.private_endpoints_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_subnet.runner_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 | [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 | [azurerm_virtual_network.vnet_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |


### PR DESCRIPTION
### List of changes
Referenced github runner subnet.
Added github runner subnet to staging slot to allow healthcheck.

### Motivation and context
Deploy from gihub actions needs to do a healthcheck before swapping staging and prod slots.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD
