### PR TITLE
[EC-359] Tuning function messages autoscale rules

### DIFF
--- a/src/domains/messages-app/07_function_pushnotif.tf
+++ b/src/domains/messages-app/07_function_pushnotif.tf
@@ -111,7 +111,9 @@ module "push_notif_function" {
   name                = format("%s-push-notif-fn", local.product)
   domain              = upper(var.domain)
   location            = var.location
-  health_check_path   = "/api/v1/info"
+
+  health_check_path            = "/api/v1/info"
+  health_check_maxpingfailures = 2
 
   runtime_version                          = "~4"
   node_version                             = "18"
@@ -200,7 +202,9 @@ module "push_notif_function_staging_slot" {
   resource_group_name = azurerm_resource_group.push_notif_rg.name
   function_app_id     = module.push_notif_function[0].id
   app_service_plan_id = module.push_notif_function[0].app_service_plan_id
-  health_check_path   = "/api/v1/info"
+
+  health_check_path            = "/api/v1/info"
+  health_check_maxpingfailures = 2
 
   storage_account_name       = module.push_notif_function[0].storage_account.name
   storage_account_access_key = module.push_notif_function[0].storage_account.primary_access_key
@@ -235,7 +239,7 @@ module "push_notif_function_staging_slot" {
 
 resource "azurerm_monitor_autoscale_setting" "push_notif_function" {
   count               = var.push_notif_enabled ? 1 : 0
-  name                = format("%s-autoscale", module.push_notif_function[0].name)
+  name                = format("%s-as-01", module.push_notif_function[0].name)
   resource_group_name = azurerm_resource_group.push_notif_rg.name
   location            = var.location
   target_resource_id  = module.push_notif_function[0].app_service_plan_id
@@ -244,9 +248,9 @@ resource "azurerm_monitor_autoscale_setting" "push_notif_function" {
     name = "default"
 
     capacity {
-      default = var.push_notif_function_autoscale_default
-      minimum = var.push_notif_function_autoscale_minimum
-      maximum = var.push_notif_function_autoscale_maximum
+      default = 3
+      minimum = 2
+      maximum = 6
     }
 
     rule {
@@ -259,15 +263,15 @@ resource "azurerm_monitor_autoscale_setting" "push_notif_function" {
         time_window              = "PT1M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 3000
-        divide_by_instance_count = false
+        threshold                = 500
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
         value     = "2"
-        cooldown  = "PT5M"
+        cooldown  = "PT2M"
       }
     }
 
@@ -289,7 +293,7 @@ resource "azurerm_monitor_autoscale_setting" "push_notif_function" {
         direction = "Increase"
         type      = "ChangeCount"
         value     = "2"
-        cooldown  = "PT5M"
+        cooldown  = "PT3M"
       }
     }
 
@@ -300,18 +304,18 @@ resource "azurerm_monitor_autoscale_setting" "push_notif_function" {
         metric_namespace         = "microsoft.web/sites"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT15M"
+        time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 2000
-        divide_by_instance_count = false
+        threshold                = 200
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT10M"
+        cooldown  = "PT0M"
       }
     }
 
@@ -325,7 +329,7 @@ resource "azurerm_monitor_autoscale_setting" "push_notif_function" {
         time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 30
+        threshold                = 15
         divide_by_instance_count = false
       }
 
@@ -333,7 +337,7 @@ resource "azurerm_monitor_autoscale_setting" "push_notif_function" {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT20M"
+        cooldown  = "PT1M"
       }
     }
   }

--- a/src/domains/messages-app/10_function_messages.tf
+++ b/src/domains/messages-app/10_function_messages.tf
@@ -255,10 +255,10 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/sites"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT1M"
+        time_window              = "PT2M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 600
+        threshold                = 700
         divide_by_instance_count = true
       }
 
@@ -368,10 +368,10 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/sites"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT1M"
+        time_window              = "PT2M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 600
+        threshold                = 700
         divide_by_instance_count = true
       }
 
@@ -609,7 +609,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/sites"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT1M"
+        time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
         threshold                = 600

