### PR TITLE
[EC-357] Move KeyVault resources to modules

### DIFF
--- a/.github/workflows/core_code_review.yaml
+++ b/.github/workflows/core_code_review.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   prod_itn_core_code_review:
-    uses: pagopa/dx/.github/workflows/infra_plan.yaml@CES-9-fix-plan-comments-being-overwritten
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: Prod - Code Review
     secrets: inherit
     with:

--- a/.github/workflows/core_code_review.yaml
+++ b/.github/workflows/core_code_review.yaml
@@ -2,7 +2,7 @@ name: PR - Core TF Validation
 
 # This pipeline starts automatically when a PR is opened.
 #
-# It is responsible for managing changes related solely to the NEW infrastructure. 
+# It is responsible for managing changes related solely to the NEW infrastructure.
 # Therefore, it checks whether the changes have occurred only in the directories listed in "paths."
 #
 ## NOTE: 'NEW infrastructure' refers to the new Terraform infrastructure located in the src/core/prod folder, which no longer requires the terraform.sh script to be applied.
@@ -23,7 +23,7 @@ on:
 
 jobs:
   prod_itn_core_code_review:
-    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@CES-9-fix-plan-comments-being-overwritten
     name: Prod - Code Review
     secrets: inherit
     with:

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -56,8 +56,6 @@
 | <a name="module_dns_forwarder_snet"></a> [dns\_forwarder\_snet](#module\_dns\_forwarder\_snet) | github.com/pagopa/terraform-azurerm-v3//subnet | v8.27.0 |
 | <a name="module_event_hub"></a> [event\_hub](#module\_event\_hub) | github.com/pagopa/terraform-azurerm-v3//eventhub | v8.27.0 |
 | <a name="module_eventhub_snet"></a> [eventhub\_snet](#module\_eventhub\_snet) | github.com/pagopa/terraform-azurerm-v3//subnet | v8.27.0 |
-| <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault) | github.com/pagopa/terraform-azurerm-v3//key_vault | v8.27.0 |
-| <a name="module_key_vault_common"></a> [key\_vault\_common](#module\_key\_vault\_common) | github.com/pagopa/terraform-azurerm-v3//key_vault | v8.27.0 |
 | <a name="module_locked_profiles_storage"></a> [locked\_profiles\_storage](#module\_locked\_profiles\_storage) | github.com/pagopa/terraform-azurerm-v3//storage_account | v8.27.0 |
 | <a name="module_redis_common_backup_zrs"></a> [redis\_common\_backup\_zrs](#module\_redis\_common\_backup\_zrs) | github.com/pagopa/terraform-azurerm-v3//storage_account | v8.27.0 |
 | <a name="module_redis_common_snet"></a> [redis\_common\_snet](#module\_redis\_common\_snet) | github.com/pagopa/terraform-azurerm-v3//subnet | v8.27.0 |
@@ -158,7 +156,6 @@
 | [azurerm_resource_group.rg_external](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.rg_internal](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.rg_linux](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_container.storage_api_cached](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.storage_api_message_content](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_queue.storage_account_apievents_events_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
@@ -202,6 +199,8 @@
 | [azurerm_eventhub_authorization_rule.io-p-messages-weu-prod01-evh-ns_messages_io-fn-messages-cqrs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/eventhub_authorization_rule) | data source |
 | [azurerm_eventhub_authorization_rule.io-p-payments-weu-prod01-evh-ns_payment-updates_io-fn-messages-cqrs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/eventhub_authorization_rule) | data source |
 | [azurerm_key_vault.ioweb_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_key_vault.key_vault_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault_certificate.api_app_internal_io_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
 | [azurerm_key_vault_certificate.api_internal_io_italia_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
 | [azurerm_key_vault_certificate.app_gw_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) | data source |
@@ -296,6 +295,7 @@
 | [azurerm_redis_cache.redis_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/redis_cache) | data source |
 | [azurerm_resource_group.lollipop_function_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.notifications_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account.logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.lollipop_assertions_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.notifications](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |

--- a/src/core/_modules/key_vaults/kv.tf
+++ b/src/core/_modules/key_vaults/kv.tf
@@ -1,0 +1,18 @@
+resource "azurerm_key_vault" "kv" {
+  name                = local.nonstandard[var.location_short].kv
+  location            = azurerm_resource_group.sec.location
+  resource_group_name = azurerm_resource_group.sec.name
+  tenant_id           = var.tenant_id
+  sku_name            = "standard"
+
+  enabled_for_disk_encryption = true
+  purge_protection_enabled    = true
+  soft_delete_retention_days  = 15
+
+  network_acls {
+    bypass         = "AzureServices"
+    default_action = "Allow" #tfsec:ignore:AZU020
+  }
+
+  tags = var.tags
+}

--- a/src/core/_modules/key_vaults/kv_common.tf
+++ b/src/core/_modules/key_vaults/kv_common.tf
@@ -1,0 +1,18 @@
+resource "azurerm_key_vault" "common" {
+  name                = local.nonstandard[var.location_short].kv_common
+  location            = var.location
+  resource_group_name = var.resource_group_common
+  tenant_id           = var.tenant_id
+  sku_name            = "standard"
+
+  enabled_for_disk_encryption = true
+  purge_protection_enabled    = true
+  soft_delete_retention_days  = 90
+
+  network_acls {
+    bypass         = "AzureServices"
+    default_action = "Allow" #tfsec:ignore:AZU020
+  }
+
+  tags = var.tags
+}

--- a/src/core/_modules/key_vaults/locals.tf
+++ b/src/core/_modules/key_vaults/locals.tf
@@ -1,0 +1,9 @@
+locals {
+  nonstandard = {
+    weu = {
+      rg        = "${var.project}-sec-rg"
+      kv        = "${var.project}-kv"
+      kv_common = "${var.project}-kv-common"
+    }
+  }
+}

--- a/src/core/_modules/key_vaults/outputs.tf
+++ b/src/core/_modules/key_vaults/outputs.tf
@@ -1,0 +1,15 @@
+output "kv" {
+  value = {
+    id                  = azurerm_key_vault.common.id
+    name                = azurerm_key_vault.common.name
+    resource_group_name = azurerm_key_vault.common.resource_group_name
+  }
+}
+
+output "kv_common" {
+  value = {
+    id                  = azurerm_key_vault.kv.id
+    name                = azurerm_key_vault.kv.name
+    resource_group_name = azurerm_key_vault.kv.resource_group_name
+  }
+}

--- a/src/core/_modules/key_vaults/resource_groups.tf
+++ b/src/core/_modules/key_vaults/resource_groups.tf
@@ -1,0 +1,6 @@
+resource "azurerm_resource_group" "sec" {
+  name     = local.nonstandard[var.location_short].rg
+  location = var.location
+
+  tags = var.tags
+}

--- a/src/core/_modules/key_vaults/variables.tf
+++ b/src/core/_modules/key_vaults/variables.tf
@@ -1,0 +1,29 @@
+variable "project" {
+  type        = string
+  description = "IO prefix, short environment and short location"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region"
+}
+
+variable "location_short" {
+  type        = string
+  description = "Azure region short name"
+}
+
+variable "tags" {
+  type        = map(any)
+  description = "Resource tags"
+}
+
+variable "resource_group_common" {
+  type        = string
+  description = "Name of common resource group"
+  default     = null
+}
+
+variable "tenant_id" {
+  type = string
+}

--- a/src/core/apim_v2.tf
+++ b/src/core/apim_v2.tf
@@ -1,16 +1,16 @@
 data "azurerm_key_vault_secret" "apim_publisher_email" {
   name         = "apim-publisher-email"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_certificate" "api_internal_io_italia_it" {
   name         = replace(local.apim_hostname_api_internal, ".", "-")
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_certificate" "api_app_internal_io_pagopa_it" {
   name         = replace(local.apim_hostname_api_app_internal, ".", "-")
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 # APIM subnet
@@ -222,7 +222,7 @@ module "apim_v2" {
 
 # ## api management key vault policy ##
 resource "azurerm_key_vault_access_policy" "apim_v2_kv_policy" {
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = module.apim_v2.principal_id
 
@@ -233,7 +233,7 @@ resource "azurerm_key_vault_access_policy" "apim_v2_kv_policy" {
 }
 
 resource "azurerm_key_vault_access_policy" "v2_common" {
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = module.apim_v2.principal_id
 

--- a/src/core/apim_v2_io_admin_api.tf
+++ b/src/core/apim_v2_io_admin_api.tf
@@ -24,7 +24,7 @@ resource "azurerm_api_management_named_value" "io_fn3_admin_url_v2" {
 
 data "azurerm_key_vault_secret" "io_fn3_admin_key_secret_v2" {
   name         = "fn3admin-KEY-APIM"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 resource "azurerm_api_management_named_value" "io_fn3_admin_key_v2" {

--- a/src/core/apim_v2_io_public_api.tf
+++ b/src/core/apim_v2_io_public_api.tf
@@ -24,7 +24,7 @@ resource "azurerm_api_management_named_value" "io_fn3_public_url_v2" {
 
 data "azurerm_key_vault_secret" "io_fn3_public_key_secret_v2" {
   name         = "fn3public-KEY-APIM"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 resource "azurerm_api_management_named_value" "io_fn3_public_key_v2" {

--- a/src/core/apim_v2_io_services_api.tf
+++ b/src/core/apim_v2_io_services_api.tf
@@ -42,7 +42,7 @@ resource "azurerm_api_management_named_value" "io_fn3_services_url_v2" {
 
 data "azurerm_key_vault_secret" "io_fn3_services_key_secret_v2" {
   name         = "fn3services-KEY-APIM"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 resource "azurerm_api_management_named_value" "io_fn3_services_key_v2" {
@@ -58,7 +58,7 @@ resource "azurerm_api_management_named_value" "io_fn3_services_key_v2" {
 
 data "azurerm_key_vault_secret" "io_fn3_eucovidcert_key_secret_v2" {
   name         = "io-fn3-eucovidcert-KEY-APIM"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 resource "azurerm_api_management_named_value" "io_fn3_eucovidcert_key_v2" {
@@ -82,7 +82,7 @@ resource "azurerm_api_management_named_value" "io_fn3_eucovidcert_url_alt_v2" {
 # Named Value api gad certificate header
 data "azurerm_key_vault_secret" "api_gad_client_certificate_verified_header_secret_v2" {
   name         = "apigad-GAD-CLIENT-CERTIFICATE-VERIFIED-HEADER"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 resource "azurerm_api_management_named_value" "api_gad_client_certificate_verified_header_v2" {

--- a/src/core/app_backend.tf
+++ b/src/core/app_backend.tf
@@ -464,199 +464,199 @@ resource "azurerm_resource_group" "rg_linux" {
 
 data "azurerm_key_vault_secret" "app_backend_SAML_CERT" {
   name         = "appbackend-SAML-CERT"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_SAML_KEY" {
   name         = "appbackend-SAML-KEY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_API_KEY" {
   name         = "funcapp-KEY-APPBACKEND"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_CGN_API_KEY" {
   name         = "funccgn-KEY-APPBACKEND"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_IO_SIGN_API_KEY" {
   name         = "funciosign-KEY-APPBACKEND"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_CGN_OPERATOR_SEARCH_API_KEY_PROD" {
   name         = "funccgnoperatorsearch-KEY-PROD-APPBACKEND"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_CGN_OPERATOR_SEARCH_API_KEY_UAT" {
   name         = "funccgnoperatorsearch-KEY-UAT-APPBACKEND"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_ALLOW_PAGOPA_IP_SOURCE_RANGE" {
   name         = "appbackend-ALLOW-PAGOPA-IP-SOURCE-RANGE"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_PAGOPA_API_KEY_PROD" {
   name         = "appbackend-PAGOPA-API-KEY-PROD-PRIMARY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_PAGOPA_API_KEY_UAT" {
   name         = "appbackend-PAGOPA-API-KEY-UAT-PRIMARY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_TEST_LOGIN_PASSWORD" {
   name         = "appbackend-TEST-LOGIN-PASSWORD"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_ALLOW_MYPORTAL_IP_SOURCE_RANGE" {
   name         = "appbackend-ALLOW-MYPORTAL-IP-SOURCE-RANGE"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_ALLOW_BPD_IP_SOURCE_RANGE" {
   name         = "appbackend-ALLOW-BPD-IP-SOURCE-RANGE"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_JWT_SUPPORT_TOKEN_PRIVATE_RSA_KEY" {
   name         = "appbackend-JWT-SUPPORT-TOKEN-PRIVATE-RSA-KEY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_TEST_CGN_FISCAL_CODES" {
   name         = "appbackend-TEST-CGN-FISCAL-CODES"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_JWT_MIT_VOUCHER_TOKEN_PRIVATE_ES_KEY" {
   name         = "appbackend-mitvoucher-JWT-PRIVATE-ES-KEY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_JWT_MIT_VOUCHER_TOKEN_AUDIENCE" {
   name         = "appbackend-mitvoucher-JWT-AUDIENCE"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_ALLOW_ZENDESK_IP_SOURCE_RANGE" {
   name         = "appbackend-ALLOW-ZENDESK-IP-SOURCE-RANGE"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_JWT_ZENDESK_SUPPORT_TOKEN_SECRET" {
   name         = "appbackend-JWT-ZENDESK-SUPPORT-TOKEN-SECRET"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_PECSERVER_TOKEN_SECRET" {
   name         = "appbackend-PECSERVER-TOKEN-SECRET"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_PECSERVER_ARUBA_TOKEN_SECRET" {
   name         = "appbackend-PECSERVER-ARUBA-TOKEN-SECRET"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_APP_MESSAGES_API_KEY" {
   name         = "appbackend-APP-MESSAGES-API-KEY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_APP_MESSAGES_BETA_FISCAL_CODES" {
   name         = "appbackend-APP-MESSAGES-BETA-FISCAL-CODES"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_PN_API_KEY_PROD" {
   name         = "appbackend-PN-API-KEY-PROD-ENV"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_PN_API_KEY_UAT_V2" {
   name         = "appbackend-PN-API-KEY-UAT-ENV-V2"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_PN_REAL_TEST_USERS" {
   name         = "appbackend-PN-REAL-TEST-USERS"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_LOLLIPOP_ITN_API_KEY" {
   name         = "appbackend-LOLLIPOP-ITN-API-KEY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_FAST_LOGIN_API_KEY" {
   name         = "appbackend-FAST-LOGIN-API-KEY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_TRIAL_SYSTEM_API_KEY" {
   name         = "appbackend-TRIAL-SYSTEM-API-KEY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_IOLOGIN_TEST_USERS" {
   name         = "appbackend-IOLOGIN-TEST-USERS"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_UNIQUE_EMAIL_ENFORCEMENT_USER" {
   name         = "appbackend-UNIQUE-EMAIL-ENFORCEMENT-USER"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_LV_TEST_USERS" {
   name         = "appbackend-LV-TEST-USERS"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_ALLOWED_CIE_TEST_FISCAL_CODES" {
   name         = "appbackend-ALLOWED-CIE-TEST-FISCAL-CODES"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_RECEIPT_SERVICE_TEST_API_KEY" {
   name         = "appbackend-RECEIPT-SERVICE-TEST-API-KEY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_RECEIPT_SERVICE_API_KEY" {
   name         = "appbackend-RECEIPT-SERVICE-API-KEY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "fn_eucovidcert_API_KEY_APPBACKEND" {
   name         = "funceucovidcert-KEY-APPBACKEND"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_secret" "fn_eucovidcert_API_KEY_PUBLICIOEVENTDISPATCHER" {
   name         = "funceucovidcert-KEY-PUBLICIOEVENTDISPATCHER"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_secret" "app_backend_IO_WALLET_API_KEY" {
   name         = "funciowallet-KEY-APPBACKEND"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 #tfsec:ignore:AZU023
 resource "azurerm_key_vault_secret" "appbackend-REDIS-PASSWORD" {
   name         = "appbackend-REDIS-PASSWORD"
   value        = data.azurerm_redis_cache.redis_common.primary_access_key
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
   content_type = "string"
 }
 
@@ -664,7 +664,7 @@ resource "azurerm_key_vault_secret" "appbackend-REDIS-PASSWORD" {
 resource "azurerm_key_vault_secret" "appbackend-SPID-LOG-STORAGE" {
   name         = "appbackend-SPID-LOG-STORAGE"
   value        = data.azurerm_storage_account.logs.primary_connection_string
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
   content_type = "string"
 }
 
@@ -672,7 +672,7 @@ resource "azurerm_key_vault_secret" "appbackend-SPID-LOG-STORAGE" {
 resource "azurerm_key_vault_secret" "appbackend-PUSH-NOTIFICATIONS-STORAGE" {
   name         = "appbackend-PUSH-NOTIFICATIONS-STORAGE"
   value        = data.azurerm_storage_account.push_notifications_storage.primary_connection_string
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
   content_type = "string"
 }
 
@@ -680,7 +680,7 @@ resource "azurerm_key_vault_secret" "appbackend-PUSH-NOTIFICATIONS-STORAGE" {
 resource "azurerm_key_vault_secret" "appbackend-NORIFICATIONS-STORAGE" {
   name         = "appbackend-NORIFICATIONS-STORAGE"
   value        = data.azurerm_storage_account.notifications.primary_connection_string
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
   content_type = "string"
 }
 
@@ -688,7 +688,7 @@ resource "azurerm_key_vault_secret" "appbackend-NORIFICATIONS-STORAGE" {
 resource "azurerm_key_vault_secret" "appbackend-USERS-LOGIN-STORAGE" {
   name         = "appbackend-USERS-LOGIN-STORAGE"
   value        = data.azurerm_storage_account.logs.primary_connection_string
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
   content_type = "string"
 }
 
@@ -696,7 +696,7 @@ resource "azurerm_key_vault_secret" "appbackend-USERS-LOGIN-STORAGE" {
 resource "azurerm_key_vault_secret" "appbackend_LOLLIPOP_ASSERTIONS_STORAGE" {
   name         = "appbackend-LOLLIPOP-ASSERTIONS-STORAGE"
   value        = data.azurerm_storage_account.lollipop_assertions_storage.primary_connection_string
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
   content_type = "string"
 }
 
@@ -704,7 +704,7 @@ resource "azurerm_key_vault_secret" "appbackend_LOLLIPOP_ASSERTIONS_STORAGE" {
 resource "azurerm_key_vault_secret" "appbackend_THIRD_PARTY_CONFIG_LIST" {
   name         = "appbackend-THIRD-PARTY-CONFIG-LIST"
   value        = local.app_backend.app_settings_common.THIRD_PARTY_CONFIG_LIST
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
   content_type = "string"
 }
 

--- a/src/core/appgateway.tf
+++ b/src/core/appgateway.tf
@@ -225,7 +225,7 @@ module "app_gw" {
   trusted_client_certificates = [
     {
       secret_name  = format("%s-issuer-chain", var.prefix)
-      key_vault_id = module.key_vault.id
+      key_vault_id = data.azurerm_key_vault.key_vault.id
     }
   ]
 
@@ -995,15 +995,15 @@ module "app_gw" {
 
 ## user assined identity: (application gateway) ##
 resource "azurerm_user_assigned_identity" "appgateway" {
-  resource_group_name = azurerm_resource_group.sec_rg.name
-  location            = azurerm_resource_group.sec_rg.location
+  resource_group_name = data.azurerm_resource_group.sec_rg.name
+  location            = data.azurerm_resource_group.sec_rg.location
   name                = format("%s-appgateway-identity", local.project)
 
   tags = var.tags
 }
 
 resource "azurerm_key_vault_access_policy" "app_gateway_policy" {
-  key_vault_id            = module.key_vault.id
+  key_vault_id            = data.azurerm_key_vault.key_vault.id
   tenant_id               = data.azurerm_client_config.current.tenant_id
   object_id               = azurerm_user_assigned_identity.appgateway.principal_id
   key_permissions         = []
@@ -1013,7 +1013,7 @@ resource "azurerm_key_vault_access_policy" "app_gateway_policy" {
 }
 
 resource "azurerm_key_vault_access_policy" "app_gateway_policy_common" {
-  key_vault_id            = module.key_vault_common.id
+  key_vault_id            = data.azurerm_key_vault.key_vault_common.id
   tenant_id               = data.azurerm_client_config.current.tenant_id
   object_id               = azurerm_user_assigned_identity.appgateway.principal_id
   key_permissions         = []
@@ -1038,7 +1038,7 @@ data "azuread_service_principal" "app_gw_uai_kvreader" {
 }
 
 resource "azurerm_key_vault_access_policy" "app_gw_uai_kvreader_common" {
-  key_vault_id            = module.key_vault_common.id
+  key_vault_id            = data.azurerm_key_vault.key_vault_common.id
   tenant_id               = data.azurerm_client_config.current.tenant_id
   object_id               = data.azuread_service_principal.app_gw_uai_kvreader.object_id
   key_permissions         = []
@@ -1049,17 +1049,17 @@ resource "azurerm_key_vault_access_policy" "app_gw_uai_kvreader_common" {
 
 data "azurerm_key_vault_certificate" "app_gw_api" {
   name         = var.app_gateway_api_certificate_name
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_certificate" "app_gw_api_mtls" {
   name         = var.app_gateway_api_mtls_certificate_name
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_certificate" "app_gw_api_app" {
   name         = var.app_gateway_api_app_certificate_name
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 ###
@@ -1078,47 +1078,47 @@ data "azurerm_key_vault_certificate" "app_gw_api_web" {
 
 data "azurerm_key_vault_certificate" "app_gw_api_io_italia_it" {
   name         = var.app_gateway_api_io_italia_it_certificate_name
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_certificate" "app_gw_app_backend_io_italia_it" {
   name         = var.app_gateway_app_backend_io_italia_it_certificate_name
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_certificate" "app_gw_developerportal_backend_io_italia_it" {
   name         = var.app_gateway_developerportal_backend_io_italia_it_certificate_name
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 data "azurerm_key_vault_certificate" "app_gw_api_io_selfcare_pagopa_it" {
   name         = var.app_gateway_api_io_selfcare_pagopa_it_certificate_name
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_certificate" "app_gw_firmaconio_selfcare_pagopa_it" {
   name         = var.app_gateway_firmaconio_selfcare_pagopa_it_certificate_name
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_certificate" "app_gw_continua" {
   name         = var.app_gateway_continua_io_pagopa_it_certificate_name
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_certificate" "app_gw_oauth" {
   name         = var.app_gateway_oauth_io_pagopa_it_certificate_name
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_certificate" "app_gw_selfcare_io" {
   name         = var.app_gateway_selfcare_io_pagopa_it_certificate_name
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_secret" "app_gw_mtls_header_name" {
   name         = "mtls-header-name"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 resource "azurerm_web_application_firewall_policy" "api_app" {

--- a/src/core/assets_cdn.tf
+++ b/src/core/assets_cdn.tf
@@ -37,7 +37,7 @@ resource "azurerm_cdn_profile" "assets_cdn_profile" {
 
 data "azurerm_key_vault_secret" "assets_cdn_fn_key_cdn" {
   name         = "${data.azurerm_linux_function_app.function_assets_cdn.name}-KEY-CDN"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 resource "azurerm_cdn_endpoint" "assets_cdn_endpoint" {

--- a/src/core/data.tf
+++ b/src/core/data.tf
@@ -96,7 +96,7 @@ data "azurerm_eventhub_authorization_rule" "io-p-messages-weu-prod01-evh-ns_mess
 
 data "azurerm_key_vault_secret" "apim_services_subscription_key" {
   name         = "apim-IO-SERVICE-KEY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 
@@ -107,7 +107,7 @@ data "azurerm_key_vault_secret" "apim_services_subscription_key" {
 
 data "azurerm_key_vault_secret" "app_backend_PRE_SHARED_KEY" {
   name         = "appbackend-PRE-SHARED-KEY"
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 
@@ -342,7 +342,7 @@ data "azurerm_api_management" "trial_system" {
 }
 
 ### Network and DNS
-# TO BE REMOVED WHEN RESOURCES ARE  
+# TO BE REMOVED WHEN RESOURCES ARE
 # MOVED TO THE MODULAR FORM
 data "azurerm_virtual_network" "common" {
   name                = "${local.project}-vnet-common"

--- a/src/core/events.tf
+++ b/src/core/events.tf
@@ -78,5 +78,5 @@ resource "azurerm_key_vault_secret" "event_hub_keys" {
   value        = module.event_hub.keys[each.key].primary_key
   content_type = "text/plain"
 
-  key_vault_id = module.key_vault.id // ?
+  key_vault_id = data.azurerm_key_vault.key_vault.id // ?
 }

--- a/src/core/keyvault.tf
+++ b/src/core/keyvault.tf
@@ -1,33 +1,15 @@
-resource "azurerm_resource_group" "sec_rg" {
-  name     = format("%s-sec-rg", local.project)
-  location = var.location
-
-  tags = var.tags
+data "azurerm_key_vault" "key_vault" {
+  name                = format("%s-kv", local.project)
+  resource_group_name = data.azurerm_resource_group.sec_rg.name
 }
 
-#tfsec:ignore:azure-keyvault-specify-network-acl:exp:2022-05-01 # already ignored, maybe a bug in tfsec
-module "key_vault" {
-  source                     = "github.com/pagopa/terraform-azurerm-v3//key_vault?ref=v8.27.0"
-  name                       = format("%s-kv", local.project)
-  location                   = azurerm_resource_group.sec_rg.location
-  resource_group_name        = azurerm_resource_group.sec_rg.name
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  soft_delete_retention_days = 15
-  lock_enable                = false
-
-  tags = var.tags
+data "azurerm_key_vault" "key_vault_common" {
+  name                = format("%s-kv-common", local.project)
+  resource_group_name = azurerm_resource_group.rg_common.name
 }
 
-module "key_vault_common" {
-  source                     = "github.com/pagopa/terraform-azurerm-v3//key_vault?ref=v8.27.0"
-  name                       = format("%s-kv-common", local.project)
-  location                   = azurerm_resource_group.rg_common.location
-  resource_group_name        = azurerm_resource_group.rg_common.name
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  soft_delete_retention_days = 90
-  lock_enable                = false
-
-  tags = var.tags
+data "azurerm_resource_group" "sec_rg" {
+  name = format("%s-sec-rg", local.project)
 }
 
 #tfsec:ignore:AZU023
@@ -36,7 +18,7 @@ resource "azurerm_key_vault_secret" "appinsights_instrumentation_key" {
   value        = azurerm_application_insights.application_insights.instrumentation_key
   content_type = "only instrumentation key"
 
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
 
 #tfsec:ignore:AZU023
@@ -45,5 +27,5 @@ resource "azurerm_key_vault_secret" "appinsights_connection_string" {
   value        = azurerm_application_insights.application_insights.connection_string
   content_type = "full connection string, example InstrumentationKey=XXXXX"
 
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }

--- a/src/core/keyvault_access_policy.tf
+++ b/src/core/keyvault_access_policy.tf
@@ -5,7 +5,7 @@ data "azuread_group" "adgroup_admin" {
 
 # kv admin policy
 resource "azurerm_key_vault_access_policy" "adgroup_admin" {
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
   object_id = data.azuread_group.adgroup_admin.object_id
@@ -18,7 +18,7 @@ resource "azurerm_key_vault_access_policy" "adgroup_admin" {
 
 # kv-common admin policy
 resource "azurerm_key_vault_access_policy" "adgroup_admin_common" {
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
   object_id = data.azuread_group.adgroup_admin.object_id
@@ -31,7 +31,7 @@ resource "azurerm_key_vault_access_policy" "adgroup_admin_common" {
 
 # kv-common managed identities reader policy
 resource "azurerm_key_vault_access_policy" "access_policy_io_infra_ci" {
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
   object_id = data.azurerm_user_assigned_identity.managed_identity_io_infra_ci.principal_id
@@ -42,7 +42,7 @@ resource "azurerm_key_vault_access_policy" "access_policy_io_infra_ci" {
 }
 
 resource "azurerm_key_vault_access_policy" "access_policy_io_infra_cd" {
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
   object_id = data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id
@@ -69,7 +69,7 @@ data "azuread_group" "adgroup_developers" {
 
 # kv developers policy
 resource "azurerm_key_vault_access_policy" "adgroup_developers" {
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
   object_id = data.azuread_group.adgroup_developers.object_id
@@ -82,7 +82,7 @@ resource "azurerm_key_vault_access_policy" "adgroup_developers" {
 
 # kv-common developers policy
 resource "azurerm_key_vault_access_policy" "adgroup_developers_common" {
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
   object_id = data.azuread_group.adgroup_developers.object_id
@@ -96,7 +96,7 @@ resource "azurerm_key_vault_access_policy" "adgroup_developers_common" {
 # Microsoft Azure WebSites
 # TODO: To remove, the old app service (api-gad) has been removed so app services not needs to access to key vaults
 resource "azurerm_key_vault_access_policy" "app_service" {
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
   object_id = "bb319217-f6ab-45d9-833d-555ef1173316"
@@ -109,7 +109,7 @@ resource "azurerm_key_vault_access_policy" "app_service" {
 # Microsoft.AzureFrontDoor-Cdn Enterprise application.
 # Note: the application id is always the same in every tenant while the object id is different.
 resource "azurerm_key_vault_access_policy" "cdn_common" {
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
   object_id = "f3b3f72f-4770-47a5-8c1e-aa298003be12"
@@ -120,7 +120,7 @@ resource "azurerm_key_vault_access_policy" "cdn_common" {
 }
 
 resource "azurerm_key_vault_access_policy" "cdn_kv" {
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
   object_id = "f3b3f72f-4770-47a5-8c1e-aa298003be12"
@@ -133,13 +133,13 @@ resource "azurerm_key_vault_access_policy" "cdn_kv" {
 data "azurerm_key_vault_secret" "sec_workspace_id" {
   count        = var.env_short == "p" ? 1 : 0
   name         = "sec-workspace-id"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_secret" "sec_storage_id" {
   count        = var.env_short == "p" ? 1 : 0
   name         = "sec-storage-id"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 #
@@ -152,7 +152,7 @@ data "azuread_service_principal" "platform_iac_sp" {
 }
 
 resource "azurerm_key_vault_access_policy" "azdevops_platform_iac_policy_kv" {
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azuread_service_principal.platform_iac_sp.object_id
 
@@ -162,7 +162,7 @@ resource "azurerm_key_vault_access_policy" "azdevops_platform_iac_policy_kv" {
 }
 
 resource "azurerm_key_vault_access_policy" "azdevops_platform_iac_policy_kv_common" {
-  key_vault_id = module.key_vault_common.id
+  key_vault_id = data.azurerm_key_vault.key_vault_common.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azuread_service_principal.platform_iac_sp.object_id
 

--- a/src/core/keyvault_access_policy.tf
+++ b/src/core/keyvault_access_policy.tf
@@ -53,7 +53,7 @@ resource "azurerm_key_vault_access_policy" "access_policy_io_infra_cd" {
 }
 
 resource "azurerm_key_vault_access_policy" "access_policy_kv_io_infra_cd" {
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
   object_id = data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id

--- a/src/core/monitor.tf
+++ b/src/core/monitor.tf
@@ -25,38 +25,38 @@ resource "azurerm_application_insights" "application_insights" {
 
 data "azurerm_key_vault_secret" "monitor_notification_slack_email" {
   name         = "monitor-notification-slack-email"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_secret" "monitor_notification_email" {
   name         = "monitor-notification-email"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_secret" "alert_error_notification_email" {
   name         = "alert-error-notification-email"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_secret" "alert_error_notification_slack" {
   name         = "alert-error-notification-slack"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_secret" "alert_quarantine_error_notification_slack" {
   name         = "alert-error-quarantine-notification-slack"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 data "azurerm_key_vault_secret" "alert_error_notification_opsgenie" {
   name         = "alert-error-notification-opsgenie"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 # point to the channel of the trial-system project
 data "azurerm_key_vault_secret" "alert_error_trial_slack" {
   name         = "alert-error-trial-slack"
-  key_vault_id = module.key_vault.id
+  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 #

--- a/src/core/prod/README.md
+++ b/src/core/prod/README.md
@@ -12,6 +12,7 @@
 |------|--------|---------|
 | <a name="module_container_registry"></a> [container\_registry](#module\_container\_registry) | ../_modules/container_registry | n/a |
 | <a name="module_global"></a> [global](#module\_global) | ../_modules/global | n/a |
+| <a name="module_key_vault_weu"></a> [key\_vault\_weu](#module\_key\_vault\_weu) | ../_modules/key_vaults | n/a |
 | <a name="module_networking_itn"></a> [networking\_itn](#module\_networking\_itn) | ../_modules/networking | n/a |
 | <a name="module_networking_weu"></a> [networking\_weu](#module\_networking\_weu) | ../_modules/networking | n/a |
 | <a name="module_vnet_peering_itn"></a> [vnet\_peering\_itn](#module\_vnet\_peering\_itn) | ../_modules/vnet_peering | n/a |
@@ -23,6 +24,7 @@
 |------|------|
 | [azurerm_resource_group.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_api_management.apim_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management) | data source |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_public_ip.appgateway_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 | [azurerm_resource_group.vnet_weu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_virtual_network.weu_beta](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |

--- a/src/core/prod/data.tf
+++ b/src/core/prod/data.tf
@@ -1,3 +1,5 @@
+data "azurerm_client_config" "current" {}
+
 data "azurerm_virtual_network" "weu_beta" {
   name                = "${local.project_weu}-beta-vnet"
   resource_group_name = "${local.project_weu}-beta-vnet-rg"

--- a/src/core/prod/westeurope.tf
+++ b/src/core/prod/westeurope.tf
@@ -71,3 +71,15 @@ module "container_registry" {
 
   tags = merge(local.tags, { Source = "https://github.com/pagopa/io-infra" })
 }
+
+module "key_vault_weu" {
+  source = "../_modules/key_vaults"
+
+  location              = data.azurerm_resource_group.vnet_weu.location
+  location_short        = local.location_short[data.azurerm_resource_group.vnet_weu.location]
+  project               = local.project_weu_legacy
+  resource_group_common = data.azurerm_resource_group.vnet_weu.name
+  tenant_id             = data.azurerm_client_config.current.tenant_id
+
+  tags = merge(local.tags)
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Move resources from legacy core folder to the new one organizing files in modules, to reuse them across two regions

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
As discussed several times, core TF configuration is too big and must be split through different configs. This file structure makes it easier reusing same definitions. Resources that will be included in this config are listed in Confluence RFC. Everything else will be moved apart

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
