### PR TITLE
[IOCOM-1305] chore(infra): Added new management group

### DIFF
--- a/src/domains/messages-common/05_apim_v2.tf
+++ b/src/domains/messages-common/05_apim_v2.tf
@@ -3,6 +3,14 @@ data "azurerm_api_management" "apim_v2_api" {
   resource_group_name = local.apim_resource_group_name
 }
 
+resource "azurerm_api_management_group" "apiremotecontentconfigurationwrite" {
+  name                = "apiremotecontentconfigurationwrite"
+  api_management_name = data.azurerm_api_management.apim_v2_api.name
+  resource_group_name = data.azurerm_api_management.apim_v2_api.resource_group_name
+  display_name        = "ApiRemoteContentConfigurationWrite"
+  description         = "A group that enables to write and manage Remote Content Configuration"
+}
+
 resource "azurerm_api_management_group" "apithirdpartymessagewrite_v2" {
   name                = "apithirdpartymessagewrite"
   api_management_name = data.azurerm_api_management.apim_v2_api.name

--- a/src/domains/messages-common/README.md
+++ b/src/domains/messages-common/README.md
@@ -36,6 +36,7 @@
 | [azurerm_api_management_group.apinewmessagenotify_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group) | resource |
 | [azurerm_api_management_group.apipaymentupdater_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group) | resource |
 | [azurerm_api_management_group.apiremindernotify_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group) | resource |
+| [azurerm_api_management_group.apiremotecontentconfigurationwrite](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group) | resource |
 | [azurerm_api_management_group.apithirdpartymessagewrite_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group) | resource |
 | [azurerm_api_management_group_user.payment_group_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group_user) | resource |
 | [azurerm_api_management_group_user.reminder_group_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group_user) | resource |


### PR DESCRIPTION
### List of changes
Added ApiRemoteContentConfigurationWrite api management group.

### Motivation and context
We need to allow only users with ApiRemoteContentConfigurationWrite to call external RC Configurations management APIs.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD