### PR TITLE
Fixed sticky settings for push-notif functions

### DIFF
--- a/src/domains/messages-app/07_function_pushnotif.tf
+++ b/src/domains/messages-app/07_function_pushnotif.tf
@@ -160,12 +160,14 @@ module "push_notif_function" {
 
   app_settings = merge(
     local.function_push_notif.app_settings_common, {
-      "AzureWebJobs.HandleNHNotificationCall.Disabled" = "0"
+      "AzureWebJobs.HandleNHNotificationCall.Disabled"               = "0",
+      "AzureWebJobs.HandleNHNotifyMessageCallActivityQueue.Disabled" = "0"
     }
   )
 
   sticky_app_setting_names = [
-    "AzureWebJobs.HandleNHNotificationCall.Disabled"
+    "AzureWebJobs.HandleNHNotificationCall.Disabled",
+    "AzureWebJobs.HandleNHNotifyMessageCallActivityQueue.Disabled"
   ]
 
   subnet_id = module.push_notif_snet.id
@@ -212,7 +214,8 @@ module "push_notif_function_staging_slot" {
 
   app_settings = merge(
     local.function_push_notif.app_settings_common, {
-      "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1"
+      "AzureWebJobs.HandleNHNotificationCall.Disabled"               = "1",
+      "AzureWebJobs.HandleNHNotifyMessageCallActivityQueue.Disabled" = "1"
     }
   )
 


### PR DESCRIPTION
### List of changes
Added sticky setting to avoid processing on staging slot

### Motivation and context
We noticed that some processing was starting on staging slot

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No