### PR TITLE
Added subnet to backend li to allow calls from itn-msgs-sending-func

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -372,6 +372,7 @@
 | [azurerm_subnet.function_let_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.functions_fast_login_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.functions_service_messages_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_subnet.itn_msgs_sending_func_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.services_cms_backoffice_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.services_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |

--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -741,6 +741,12 @@ data "azurerm_subnet" "functions_service_messages_snet" {
   resource_group_name  = azurerm_resource_group.rg_common.name
 }
 
+data "azurerm_subnet" "itn_msgs_sending_func_snet" {
+  name                 = "io-p-itn-msgs-sending-func-snet-01"
+  virtual_network_name = "io-p-itn-common-vnet-01"
+  resource_group_name  = "io-p-itn-common-rg-01"
+}
+
 module "appservice_app_backendl1" {
   source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//app_service?ref=v7.61.0"
 
@@ -1270,6 +1276,7 @@ module "appservice_app_backendli" {
     data.azurerm_subnet.admin_snet.id,
     data.azurerm_subnet.functions_fast_login_snet.id,
     data.azurerm_subnet.functions_service_messages_snet.id,
+    data.azurerm_subnet.itn_msgs_sending_func_snet.id,
   ]
 
   allowed_ips = concat(


### PR DESCRIPTION
### List of changes
Added a subnet to backendli appservice whitelist.

### Motivation and context
We need to call backendli from itn-msgs-sending-func to resolve sessions

### Type of changes
- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply
- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [ ] No

### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
