### PR TITLE
Add azurerm_key_vault_access_policy to io-p-sign-backoffice-func/staging

### DIFF
--- a/src/domains/sign/99_main.tf
+++ b/src/domains/sign/99_main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "<= 3.86.0"
+      version = "<= 3.95.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/src/domains/sign/io_sign_backoffice_func.tf
+++ b/src/domains/sign/io_sign_backoffice_func.tf
@@ -77,7 +77,7 @@ resource "azurerm_key_vault_access_policy" "backoffice_func_key_vault_access_pol
 }
 
 module "io_sign_backoffice_func_staging_slot" {
-  source = "github.com/pagopa/terraform-azurerm-v3.git//function_app_slot?ref=v7.46.0"
+  source = "github.com/pagopa/terraform-azurerm-v3.git//function_app_slot?ref=v8.12.2"
 
   name                = "staging"
   location            = azurerm_resource_group.backend_rg.location
@@ -112,4 +112,14 @@ module "io_sign_backoffice_func_staging_slot" {
   ]
 
   tags = var.tags
+}
+
+resource "azurerm_key_vault_access_policy" "backoffice_func_staging_key_vault_access_policy" {
+  key_vault_id = module.key_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = module.io_sign_backoffice_func.system_identity_principal
+
+  secret_permissions      = ["Get"]
+  storage_permissions     = []
+  certificate_permissions = []
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

1. Add `azurerm_key_vault_access_policy` to the `staging` slot of `io-p-sign-backoffice-func`
2. Update `github.com/pagopa/terraform-azurerm-v3.git//function_app_slot` ref to the latest version

<!--- Describe your changes in detail -->

### Motivation and context
This policy is required to access the slot settings (that are written as key vault references). The lack of this policy cause the failure of the `staging` health probe.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
