### PR TITLE
Update fims-op-app rewrite rule in appgateway

### DIFF
--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -362,6 +362,11 @@ variable "app_gateway_api_io_selfcare_pagopa_it_certificate_name" {
   description = "Application gateway api certificate name on Key Vault"
 }
 
+variable "app_gateway_oauth_io_pagopa_it_certificate_name" {
+  type        = string
+  description = "Application gateway oauth certificate name on Key Vault"
+}
+
 variable "app_gateway_firmaconio_selfcare_pagopa_it_certificate_name" {
   type        = string
   description = "Application gateway api certificate name on Key Vault"
@@ -375,11 +380,6 @@ variable "app_gateway_continua_io_pagopa_it_certificate_name" {
 variable "app_gateway_selfcare_io_pagopa_it_certificate_name" {
   type        = string
   description = "Application gateway selfcare-io certificate name on Key Vault"
-}
-
-variable "app_gateway_openid_provider_io_pagopa_it_certificate_name" {
-  type        = string
-  description = "Application gateway openid-provider certificate name on Key Vault"
 }
 
 variable "app_gateway_min_capacity" {

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -290,6 +290,7 @@
 | [azurerm_key_vault_certificate.app_gw_continua](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
 | [azurerm_key_vault_certificate.app_gw_developerportal_backend_io_italia_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
 | [azurerm_key_vault_certificate.app_gw_firmaconio_selfcare_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
+| [azurerm_key_vault_certificate.app_gw_oauth](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
 | [azurerm_key_vault_certificate.app_gw_openid_provider_io](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
 | [azurerm_key_vault_certificate.app_gw_selfcare_io](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
 | [azurerm_key_vault_secret.alert_error_notification_email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -291,7 +291,6 @@
 | [azurerm_key_vault_certificate.app_gw_developerportal_backend_io_italia_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
 | [azurerm_key_vault_certificate.app_gw_firmaconio_selfcare_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
 | [azurerm_key_vault_certificate.app_gw_oauth](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
-| [azurerm_key_vault_certificate.app_gw_openid_provider_io](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
 | [azurerm_key_vault_certificate.app_gw_selfcare_io](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
 | [azurerm_key_vault_secret.alert_error_notification_email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.alert_error_notification_opsgenie](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
@@ -409,7 +408,7 @@
 | <a name="input_app_gateway_firmaconio_selfcare_pagopa_it_certificate_name"></a> [app\_gateway\_firmaconio\_selfcare\_pagopa\_it\_certificate\_name](#input\_app\_gateway\_firmaconio\_selfcare\_pagopa\_it\_certificate\_name) | Application gateway api certificate name on Key Vault | `string` | n/a | yes |
 | <a name="input_app_gateway_max_capacity"></a> [app\_gateway\_max\_capacity](#input\_app\_gateway\_max\_capacity) | n/a | `number` | `2` | no |
 | <a name="input_app_gateway_min_capacity"></a> [app\_gateway\_min\_capacity](#input\_app\_gateway\_min\_capacity) | n/a | `number` | `0` | no |
-| <a name="input_app_gateway_openid_provider_io_pagopa_it_certificate_name"></a> [app\_gateway\_openid\_provider\_io\_pagopa\_it\_certificate\_name](#input\_app\_gateway\_openid\_provider\_io\_pagopa\_it\_certificate\_name) | Application gateway openid-provider certificate name on Key Vault | `string` | n/a | yes |
+| <a name="input_app_gateway_oauth_io_pagopa_it_certificate_name"></a> [app\_gateway\_oauth\_io\_pagopa\_it\_certificate\_name](#input\_app\_gateway\_oauth\_io\_pagopa\_it\_certificate\_name) | Application gateway oauth certificate name on Key Vault | `string` | n/a | yes |
 | <a name="input_app_gateway_selfcare_io_pagopa_it_certificate_name"></a> [app\_gateway\_selfcare\_io\_pagopa\_it\_certificate\_name](#input\_app\_gateway\_selfcare\_io\_pagopa\_it\_certificate\_name) | Application gateway selfcare-io certificate name on Key Vault | `string` | n/a | yes |
 | <a name="input_application_insights_name"></a> [application\_insights\_name](#input\_application\_insights\_name) | The common Application Insights name | `string` | `""` | no |
 | <a name="input_azdo_sp_tls_cert_enabled"></a> [azdo\_sp\_tls\_cert\_enabled](#input\_azdo\_sp\_tls\_cert\_enabled) | Enable Azure DevOps connection for TLS cert management | `string` | `false` | no |

--- a/src/core/appgateway.tf
+++ b/src/core/appgateway.tf
@@ -1114,11 +1114,6 @@ data "azurerm_key_vault_certificate" "app_gw_selfcare_io" {
   key_vault_id = module.key_vault.id
 }
 
-data "azurerm_key_vault_certificate" "app_gw_openid_provider_io" {
-  name         = var.app_gateway_openid_provider_io_pagopa_it_certificate_name
-  key_vault_id = module.key_vault.id
-}
-
 data "azurerm_key_vault_secret" "app_gw_mtls_header_name" {
   name         = "mtls-header-name"
   key_vault_id = module.key_vault.id

--- a/src/core/appgateway.tf
+++ b/src/core/appgateway.tf
@@ -508,7 +508,7 @@ module "app_gw" {
       listener              = "oauth-io-pagopa-it"
       backend               = "fims-op-app"
       rewrite_rule_set_name = "rewrite-rule-set-fims-op-app"
-      priority              = 80
+      priority              = 120
     }
   }
 
@@ -1105,7 +1105,7 @@ data "azurerm_key_vault_certificate" "app_gw_continua" {
 }
 
 data "azurerm_key_vault_certificate" "app_gw_oauth" {
-  name         = var.app_gateway_continua_io_pagopa_it_certificate_name
+  name         = var.app_gateway_oauth_io_pagopa_it_certificate_name
   key_vault_id = module.key_vault.id
 }
 

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -74,7 +74,7 @@ app_gateway_api_io_selfcare_pagopa_it_certificate_name            = "api-io-self
 app_gateway_firmaconio_selfcare_pagopa_it_certificate_name        = "firmaconio-selfcare-pagopa-it"
 app_gateway_continua_io_pagopa_it_certificate_name                = "continua-io-pagopa-it"
 app_gateway_selfcare_io_pagopa_it_certificate_name                = "selfcare-io-pagopa-it"
-app_gateway_openid_provider_io_pagopa_it_certificate_name         = "openid-provider-io-pagopa-it"
+app_gateway_oauth_io_pagopa_it_certificate_name                   = "oauth-io-pagopa-it"
 app_gateway_min_capacity                                          = 4 # 4 capacity=baseline, 10 capacity=high volume event, 15 capacity=very high volume event
 app_gateway_max_capacity                                          = 50
 app_gateway_alerts_enabled                                        = true


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
1. update the rewrite rule of `fims-op-app` to map the backend to `auth.io.pagopa.it` instead of `api-app.io.italia.it/oauth2`

<!--- Describe your changes in detail -->

### Motivation and context
`api-app.io.italia.it` is reserved for APIs consumed by the IO app, but `fims-op-app` should also be accessible to third parties.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
