### PR TITLE
[#IOPID-2001] Appinsight connection string fn-lollipop

### DIFF
--- a/src/domains/citizen-auth-app/04_function_lollipop.tf
+++ b/src/domains/citizen-auth-app/04_function_lollipop.tf
@@ -48,8 +48,7 @@ locals {
       FIRST_LC_ASSERTION_CLIENT_SUBSCRIPTION_KEY = data.azurerm_key_vault_secret.first_lollipop_consumer_subscription_key.value
 
       # APPINSIGHTS
-      APPINSIGHTS_CONNECTION_STRING = data.azurerm_application_insights.application_insights.connection_string
-
+      APPLICATIONINSIGHTS_CONNECTION_STRING = data.azurerm_application_insights.application_insights.connection_string
     }
 
     # Scaling strategy

--- a/src/domains/citizen-auth-app/04_function_lollipop.tf
+++ b/src/domains/citizen-auth-app/04_function_lollipop.tf
@@ -193,7 +193,7 @@ module "function_lollipop_itn" {
     APPINSIGHTS_CLOUD_ROLE_NAME = local.function_name },
   )
 
-  sticky_app_setting_names = ["AzureWebJobs.HandlePubKeyRevoke.Disabled"]
+  sticky_app_setting_names = ["AzureWebJobs.HandlePubKeyRevoke.Disabled", "APPINSIGHTS_CLOUD_ROLE_NAME"]
 
   internal_storage = {
     "enable"                     = true,

--- a/src/domains/citizen-auth-app/04_function_lollipop.tf
+++ b/src/domains/citizen-auth-app/04_function_lollipop.tf
@@ -49,6 +49,13 @@ locals {
 
       # APPINSIGHTS
       APPLICATIONINSIGHTS_CONNECTION_STRING = data.azurerm_application_insights.application_insights.connection_string
+      // NOTE: the following variable ensures that the applicationinsights
+      // nodejs sdk doesn't include additional headers towards requests on all
+      // type of storage accounts. without the following, all requests would
+      // fail for an unexpected signature from the storage account. to support
+      // the storage-account calls, a migration from `azure-storage` to
+      // `@azure/...` sdks is needed (see https://www.npmjs.com/package/diagnostic-channel-publishers/v/1.0.8#currently-supported-modules)
+      APPINSIGHTS_EXCLUDED_DOMAINS = "queue.core.windows.net,blob.core.windows.net,table.core.windows.net,file.core.windows.net"
     }
 
     # Scaling strategy


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add the App Insights connection string as env variale
Add Cloud Rolename env variable
<!--- Describe your changes in detail -->

### Motivation and context
To upgrade the appinsights javascirpt sdk the connection string is required instead of the Instrumentation Key.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
