### PR TITLE
[#IOPID-2152] Create profile failure queue and poison

### DIFF
--- a/src/domains/elt/_modules/function_apps/function_app_elt.tf
+++ b/src/domains/elt/_modules/function_apps/function_app_elt.tf
@@ -95,6 +95,7 @@ locals {
       MESSAGE_STATUS_FAILURE_QUEUE_NAME      = "pdnd-io-cosmosdb-message-status-failure"
       SERVICES_FAILURE_QUEUE_NAME            = "pdnd-io-cosmosdb-services-failure"
       SERVICE_PREFERENCES_FAILURE_QUEUE_NAME = "pdnd-io-cosmosdb-service-preferences-failure"
+      PROFILES_FAILURE_QUEUE_NAME            = "pdnd-io-cosmosdb-profiles-failure"
 
       INTERNAL_TEST_FISCAL_CODES = module.tests.test_users.all
     }
@@ -166,7 +167,9 @@ module "function_elt" {
       local.function_elt.app_settings.SERVICES_FAILURE_QUEUE_NAME,
       "${local.function_elt.app_settings.SERVICES_FAILURE_QUEUE_NAME}-poison",
       local.function_elt.app_settings.SERVICE_PREFERENCES_FAILURE_QUEUE_NAME,
-      "${local.function_elt.app_settings.SERVICE_PREFERENCES_FAILURE_QUEUE_NAME}-poison"
+      "${local.function_elt.app_settings.SERVICE_PREFERENCES_FAILURE_QUEUE_NAME}-poison",
+      local.function_elt.app_settings.PROFILES_FAILURE_QUEUE_NAME,
+      "${local.function_elt.app_settings.PROFILES_FAILURE_QUEUE_NAME}-poison"
     ],
     "containers"           = [],
     "blobs_retention_days" = 1,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Create two new queue to handle profiles changefeed processor failures retry.
Add failure queue name variable to the `fn-elt` function.

<!--- Describe your changes in detail -->

### Motivation and context
To handle failures retry scenarios are used queue and queue trigger. This PR add the required queue and configuration.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [X] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