--- a/src/domains/messages-app/10_function_messages.tf
+++ b/src/domains/messages-app/10_function_messages.tf
@@ -129,7 +129,9 @@ module "app_messages_function" {
   name                = format("%s-app-messages-fn-%d", local.product, count.index + 1)
   domain              = "MESSAGES"
   location            = azurerm_resource_group.app_messages_rg[count.index].location
-  health_check_path   = "/api/v1/info"
+
+  health_check_path            = "/api/v1/info"
+  health_check_maxpingfailures = 2
 
   runtime_version                          = "~4"
   node_version                             = "18"
@@ -195,7 +197,9 @@ module "app_messages_function_staging_slot" {
   resource_group_name = azurerm_resource_group.app_messages_rg[count.index].name
   function_app_id     = module.app_messages_function[count.index].id
   app_service_plan_id = module.app_messages_function[count.index].app_service_plan_id
-  health_check_path   = "/api/v1/info"
+
+  health_check_path            = "/api/v1/info"
+  health_check_maxpingfailures = 2
 
   storage_account_name       = module.app_messages_function[count.index].storage_account.name
   storage_account_access_key = module.app_messages_function[count.index].storage_account.primary_access_key
@@ -229,7 +233,7 @@ module "app_messages_function_staging_slot" {
 
 resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
   count               = var.app_messages_count
-  name                = format("%s-autoscale", module.app_messages_function[count.index].name)
+  name                = format("%s-as-01", module.app_messages_function[count.index].name)
   resource_group_name = azurerm_resource_group.app_messages_rg[count.index].name
   location            = azurerm_resource_group.app_messages_rg[count.index].location
   target_resource_id  = module.app_messages_function[count.index].app_service_plan_id
@@ -253,14 +257,14 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         time_window              = "PT1M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 3000
-        divide_by_instance_count = false
+        threshold                = 600
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
-        value     = "2"
+        value     = "1"
         cooldown  = "PT1M"
       }
     }
@@ -272,10 +276,10 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/serverfarms"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT1M"
+        time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 45
+        threshold                = 60
         divide_by_instance_count = false
       }
 
@@ -283,7 +287,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Increase"
         type      = "ChangeCount"
         value     = "2"
-        cooldown  = "PT1M"
+        cooldown  = "PT2M"
       }
     }
 
@@ -294,18 +298,18 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/sites"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT15M"
+        time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 2000
-        divide_by_instance_count = false
+        threshold                = 150
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT10M"
+        cooldown  = "PT1M"
       }
     }
 
@@ -319,7 +323,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 30
+        threshold                = 15
         divide_by_instance_count = false
       }
 
@@ -327,7 +331,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT20M"
+        cooldown  = "PT2M"
       }
     }
 
@@ -366,14 +370,14 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         time_window              = "PT1M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 3000
-        divide_by_instance_count = false
+        threshold                = 600
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
-        value     = "2"
+        value     = "1"
         cooldown  = "PT1M"
       }
     }
@@ -385,10 +389,10 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/serverfarms"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT1M"
+        time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 45
+        threshold                = 60
         divide_by_instance_count = false
       }
 
@@ -396,7 +400,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Increase"
         type      = "ChangeCount"
         value     = "2"
-        cooldown  = "PT1M"
+        cooldown  = "PT2M"
       }
     }
 
@@ -407,18 +411,18 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/sites"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT15M"
+        time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 2000
-        divide_by_instance_count = false
+        threshold                = 150
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT10M"
+        cooldown  = "PT1M"
       }
     }
 
@@ -432,7 +436,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 30
+        threshold                = 15
         divide_by_instance_count = false
       }
 
@@ -440,7 +444,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT20M"
+        cooldown  = "PT2M"
       }
     }
 
@@ -465,8 +469,8 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
 
     capacity {
       default = 10
-      minimum = 4
-      maximum = 15
+      minimum = 5
+      maximum = 20
     }
 
     recurrence {
@@ -494,15 +498,15 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         time_window              = "PT1M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 3000
-        divide_by_instance_count = false
+        threshold                = 500
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
         value     = "2"
-        cooldown  = "PT1M"
+        cooldown  = "PT0M"
       }
     }
 
