### PR TITLE
fix: datasource fetching resources previously migrated from itn to weu

### DIFF
--- a/src/core/function_app.tf
+++ b/src/core/function_app.tf
@@ -182,11 +182,11 @@ data "azurerm_subnet" "ioweb_profile_snet" {
   resource_group_name  = azurerm_resource_group.rg_common.name
 }
 
-# subnet for session-manager(located in italy north)
+# subnet for session-manager
 data "azurerm_subnet" "session_manager_snet" {
-  name                 = format("%s-itn-session-manager-snet-01", local.project)
-  virtual_network_name = format("%s-itn-common-vnet-01", local.project)
-  resource_group_name  = format("%s-itn-common-rg-01", local.project)
+  name                 = format("%s-weu-session-manager-snet-02", local.project)
+  virtual_network_name = format("%s-vnet-common", local.project)
+  resource_group_name  = format("%s-rg-common", local.project)
 }
 
 #tfsec:ignore:azure-storage-queue-services-logging-enabled:exp:2022-05-01 # already ignored, maybe a bug in tfsec


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Fixed datasource fetching resources previously migrated from itn to weu causing errors when applying.

<!--- Describe your changes in detail -->

### Motivation and context
The lack of the resources fetched by the datasource caused errors when applying io-infra core domain.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
