### PR TITLE
[#IOPID-1925] Alert Profile poison

### DIFF
--- a/src/domains/elt/_modules/function_apps/function_app_elt.tf
+++ b/src/domains/elt/_modules/function_apps/function_app_elt.tf
@@ -95,7 +95,7 @@ locals {
       MESSAGE_STATUS_FAILURE_QUEUE_NAME      = "pdnd-io-cosmosdb-message-status-failure"
       SERVICES_FAILURE_QUEUE_NAME            = "pdnd-io-cosmosdb-services-failure"
       SERVICE_PREFERENCES_FAILURE_QUEUE_NAME = local.service_preferences_failure_queue_name
-      PROFILES_FAILURE_QUEUE_NAME            = "pdnd-io-cosmosdb-profiles-failure"
+      PROFILES_FAILURE_QUEUE_NAME            = local.profiles_failure_queue_name
 
       INTERNAL_TEST_FISCAL_CODES = module.tests.test_users.all
     }
@@ -168,8 +168,8 @@ module "function_elt" {
       "${local.function_elt.app_settings.SERVICES_FAILURE_QUEUE_NAME}-poison",
       local.service_preferences_failure_queue_name,
       "${local.service_preferences_failure_queue_name}-poison",
-      local.function_elt.app_settings.PROFILES_FAILURE_QUEUE_NAME,
-      "${local.function_elt.app_settings.PROFILES_FAILURE_QUEUE_NAME}-poison"
+      local.profiles_failure_queue_name,
+      "${local.profiles_failure_queue_name}-poison"
     ],
     "containers"           = [],
     "blobs_retention_days" = 1,

--- a/src/domains/elt/_modules/function_apps/locals.tf
+++ b/src/domains/elt/_modules/function_apps/locals.tf
@@ -17,4 +17,5 @@ locals {
   pn_service_id = "01G40DWQGKY5GRWSNM4303VNRP"
 
   service_preferences_failure_queue_name = "pdnd-io-cosmosdb-service-preferences-failure"
+  profiles_failure_queue_name            = "pdnd-io-cosmosdb-profiles-failure"
 }

--- a/src/domains/elt/_modules/function_apps/monitor.tf
+++ b/src/domains/elt/_modules/function_apps/monitor.tf
@@ -56,3 +56,37 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "service_preferences_f
 
   tags = var.tags
 }
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "profiles_failure_alert_rule" {
+  enabled             = true
+  name                = "[CITIZEN-AUTH | iopfneltsdt] Failures on pdnd-io-cosmosdb-profiles-failure-poison"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  scopes                  = [data.azurerm_storage_account.function_elt_internal_storage.id]
+  description             = "Permanent failures processing Profiles export to PDND. REQUIRED MANUAL ACTION"
+  severity                = 1
+  auto_mitigation_enabled = false
+
+  window_duration      = "PT15M" # Select the interval that's used to group the data points by using the aggregation type function. Choose an Aggregation granularity (period) that's greater than the Frequency of evaluation to reduce the likelihood of missing the first evaluation period of an added time series.
+  evaluation_frequency = "PT15M" # Select how often the alert rule is to be run. Select a frequency that's smaller than the aggregation granularity to generate a sliding window for the evaluation.
+
+  criteria {
+    query                   = <<-QUERY
+      StorageQueueLogs
+        | where OperationName contains "PutMessage"
+        | where Uri contains "${local.profiles_failure_queue_name}-poison"
+      QUERY
+    operator                = "GreaterThan"
+    threshold               = 0
+    time_aggregation_method = "Count"
+  }
+
+  action {
+    action_groups = [
+      data.azurerm_monitor_action_group.quarantine_error_action_group.id,
+    ]
+  }
+
+  tags = var.tags
+}


### PR DESCRIPTION
⚠️ Depends on https://github.com/pagopa/io-infra/pull/1132
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
<!--- Describe your changes in detail -->
Create an alert listening on new messages come into the poison queue for Profiles.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
When the queue retry on errors for the processing of Profiles elapse, the message is moved into the poison queue. This require a manual action to move these messages into the normal retry queue. An alert advise developers of the required action.

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
