### PR TITLE
[EC-307] Fix for terraform_validate pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,8 @@ repos:
         args:
           - --args=--exclude-downloaded-modules
       - id: terraform_validate
+        exclude: '(\/_?modules\/.*)'
         args:
+          - --tf-init-args=-lockfile=readonly
           - --args=-json
           - --args=-no-color
-          - --hook-config=--retry-once-with-cleanup=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.0
+    rev: v1.90.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -9,8 +9,8 @@ repos:
       - id: terraform_tfsec
         args:
           - --args=--exclude-downloaded-modules
-      # - id: terraform_validate
-      #   args:
-      #     - --init-args=-lockfile=readonly
-      #     - --args=-json
-      #     - --args=-no-color
+      - id: terraform_validate
+        args:
+          - --args=-json
+          - --args=-no-color
+          - --hook-config=--retry-once-with-cleanup=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.90.0
+    rev: v1.83.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- Re-enabled the terraform_validate pre-commit check.
- Excluded all paths that contain the "modules" or "_modules" folder from the terraform_validate check

<!--- Describe your changes in detail -->

### Motivation and context
With the introduction of the repository structure suggested in this [RFC](https://pagopa.atlassian.net/wiki/spaces/ENG/pages/910492147/RFC-ENG+Riorganizzazione+configurazioni+Terraform), the terraform_validate pre-commit check began failing for each child module with the following error:

```
This configuration requires provider registry.terraform.io/hashicorp/azurerm, but that provider isn't available. You may be able to install it automatically by running:
  terraform init
```

The issue is caused by the recursive run of "terraform validate" commands both on root and child modules. The latter, by nature, shouldn't be initialized and checked, since the provider is inherited from the root module.

For this reason, terraform_validate checks must be disabled for child modules.

Excluding child modules from the check, however, doesn't prevent from validating its code. 
In fact, they are validated at the root module level as seen in the following example:


```
Terraform validate......................................................................Failed
- hook id: terraform_validate
- exit code: 1

Validation failed: src/domains/selfcare/prod/westeurope

{
  "format_version": "1.0",
  "valid": false,
  "error_count": 2,
  "warning_count": 0,
  "diagnostics": [
    {
      "severity": "error",
      "summary": "Missing required argument",
      "detail": "The argument \"location\" is required, but no definition was found.",
      "range": {
        "filename": "../../**_modules**/app_services/autoscalers.tf",
        "start": {
          "line": 1,
          "column": 78,
          "byte": 77
        },
        "end": {
          "line": 1,
          "column": 79,
          "byte": 78
        }
      },
      "snippet": {
        "context": "resource \"azurerm_monitor_autoscale_setting\" \"appservice_selfcare_be_common\"",
        "code": "resource \"azurerm_monitor_autoscale_setting\" \"appservice_selfcare_be_common\" {",
        "start_line": 1,
        "highlight_start_offset": 77,
        "highlight_end_offset": 78,
        "values": []
      }
    },
   . . .
  ]
}
```

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Tried to update the pre-commit check revision to the 1.90.0. However, terraform_tfsec check would fail due to security issues. Would be nice to analyze and evaluate such issues in another PR.
---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
