### PR TITLE
[IOCOM-1485] Allow fims-op to make requests to session-manager

### DIFF
--- a/src/domains/citizen-auth-app/01_network.tf
+++ b/src/domains/citizen-auth-app/01_network.tf
@@ -80,6 +80,12 @@ data "azurerm_subnet" "ioweb_profile_snet" {
   resource_group_name  = local.vnet_common_resource_group_name
 }
 
+data "azurerm_subnet" "fims_op_app_snet_01" {
+  name                 = "io-p-weu-fims-op-app-snet-01"
+  virtual_network_name = local.vnet_common_name
+  resource_group_name  = local.vnet_common_resource_group_name
+}
+
 data "azurerm_subnet" "apim_v2_snet" {
   name                 = "apimv2api"
   virtual_network_name = local.vnet_common_name

--- a/src/domains/citizen-auth-app/08_session_manager.tf
+++ b/src/domains/citizen-auth-app/08_session_manager.tf
@@ -230,7 +230,8 @@ module "session_manager_weu" {
 
   allowed_subnets = [
     data.azurerm_subnet.apim_v2_snet.id,
-    data.azurerm_subnet.appgateway_snet.id
+    data.azurerm_subnet.appgateway_snet.id,
+    data.azurerm_subnet.fims_op_app_snet_01.id
     // TODO: add proxy subnet
   ]
   allowed_ips = []

--- a/src/domains/citizen-auth-app/README.md
+++ b/src/domains/citizen-auth-app/README.md
@@ -106,6 +106,7 @@
 | [azurerm_subnet.app_backend_l2_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.appgateway_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.azdoa_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_subnet.fims_op_app_snet_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.ioweb_profile_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.private_endpoints_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.self_hosted_runner_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
1. Add `io-p-weu-fims-op-app-snet-01` to `io-p-weu-session-manager-app-02` allowed subnets.

<!--- Describe your changes in detail -->

### Motivation and context
`io-p-weu-fims-op-app` makes use of some APIs exposed by the session manager that are not yet in production (not accessible via APIM/APP GW). So, until the new session manager is released in production, it will consume those APIs by making internal calls.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
