### PR TITLE
[IOCOM-1313] Created two new APIs to point messages sending functions

### DIFF
--- a/src/domains/messages-common/05_apim_v2.tf
+++ b/src/domains/messages-common/05_apim_v2.tf
@@ -195,9 +195,9 @@ data "http" "messages_sending_external_openapi" {
 }
 
 module "apim_v2_messages_sending_external_api_v1" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api?ref=v7.69.1"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api?ref=v8.11.0"
 
-  name                  = format("%s-messages-sending-external-api", local.product)
+  name                  = format("%s-%s-messages-sending-external-api", local.product, var.location_short)
   api_management_name   = data.azurerm_api_management.apim_v2_api.name
   resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
   product_ids           = [data.azurerm_api_management_product.apim_v2_product_services.product_id]
@@ -220,9 +220,9 @@ data "http" "messages_sending_internal_openapi" {
 }
 
 module "apim_v2_messages_sending_internal_api_v1" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api?ref=v7.69.1"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api?ref=v8.11.0"
 
-  name                  = format("%s-messages-sending-internal-api", local.product)
+  name                  = format("%s-%s-messages-sending-internal-api", local.product, var.location_short)
   api_management_name   = data.azurerm_api_management.apim_v2_api.name
   resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
   product_ids           = [module.apim_v2_product_notifications.product_id]

