### PR TITLE
[IOPAE-1329] remove postgres host suffix from username

### DIFF
--- a/src/domains/selfcare/_modules/app_services/locals.tf
+++ b/src/domains/selfcare/_modules/app_services/locals.tf
@@ -170,7 +170,7 @@ locals {
       DB_NAME         = "db"
       DB_SCHEMA       = "DeveloperPortalServiceData"
       DB_TABLE        = "services"
-      DB_USER         = "${var.dev_portal_db_data.username}@${var.dev_portal_db_data.host}"
+      DB_USER         = "${var.dev_portal_db_data.username}"
       DB_PASSWORD     = var.dev_portal_db_data.password
 
       WEBSITE_DNS_SERVER = "168.63.129.16"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Remove `@<host>` suffix from Postgres username

### List of changes
<!--- Describe your changes in detail -->
- [remove postgres host suffix from username](https://github.com/pagopa/io-infra/commit/85fc80814ede81c70a09b90f6e2de3104a752c08)

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
Username value with `@<host>` suffix do not work anymore on _Azure Database for PostgreSQL flexible server_

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
