### PR TITLE
[#IOPID-1768 / 2] Move io-backend path to path-based routing

### DIFF
--- a/src/core/appgateway.tf
+++ b/src/core/appgateway.tf
@@ -70,6 +70,20 @@ module "app_gw" {
       request_timeout             = 10
       pick_host_name_from_backend = true
     }
+   
+    session-manager-app = {
+      protocol     = "Https"
+      host         = null
+      port         = 443
+      ip_addresses = null # with null value use fqdns
+      fqdns = [
+        data.azurerm_linux_web_app.session_manager.default_hostname
+      ]
+      probe                       = "/healthcheck"
+      probe_name                  = "probe-session-manager-app"
+      request_timeout             = 10
+      pick_host_name_from_backend = true
+    }
 
     session-manager-app = {
       protocol     = "Https"

--- a/src/core/appgateway.tf
+++ b/src/core/appgateway.tf
@@ -70,7 +70,7 @@ module "app_gw" {
       request_timeout             = 10
       pick_host_name_from_backend = true
     }
-   
+
     session-manager-app = {
       protocol     = "Https"
       host         = null

--- a/src/core/appgateway.tf
+++ b/src/core/appgateway.tf
@@ -106,20 +106,6 @@ module "app_gw" {
       pick_host_name_from_backend = true
     }
 
-    session-manager-app = {
-      protocol     = "Https"
-      host         = null
-      port         = 443
-      ip_addresses = null # with null value use fqdns
-      fqdns = [
-        data.azurerm_linux_web_app.session_manager.default_hostname
-      ]
-      probe                       = "/healthcheck"
-      probe_name                  = "probe-session-manager-app"
-      request_timeout             = 10
-      pick_host_name_from_backend = true
-    }
-
     developerportal-backend = {
       protocol     = "Https"
       host         = null

--- a/src/core/appgateway.tf
+++ b/src/core/appgateway.tf
@@ -24,6 +24,27 @@ module "appgateway_snet" {
   ]
 }
 
+
+locals {
+  io_backend_ip_headers_rule = {
+    name          = "http-headers-api-app"
+    rule_sequence = 100
+    conditions    = []
+    url           = null
+    request_header_configurations = [
+      {
+        header_name  = "X-Forwarded-For"
+        header_value = "{var_client_ip}"
+      },
+      {
+        header_name  = "X-Client-Ip"
+        header_value = "{var_client_ip}"
+      },
+    ]
+    response_header_configurations = []
+  }
+}
+
 ## Application gateway ##
 module "app_gw" {
   source = "github.com/pagopa/terraform-azurerm-v3.git//app_gateway?ref=v8.20.0"
@@ -440,25 +461,12 @@ module "app_gw" {
       priority              = 10
     }
 
-    api-app-io-pagopa-it = {
-      listener              = "api-app-io-pagopa-it"
-      backend               = "appbackend-app"
-      rewrite_rule_set_name = "rewrite-rule-set-api-app"
-      priority              = 70
-    }
 
     api-web-io-pagopa-it = {
       listener              = "api-web-io-pagopa-it"
       backend               = "apim"
       rewrite_rule_set_name = "rewrite-rule-set-api-web"
       priority              = 100
-    }
-
-    app-backend-io-italia-it = {
-      listener              = "app-backend-io-italia-it"
-      backend               = "appbackend-app"
-      rewrite_rule_set_name = "rewrite-rule-set-api-app"
-      priority              = 40
     }
 
     developerportal-backend-io-italia-it = {
@@ -501,6 +509,34 @@ module "app_gw" {
       backend               = "apim"
       rewrite_rule_set_name = "rewrite-rule-set-openid-provider-io"
       priority              = 120
+    }
+  }
+
+  routes_path_based = {
+    app-backend-io-italia-it = {
+      listener     = "app-backend-io-italia-it"
+      url_map_name = "io-backend-path-based-rule"
+      priority     = 40
+    }
+
+    api-app-io-pagopa-it = {
+      listener     = "api-app-io-pagopa-it"
+      url_map_name = "io-backend-path-based-rule"
+      priority     = 70
+    }
+  }
+
+  url_path_map = {
+    io-backend-path-based-rule = {
+      default_backend               = "appbackend-app"
+      default_rewrite_rule_set_name = "rewrite-rule-set-api-app"
+      path_rule = {
+        healthcheck = {
+          paths                 = ["/healthcheck"]
+          backend               = "appbackend-app",
+          rewrite_rule_set_name = "rewrite-rule-set-api-app"
+        },
+      }
     }
   }
 
@@ -556,24 +592,8 @@ module "app_gw" {
       }]
     },
     {
-      name = "rewrite-rule-set-api-app"
-      rewrite_rules = [{
-        name          = "http-headers-api-app"
-        rule_sequence = 100
-        conditions    = []
-        url           = null
-        request_header_configurations = [
-          {
-            header_name  = "X-Forwarded-For"
-            header_value = "{var_client_ip}"
-          },
-          {
-            header_name  = "X-Client-Ip"
-            header_value = "{var_client_ip}"
-          },
-        ]
-        response_header_configurations = []
-      }]
+      name          = "rewrite-rule-set-api-app"
+      rewrite_rules = [local.io_backend_ip_headers_rule]
     },
     {
       name = "rewrite-rule-set-api-web"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR depends on https://github.com/pagopa/io-infra/pull/1007

### List of changes

<!--- Describe your changes in detail -->

- Move io-backend path to path-based routing
- Add `healthcheck` path rule for testing
- Move "http-headers-api-app" rewrite rule to local variable

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Enable beta routing for Session Manager / Step 1

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