@@ -513,10 +517,10 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/serverfarms"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT1M"
+        time_window              = "PT3M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 45
+        threshold                = 60
         divide_by_instance_count = false
       }
 
@@ -524,7 +528,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Increase"
         type      = "ChangeCount"
         value     = "2"
-        cooldown  = "PT1M"
+        cooldown  = "PT0M"
       }
     }
 
@@ -535,18 +539,18 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/sites"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT15M"
+        time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 2000
-        divide_by_instance_count = false
+        threshold                = 100
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT10M"
+        cooldown  = "PT0M"
       }
     }
 
@@ -557,10 +561,10 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/serverfarms"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT5M"
+        time_window              = "PT10M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 30
+        threshold                = 10
         divide_by_instance_count = false
       }
 
@@ -568,7 +572,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT20M"
+        cooldown  = "PT0M"
       }
     }
   }
@@ -607,15 +611,15 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         time_window              = "PT1M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 2000
-        divide_by_instance_count = false
+        threshold                = 600
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
-        value     = "2"
-        cooldown  = "PT1M"
+        value     = "1"
+        cooldown  = "PT2M"
       }
     }
 
@@ -626,10 +630,10 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/serverfarms"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT1M"
+        time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 30
+        threshold                = 60
         divide_by_instance_count = false
       }
 
@@ -637,7 +641,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Increase"
         type      = "ChangeCount"
         value     = "2"
-        cooldown  = "PT1M"
+        cooldown  = "PT2M"
       }
     }
 
@@ -648,18 +652,18 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         metric_namespace         = "microsoft.web/sites"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT15M"
+        time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 1500
-        divide_by_instance_count = false
+        threshold                = 200
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT10M"
+        cooldown  = "PT2M"
       }
     }
 
@@ -673,7 +677,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 15
+        threshold                = 20
         divide_by_instance_count = false
       }
 
@@ -681,7 +685,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT20M"
+        cooldown  = "PT2M"
       }
     }
   }

--- a/src/domains/messages-app/10_function_messages.tf
+++ b/src/domains/messages-app/10_function_messages.tf
@@ -507,7 +507,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Increase"
         type      = "ChangeCount"
         value     = "2"
-        cooldown  = "PT0M"
+        cooldown  = "PT1M"
       }
     }
 
@@ -529,7 +529,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Increase"
         type      = "ChangeCount"
         value     = "2"
-        cooldown  = "PT0M"
+        cooldown  = "PT1M"
       }
     }
 
@@ -551,7 +551,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT0M"
+        cooldown  = "PT1M"
       }
     }
 
@@ -573,7 +573,7 @@ resource "azurerm_monitor_autoscale_setting" "app_messages_function" {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT0M"
+        cooldown  = "PT1M"
       }
     }
   }

--- a/src/domains/messages-app/11_function_cqrs.tf
+++ b/src/domains/messages-app/11_function_cqrs.tf
@@ -283,7 +283,7 @@ module "function_messages_cqrs_staging_slot" {
 }
 
 resource "azurerm_monitor_autoscale_setting" "function_messages_cqrs" {
-  name                = format("%s-autoscale", module.function_messages_cqrs.name)
+  name                = format("%s-as-01", module.function_messages_cqrs.name)
   resource_group_name = azurerm_resource_group.backend_messages_rg.name
   location            = var.location
   target_resource_id  = module.function_messages_cqrs.app_service_plan_id
@@ -292,8 +292,8 @@ resource "azurerm_monitor_autoscale_setting" "function_messages_cqrs" {
     name = "default"
 
     capacity {
-      default = 1
-      minimum = 1
+      default = 3
+      minimum = 2
       maximum = 30
     }
 
@@ -307,15 +307,15 @@ resource "azurerm_monitor_autoscale_setting" "function_messages_cqrs" {
         time_window              = "PT1M"
         time_aggregation         = "Average"
         operator                 = "GreaterThan"
-        threshold                = 3500
-        divide_by_instance_count = false
+        threshold                = 500
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
         value     = "2"
-        cooldown  = "PT5M"
+        cooldown  = "PT2M"
       }
     }
 
@@ -337,7 +337,7 @@ resource "azurerm_monitor_autoscale_setting" "function_messages_cqrs" {
         direction = "Increase"
         type      = "ChangeCount"
         value     = "2"
-        cooldown  = "PT5M"
+        cooldown  = "PT3M"
       }
     }
 
@@ -348,18 +348,18 @@ resource "azurerm_monitor_autoscale_setting" "function_messages_cqrs" {
         metric_namespace         = "microsoft.web/sites"
         time_grain               = "PT1M"
         statistic                = "Average"
-        time_window              = "PT15M"
+        time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 2500
-        divide_by_instance_count = false
+        threshold                = 200
+        divide_by_instance_count = true
       }
 
       scale_action {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT10M"
+        cooldown  = "PT0M"
       }
     }
 
@@ -373,7 +373,7 @@ resource "azurerm_monitor_autoscale_setting" "function_messages_cqrs" {
         time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 30
+        threshold                = 15
         divide_by_instance_count = false
       }
 
@@ -381,7 +381,7 @@ resource "azurerm_monitor_autoscale_setting" "function_messages_cqrs" {
         direction = "Decrease"
         type      = "ChangeCount"
         value     = "1"
-        cooldown  = "PT20M"
+        cooldown  = "PT1M"
       }
     }
   }

--- a/src/domains/messages-app/12_function_service_messages.tf
+++ b/src/domains/messages-app/12_function_service_messages.tf
@@ -109,8 +109,10 @@ module "function_service_messages" {
   resource_group_name = azurerm_resource_group.service_messages_rg.name
   name                = format("%s-messages-sending-func", local.product)
   location            = azurerm_resource_group.service_messages_rg.location
-  health_check_path   = "/api/v1/info"
   domain              = "MESSAGES"
+
+  health_check_path            = "/api/v1/info"
+  health_check_maxpingfailures = 2
 
   node_version                             = "18"
   runtime_version                          = "~4"
@@ -172,7 +174,9 @@ module "function_service_messages_staging_slot" {
   resource_group_name = azurerm_resource_group.service_messages_rg.name
   function_app_id     = module.function_service_messages[0].id
   app_service_plan_id = module.function_service_messages[0].app_service_plan_id
-  health_check_path   = "/api/v1/info"
+
+  health_check_path            = "/api/v1/info"
+  health_check_maxpingfailures = 2
 
   node_version                             = "18"
   runtime_version                          = "~4"
@@ -203,7 +207,7 @@ module "function_service_messages_staging_slot" {
 
 resource "azurerm_monitor_autoscale_setting" "function_service_messages" {
   count               = var.function_service_messages_enabled ? 1 : 0
-  name                = format("%s-autoscale", module.function_service_messages[0].name)
+  name                = format("%s-as-01", module.function_service_messages[0].name)
   resource_group_name = azurerm_resource_group.service_messages_rg.name
   location            = var.location
   target_resource_id  = module.function_service_messages[0].app_service_plan_id

--- a/src/domains/messages-app/99_variables.tf
+++ b/src/domains/messages-app/99_variables.tf
@@ -302,24 +302,6 @@ variable "push_notif_function_sku_size" {
   default     = null
 }
 
-variable "push_notif_function_autoscale_minimum" {
-  type        = number
-  description = "The minimum number of instances for this resource."
-  default     = 1
-}
-
-variable "push_notif_function_autoscale_maximum" {
-  type        = number
-  description = "The maximum number of instances for this resource."
-  default     = 3
-}
-
-variable "push_notif_function_autoscale_default" {
-  type        = number
-  description = "The number of instances that are available for scaling if metrics are not available for evaluation."
-  default     = 1
-}
-
 ###############################
 # Messages functions
 ###############################

--- a/src/domains/messages-app/README.md
+++ b/src/domains/messages-app/README.md
@@ -171,9 +171,6 @@
 | <a name="input_push_notif_count"></a> [push\_notif\_count](#input\_push\_notif\_count) | n/a | `number` | `2` | no |
 | <a name="input_push_notif_enabled"></a> [push\_notif\_enabled](#input\_push\_notif\_enabled) | Push Notif function enabled? | `bool` | `false` | no |
 | <a name="input_push_notif_function_always_on"></a> [push\_notif\_function\_always\_on](#input\_push\_notif\_function\_always\_on) | n/a | `bool` | `false` | no |
-| <a name="input_push_notif_function_autoscale_default"></a> [push\_notif\_function\_autoscale\_default](#input\_push\_notif\_function\_autoscale\_default) | The number of instances that are available for scaling if metrics are not available for evaluation. | `number` | `1` | no |
-| <a name="input_push_notif_function_autoscale_maximum"></a> [push\_notif\_function\_autoscale\_maximum](#input\_push\_notif\_function\_autoscale\_maximum) | The maximum number of instances for this resource. | `number` | `3` | no |
-| <a name="input_push_notif_function_autoscale_minimum"></a> [push\_notif\_function\_autoscale\_minimum](#input\_push\_notif\_function\_autoscale\_minimum) | The minimum number of instances for this resource. | `number` | `1` | no |
 | <a name="input_push_notif_function_kind"></a> [push\_notif\_function\_kind](#input\_push\_notif\_function\_kind) | App service plan kind | `string` | `null` | no |
 | <a name="input_push_notif_function_sku_size"></a> [push\_notif\_function\_sku\_size](#input\_push\_notif\_function\_sku\_size) | App service plan sku size | `string` | `null` | no |
 | <a name="input_push_notif_function_sku_tier"></a> [push\_notif\_function\_sku\_tier](#input\_push\_notif\_function\_sku\_tier) | App service plan sku tier | `string` | `null` | no |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Function messages autoscale rules:

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-GB style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr;border-width:100%'>

<div style='direction:ltr;margin-top:0in;margin-left:0in;width:5.1625in'>

<div style='direction:ltr;margin-top:0in;margin-left:0in;width:5.1625in'>

<div style='direction:ltr'>


  | Service | Type | Metric | Value | Window | Cooldown
-- | -- | -- | -- | -- | -- | --
default | Func msg | Inc 1 | Requests | 600 | 2m | 1m
evening | Func msg | Inc 2 | Requests | 500 | 1m | 1m
night | Func msg | Inc 1 | Requests | 600 | 5m | 2m
  |   |   |   |   |   |  
default | Func msg | Inc 2 | CPU | 60 | 5m | 2m
evening | Func msg | Inc 2 | CPU | 60 | 3m | 1m
night | Func msg | Inc 2 | CPU | 60 | 5m | 2m
  |   |   |   |   |   |  
default | Func msg | Dec 1 | Requests | 150 | 5m | 1m
evening | Func msg | Dec 1 | Requests | 100 | 5m | 1m
night | Func msg | Dec 1 | Requests | 200 | 5m | 2m
  |   |   |   |   |   |  
default | Func msg | Dec 1 | CPU | 15 | 5m | 2m
evening | Func msg | Dec 1 | CPU | 10 | 10m | 1m
night | Func msg | Dec 1 | CPU | 20 | 5m | 2m



</div>

</div>

</div>

</div>

<!--EndFragment-->
</body>

</html>


CQRS:
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-GB style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


  | Service | Type | Metric | Value | Window | Cooldown
-- | -- | -- | -- | -- | -- | --
default | Func cqrs | Inc 2 | Requests | 500 | 1m | 2m
default | Func cqrs | Inc 2 | CPU | 60 | 5m | 3m
  |   |   |   |   |   |  
default | Func cqrs | Dec 1 | Requests | 200 | 5m | 0m
default | Func cqrs | Dec 1 | CPU | 15 | 5m | 1m



</div>

<!--EndFragment-->
</body>

</html>

Push notif:

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-GB style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


  | Service | Type | Metric | Value | Window | Cooldown
-- | -- | -- | -- | -- | -- | --
default | Func push | Inc 2 | Requests | 500 | 1m | 2m
default | Func push | Inc 2 | CPU | 60 | 5m | 3m
  |   |   |   |   |   |  
default | Func push | Dec 1 | Requests | 200 | 5m | 0m
default | Func push | Dec 1 | CPU | 15 | 5m | 1m



</div>

<!--EndFragment-->
</body>

</html>


Note, `divide_by_instance_count` flag is enabled only for `Requests` metrics

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Functions never scales out

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
