### PR TITLE
fix: Ioselfcare ci/cd now runs on private agent

### DIFF
--- a/.github/workflows/ioselfcare_cd.yaml
+++ b/.github/workflows/ioselfcare_cd.yaml
@@ -16,3 +16,4 @@ jobs:
     with:
       environment: prod
       dir: "src/domains/selfcare/prod/westeurope"
+      use_private_agent: true

--- a/.github/workflows/ioselfcare_ci.yaml
+++ b/.github/workflows/ioselfcare_ci.yaml
@@ -21,3 +21,4 @@ jobs:
     with:
       environment: prod
       dir: "src/domains/selfcare/prod/westeurope"
+      use_private_agent: true


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Ioselfcare ci/cd now runs on private agent

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Some resources managed by terraform are private and only accessible from the vnet

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