--- a/src/domains/messages-common/05_apim_v2.tf
+++ b/src/domains/messages-common/05_apim_v2.tf
@@ -197,7 +197,7 @@ data "http" "messages_sending_external_openapi" {
 module "apim_v2_messages_sending_external_api_v1" {
   source = "git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api?ref=v8.11.0"
 
-  name                  = format("%s-%s-messages-sending-external-api", local.product, var.location_short)
+  name                  = format("%s-%s-messages-sending-external-api-01", local.product, var.location_short)
   api_management_name   = data.azurerm_api_management.apim_v2_api.name
   resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
   product_ids           = [data.azurerm_api_management_product.apim_v2_product_services.product_id]
@@ -222,7 +222,7 @@ data "http" "messages_sending_internal_openapi" {
 module "apim_v2_messages_sending_internal_api_v1" {
   source = "git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api?ref=v8.11.0"
 
-  name                  = format("%s-%s-messages-sending-internal-api", local.product, var.location_short)
+  name                  = format("%s-%s-messages-sending-internal-api-01", local.product, var.location_short)
   api_management_name   = data.azurerm_api_management.apim_v2_api.name
   resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
   product_ids           = [module.apim_v2_product_notifications.product_id]

--- a/src/domains/messages-common/05_apim_v2.tf
+++ b/src/domains/messages-common/05_apim_v2.tf
@@ -188,8 +188,60 @@ data "azurerm_api_management_product" "apim_v2_product_services" {
   resource_group_name = data.azurerm_api_management.apim_v2_api.resource_group_name
 }
 
+# APIM APIs
+
+data "http" "messages_sending_external_openapi" {
+  url = "https://raw.githubusercontent.com/pagopa/io-functions-services-messages/master/openapi/index_external.yaml"
+}
+
+module "apim_v2_messages_sending_external_api_v1" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api?ref=v7.69.1"
+
+  name                  = format("%s-messages-sending-external-api", local.product)
+  api_management_name   = data.azurerm_api_management.apim_v2_api.name
+  resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
+  product_ids           = [data.azurerm_api_management_product.apim_v2_product_services.product_id]
+  subscription_required = true
+  service_url           = null
+
+  description  = "IO Messages Sending - External - API"
+  display_name = "IO Messages Sending - External - API"
+  path         = "api/v1/messages-sending"
+  protocols    = ["https"]
+
+  content_format = "openapi"
+  content_value  = data.http.messages_sending_external_openapi.body
+
+  xml_content = file("./api/messages-sending/v1/_base_policy.xml")
+}
+
+data "http" "messages_sending_internal_openapi" {
+  url = "https://raw.githubusercontent.com/pagopa/io-functions-services-messages/master/openapi/index.yaml"
+}
+
+module "apim_v2_messages_sending_internal_api_v1" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api?ref=v7.69.1"
+
+  name                  = format("%s-messages-sending-internal-api", local.product)
+  api_management_name   = data.azurerm_api_management.apim_v2_api.name
+  resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
+  product_ids           = [module.apim_v2_product_notifications.product_id]
+  subscription_required = true
+  service_url           = null
+
+  description  = "IO Messages Sending - Internal - API"
+  display_name = "IO Messages Sending - Internal - API"
+  path         = "api/v1/messages-sending/internal"
+  protocols    = ["https"]
+
+  content_format = "openapi"
+  content_value  = data.http.messages_sending_internal_openapi.body
+
+  xml_content = file("./api/messages-sending/v1/_base_policy.xml")
+}
+
 data "http" "service_messages_manage_openapi" {
-  url = "https://raw.githubusercontent.com/pagopa/io-functions-service-messages/master/openapi/index_external.yaml"
+  url = "https://raw.githubusercontent.com/pagopa/io-functions-services-messages/833616dceab72bd65c4d3875c64eb75787b19258/openapi/index_external.yaml"
 }
 
 module "apim_v2_service_messages_manage_api_v1" {
@@ -214,7 +266,7 @@ module "apim_v2_service_messages_manage_api_v1" {
 }
 
 data "http" "service_messages_internal_openapi" {
-  url = "https://raw.githubusercontent.com/pagopa/io-functions-service-messages/master/openapi/index.yaml"
+  url = "https://raw.githubusercontent.com/pagopa/io-functions-services-messages/833616dceab72bd65c4d3875c64eb75787b19258/openapi/index.yaml"
 }
 
 module "apim_v2_service_messages_internal_api_v1" {

--- a/src/domains/messages-common/README.md
+++ b/src/domains/messages-common/README.md
@@ -12,6 +12,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_apim_v2_messages_sending_external_api_v1"></a> [apim\_v2\_messages\_sending\_external\_api\_v1](#module\_apim\_v2\_messages\_sending\_external\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v7.69.1 |
+| <a name="module_apim_v2_messages_sending_internal_api_v1"></a> [apim\_v2\_messages\_sending\_internal\_api\_v1](#module\_apim\_v2\_messages\_sending\_internal\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v7.69.1 |
 | <a name="module_apim_v2_product_notifications"></a> [apim\_v2\_product\_notifications](#module\_apim\_v2\_product\_notifications) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_product | v7.69.1 |
 | <a name="module_apim_v2_service_messages_internal_api_v1"></a> [apim\_v2\_service\_messages\_internal\_api\_v1](#module\_apim\_v2\_service\_messages\_internal\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v7.69.1 |
 | <a name="module_apim_v2_service_messages_manage_api_v1"></a> [apim\_v2\_service\_messages\_manage\_api\_v1](#module\_apim\_v2\_service\_messages\_manage\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v7.69.1 |
@@ -107,6 +109,8 @@
 | [azurerm_subnet.private_endpoints_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 | [azurerm_virtual_network.vnet_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
+| [http_http.messages_sending_external_openapi](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.messages_sending_internal_openapi](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [http_http.service_messages_internal_openapi](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [http_http.service_messages_manage_openapi](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 

--- a/src/domains/messages-common/README.md
+++ b/src/domains/messages-common/README.md
@@ -12,8 +12,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_apim_v2_messages_sending_external_api_v1"></a> [apim\_v2\_messages\_sending\_external\_api\_v1](#module\_apim\_v2\_messages\_sending\_external\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v7.69.1 |
-| <a name="module_apim_v2_messages_sending_internal_api_v1"></a> [apim\_v2\_messages\_sending\_internal\_api\_v1](#module\_apim\_v2\_messages\_sending\_internal\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v7.69.1 |
+| <a name="module_apim_v2_messages_sending_external_api_v1"></a> [apim\_v2\_messages\_sending\_external\_api\_v1](#module\_apim\_v2\_messages\_sending\_external\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v8.11.0 |
+| <a name="module_apim_v2_messages_sending_internal_api_v1"></a> [apim\_v2\_messages\_sending\_internal\_api\_v1](#module\_apim\_v2\_messages\_sending\_internal\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v8.11.0 |
 | <a name="module_apim_v2_product_notifications"></a> [apim\_v2\_product\_notifications](#module\_apim\_v2\_product\_notifications) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_product | v7.69.1 |
 | <a name="module_apim_v2_service_messages_internal_api_v1"></a> [apim\_v2\_service\_messages\_internal\_api\_v1](#module\_apim\_v2\_service\_messages\_internal\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v7.69.1 |
 | <a name="module_apim_v2_service_messages_manage_api_v1"></a> [apim\_v2\_service\_messages\_manage\_api\_v1](#module\_apim\_v2\_service\_messages\_manage\_api\_v1) | git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api | v7.69.1 |

--- a/src/domains/messages-common/api/messages-sending/v1/_base_policy.xml
+++ b/src/domains/messages-common/api/messages-sending/v1/_base_policy.xml
@@ -1,0 +1,24 @@
+<policies>
+    <inbound>
+        <base />
+        <set-backend-service base-url="https://io-p-messages-sending-func.azurewebsites.net/api/v1" />
+        <set-header name="x-functions-key" exists-action="override">
+            <value>{{io-p-messages-sending-func-key}}</value>
+        </set-header>
+        <set-header name="x-user-groups" exists-action="override">
+            <value>@(String.Join(",", context.User.Groups.Select(g => g.Name)))</value>
+        </set-header>
+        <set-header name="x-user-id" exists-action="override">
+            <value>@(context.User.Id)</value>
+        </set-header>  
+    </inbound>
+    <outbound>
+        <base />
+    </outbound>
+    <backend>
+        <base />
+    </backend>
+    <on-error>
+        <base />
+    </on-error>
+</policies>


### PR DESCRIPTION
### List of changes
Freezed old APIs openapi to 833616dceab72bd65c4d3875c64eb75787b19258 to continue working with old specs.
Added two new APIs that point new master openapi specs to serve the same functions on aligned paths.

### Motivation and context
We need to align external APIs path to existing ones.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources
