### PR TITLE
[IOCOM-1327] patch: added subscription id to headers

### DIFF
--- a/src/domains/citizen-auth-app/README.md
+++ b/src/domains/citizen-auth-app/README.md
@@ -53,7 +53,6 @@
 | [azurerm_key_vault.kv_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault_certificate_data.lollipop_certificate_v1](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate_data) | data source |
 | [azurerm_key_vault_secret.app_backend_ALLOWED_CIE_TEST_FISCAL_CODES](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.app_backend_LOLLIPOP_API_KEY](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_LV_TEST_USERS](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_SAML_CERT](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.app_backend_SAML_KEY](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |

--- a/src/domains/messages-common/api/messages-sending/v1/_base_policy_external.xml
+++ b/src/domains/messages-common/api/messages-sending/v1/_base_policy_external.xml
@@ -18,6 +18,9 @@
         <set-header name="x-user-id" exists-action="override">
             <value>@(context.User.Id)</value>
         </set-header>  
+        <set-header name="x-subscription-id" exists-action="override">
+            <value>@(context.Subscription.Id)</value>
+        </set-header>
     </inbound>
     <outbound>
         <base />

--- a/src/domains/messages-common/api/messages-sending/v1/_base_policy_internal.xml
+++ b/src/domains/messages-common/api/messages-sending/v1/_base_policy_internal.xml
@@ -11,6 +11,9 @@
         <set-header name="x-user-id" exists-action="override">
             <value>@(context.User.Id)</value>
         </set-header>  
+        <set-header name="x-subscription-id" exists-action="override">
+            <value>@(context.Subscription.Id)</value>
+        </set-header>
     </inbound>
     <outbound>
         <base />


### PR DESCRIPTION
### List of changes
Added subscription id to `x-subscription-id` header for Messages Sending Functions request.

### Motivation and context
We need to check that Remote Content Configuration management APIs are called with a `manage` subscription.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD
