### PR TITLE
[#IOPID-2042] Routing `test-login` endpoint to Session Manager

### DIFF
--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -160,7 +160,7 @@ locals {
       FF_ROUTING_PUSH_NOTIF_CANARY_SHA_USERS_REGEX = "^([(0-9)|(a-f)|(A-F)]{63}[(0-4)]{1})$"
 
       FF_PN_ACTIVATION_ENABLED = "1"
-      FF_TRIAL_SYSTEM_ENABLED  = "0"
+      FF_TRIAL_SYSTEM_ENABLED  = "1"
 
       // TEST LOGIN
       TEST_LOGIN_PASSWORD     = data.azurerm_key_vault_secret.app_backend_TEST_LOGIN_PASSWORD.value

--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -25,6 +25,9 @@ locals {
       FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
       FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
+      // see https://learn.microsoft.com/en-us/azure/app-service/monitor-instances-health-check?tabs=dotnet#configuration
+      WEBSITE_HEALTHCHECK_MAXUNHEALTHYWORKERPERCENT = "95"
+
       // SPID
       SAML_CALLBACK_URL                      = "https://app-backend.io.italia.it/assertionConsumerService"
       SAML_CERT                              = trimspace(data.azurerm_key_vault_secret.app_backend_SAML_CERT.value)

--- a/src/core/appgateway.tf
+++ b/src/core/appgateway.tf
@@ -543,8 +543,8 @@ module "app_gw" {
         },
         test-login = {
           paths                 = ["/test-login"]
-          backend               = "appbackend-app",
-          rewrite_rule_set_name = "rewrite-rule-set-api-app-rewrite-to-session-manager"
+          backend               = "session-manager-app",
+          rewrite_rule_set_name = "rewrite-rule-set-api-app"
         },
         login = {
           paths                 = ["/login"]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
The path rules for `test-login` endpoint now redirect the API to the `session-manager` backend pool and apply the default rewrite rule.
<!--- Describe your changes in detail -->

### Motivation and context
To perform the rollout in production of the session manager the `test-login` endpoint is migrated.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
