### PR TITLE
[#IOPID-1869] Add Lock profile storage envs to SessionManager

### DIFF
--- a/src/domains/citizen-auth-app/06_storage.tf
+++ b/src/domains/citizen-auth-app/06_storage.tf
@@ -12,3 +12,9 @@ data "azurerm_storage_account" "logs" {
   name                = replace(format("%s-stlogs", local.product), "-", "")
   resource_group_name = format("%s-rg-operations", local.product)
 }
+
+
+data "azurerm_storage_account" "locked_profiles_storage" {
+  name                = replace(format("%s-locked-profiles-st", local.product), "-", "")
+  resource_group_name = format("%s-rg-internal", local.product)
+}

--- a/src/domains/citizen-auth-app/08_session_manager.tf
+++ b/src/domains/citizen-auth-app/08_session_manager.tf
@@ -117,6 +117,10 @@ locals {
 
     BACKEND_HOST = "https://${trimsuffix(data.azurerm_dns_a_record.api_app_io_pagopa_it.fqdn, ".")}"
 
+    # Locked profile storage
+    LOCKED_PROFILES_STORAGE_CONNECTION_STRING = data.azurerm_storage_account.locked_profiles_storage.primary_connection_string
+    LOCKED_PROFILES_TABLE_NAME                = "lockedprofiles"
+
     # Spid logs config
     SPID_LOG_QUEUE_NAME                = "spidmsgitems"
     SPID_LOG_STORAGE_CONNECTION_STRING = data.azurerm_storage_account.logs.primary_connection_string

--- a/src/domains/citizen-auth-app/README.md
+++ b/src/domains/citizen-auth-app/README.md
@@ -87,6 +87,7 @@
 | [azurerm_resource_group.monitor_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.rg_external](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account.immutable_lv_audit_logs_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
+| [azurerm_storage_account.locked_profiles_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.lollipop_assertion_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_subnet.apim_v2_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Import Lock Session storage data in citizen auth domain
Add required env variables to Session Manager app service config
<!--- Describe your changes in detail -->

### Motivation and context
New features porting to Session Manager requires new env variables
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
