### PR TITLE
[IOCOM-1636] Added apis to point citizen exposed messages functions

### DIFF
--- a/src/domains/messages-common/05_apim_v2.tf
+++ b/src/domains/messages-common/05_apim_v2.tf
@@ -312,21 +312,10 @@ module "apim_v2_product_messages_backend" {
   policy_xml = file("./api_product/backend/_base_policy.xml")
 }
 
-resource "azurerm_api_management_user" "messages_backend_user" {
-  user_id             = "iobackenduser"
-  api_management_name = data.azurerm_api_management.apim_v2_api.name
-  resource_group_name = data.azurerm_api_management.apim_v2_api.resource_group_name
-  first_name          = "IO Backend"
-  last_name           = "Messages"
-  email               = "io-comunicazione@pagopa.it"
-  state               = "active"
-}
-
 
 resource "azurerm_api_management_subscription" "messages_backend_v2" {
   api_management_name = data.azurerm_api_management.apim_v2_api.name
   resource_group_name = data.azurerm_api_management.apim_v2_api.resource_group_name
-  user_id             = azurerm_api_management_user.messages_backend_user.id
   product_id          = module.apim_v2_product_messages_backend.id
   display_name        = "Messages Backend API"
   state               = "active"

--- a/src/domains/messages-common/05_apim_v2.tf
+++ b/src/domains/messages-common/05_apim_v2.tf
@@ -295,6 +295,23 @@ module "apim_v2_service_messages_internal_api_v1" {
 }
 
 # MESSAGES CITIZEN FUNC
+module "apim_v2_product_messages_backend" {
+  source = "github.com/pagopa/terraform-azurerm-v3//api_management_product?ref=v8.27.0"
+
+  product_id   = "io-messages-backend-api"
+  display_name = "IO MESSAGES BACKEND API"
+  description  = "Product for IO MESSAGES BACKEND API"
+
+  api_management_name = data.azurerm_api_management.apim_v2_api.name
+  resource_group_name = data.azurerm_api_management.apim_v2_api.resource_group_name
+
+  published             = true
+  subscription_required = true
+  approval_required     = false
+
+  policy_xml = file("./api_product/backend/_base_policy.xml")
+}
+
 data "http" "messages_citizen_openapi" {
   url = "https://github.com/pagopa/io-messages/blob/main/apps/citizen-func/openapi/index.yaml"
 }
@@ -305,13 +322,13 @@ module "apim_v2_messages_citizen_l1_api_v1" {
   name                  = format("%s-%s-messages-citizen-api-01", local.product, var.location_short)
   api_management_name   = data.azurerm_api_management.apim_v2_api.name
   resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
-  product_ids           = [module.apim_v2_product_notifications.product_id]
+  product_ids           = [module.apim_v2_product_messages_backend.product_id]
   subscription_required = true
   service_url           = null
 
   description  = "IO Messages Citizen - L1 - API"
   display_name = "IO Messages Citizen - L1 - API"
-  path         = "l1/api/v1/"
+  path         = "l1/api/v1"
   protocols    = ["https"]
 
   content_format = "openapi"
@@ -326,13 +343,13 @@ module "apim_v2_messages_citizen_l2_api_v1" {
   name                  = format("%s-%s-messages-citizen-api-02", local.product, var.location_short)
   api_management_name   = data.azurerm_api_management.apim_v2_api.name
   resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
-  product_ids           = [module.apim_v2_product_notifications.product_id]
+  product_ids           = [module.apim_v2_product_messages_backend.product_id]
   subscription_required = true
   service_url           = null
 
   description  = "IO Messages Citizen - L2 - API"
   display_name = "IO Messages Citizen - L2 - API"
-  path         = "l2/api/v1/"
+  path         = "l2/api/v1"
   protocols    = ["https"]
 
   content_format = "openapi"

--- a/src/domains/messages-common/05_apim_v2.tf
+++ b/src/domains/messages-common/05_apim_v2.tf
@@ -312,6 +312,27 @@ module "apim_v2_product_messages_backend" {
   policy_xml = file("./api_product/backend/_base_policy.xml")
 }
 
+resource "azurerm_api_management_user" "messages_backend_user" {
+  user_id             = "iobackenduser"
+  api_management_name = data.azurerm_api_management.apim_v2_api.name
+  resource_group_name = data.azurerm_api_management.apim_v2_api.resource_group_name
+  first_name          = "IO Backend"
+  last_name           = "Messages"
+  email               = "io-comunicazione@pagopa.it"
+  state               = "active"
+}
+
+
+resource "azurerm_api_management_subscription" "messages_backend_v2" {
+  api_management_name = data.azurerm_api_management.apim_v2_api.name
+  resource_group_name = data.azurerm_api_management.apim_v2_api.resource_group_name
+  user_id             = azurerm_api_management_user.messages_backend_user.id
+  product_id          = module.apim_v2_product_messages_backend.id
+  display_name        = "Messages Backend API"
+  state               = "active"
+  allow_tracing       = false
+}
+
 data "http" "messages_citizen_openapi" {
   url = "https://github.com/pagopa/io-messages/blob/main/apps/citizen-func/openapi/index.yaml"
 }

--- a/src/domains/messages-common/05_apim_v2.tf
+++ b/src/domains/messages-common/05_apim_v2.tf
@@ -305,7 +305,7 @@ module "apim_v2_messages_citizen_l1_api_v1" {
   name                  = format("%s-%s-messages-citizen-api-01", local.product, var.location_short)
   api_management_name   = data.azurerm_api_management.apim_v2_api.name
   resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
-  product_ids           = [data.azurerm_api_management_product.apim_v2_product_notifications.product_id]
+  product_ids           = [module.apim_v2_product_notifications.product_id]
   subscription_required = true
   service_url           = null
 
@@ -326,7 +326,7 @@ module "apim_v2_messages_citizen_l2_api_v1" {
   name                  = format("%s-%s-messages-citizen-api-02", local.product, var.location_short)
   api_management_name   = data.azurerm_api_management.apim_v2_api.name
   resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
-  product_ids           = [data.azurerm_api_management_product.apim_v2_product_notifications.product_id]
+  product_ids           = [module.apim_v2_product_notifications.product_id]
   subscription_required = true
   service_url           = null
 

--- a/src/domains/messages-common/05_apim_v2.tf
+++ b/src/domains/messages-common/05_apim_v2.tf
@@ -334,7 +334,7 @@ resource "azurerm_api_management_subscription" "messages_backend_v2" {
 }
 
 data "http" "messages_citizen_openapi" {
-  url = "https://github.com/pagopa/io-messages/blob/main/apps/citizen-func/openapi/index.yaml"
+  url = "https://raw.githubusercontent.com/pagopa/io-messages/main/apps/citizen-func/openapi/index.yaml"
 }
 
 module "apim_v2_messages_citizen_l1_api_v1" {

--- a/src/domains/messages-common/05_apim_v2.tf
+++ b/src/domains/messages-common/05_apim_v2.tf
@@ -190,6 +190,7 @@ data "azurerm_api_management_product" "apim_v2_product_services" {
 
 # APIM APIs
 
+# MESSAGES SENDING FUNC EXTERNAL
 data "http" "messages_sending_external_openapi" {
   url = "https://raw.githubusercontent.com/pagopa/io-functions-services-messages/master/openapi/index_external.yaml"
 }
@@ -215,6 +216,7 @@ module "apim_v2_messages_sending_external_api_v1" {
   xml_content = file("./api/messages-sending/v1/_base_policy_external.xml")
 }
 
+# MESSAGES SENDING FUNC INTERNAL
 data "http" "messages_sending_internal_openapi" {
   url = "https://raw.githubusercontent.com/pagopa/io-functions-services-messages/master/openapi/index.yaml"
 }
@@ -240,6 +242,7 @@ module "apim_v2_messages_sending_internal_api_v1" {
   xml_content = file("./api/messages-sending/v1/_base_policy_internal.xml")
 }
 
+# SERVICE MESSAGE MANAGE (TO REMOVE)
 data "http" "service_messages_manage_openapi" {
   url = "https://raw.githubusercontent.com/pagopa/io-functions-services-messages/833616dceab72bd65c4d3875c64eb75787b19258/openapi/index_external.yaml"
 }
@@ -265,6 +268,7 @@ module "apim_v2_service_messages_manage_api_v1" {
   xml_content = file("./api/service-messages/v1/_base_policy.xml")
 }
 
+# SERVICE MESSAGE INTERNAL (TO REMOVE)
 data "http" "service_messages_internal_openapi" {
   url = "https://raw.githubusercontent.com/pagopa/io-functions-services-messages/833616dceab72bd65c4d3875c64eb75787b19258/openapi/index.yaml"
 }
@@ -288,4 +292,51 @@ module "apim_v2_service_messages_internal_api_v1" {
   content_value  = data.http.service_messages_internal_openapi.body
 
   xml_content = file("./api/service-messages/v1/_base_policy.xml")
+}
+
+# MESSAGES CITIZEN FUNC
+data "http" "messages_citizen_openapi" {
+  url = "https://github.com/pagopa/io-messages/blob/main/apps/citizen-func/openapi/index.yaml"
+}
+
+module "apim_v2_messages_citizen_l1_api_v1" {
+  source = "github.com/pagopa/terraform-azurerm-v3//api_management_api?ref=v8.17.0"
+
+  name                  = format("%s-%s-messages-citizen-api-01", local.product, var.location_short)
+  api_management_name   = data.azurerm_api_management.apim_v2_api.name
+  resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
+  product_ids           = [data.azurerm_api_management_product.apim_v2_product_notifications.product_id]
+  subscription_required = true
+  service_url           = null
+
+  description  = "IO Messages Citizen - L1 - API"
+  display_name = "IO Messages Citizen - L1 - API"
+  path         = "l1/api/v1/"
+  protocols    = ["https"]
+
+  content_format = "openapi"
+  content_value  = data.http.messages_citizen_openapi.body
+
+  xml_content = file("./api/messages-citizen/v1/_base_policy_l1.xml")
+}
+
+module "apim_v2_messages_citizen_l2_api_v1" {
+  source = "github.com/pagopa/terraform-azurerm-v3//api_management_api?ref=v8.17.0"
+
+  name                  = format("%s-%s-messages-citizen-api-02", local.product, var.location_short)
+  api_management_name   = data.azurerm_api_management.apim_v2_api.name
+  resource_group_name   = data.azurerm_api_management.apim_v2_api.resource_group_name
+  product_ids           = [data.azurerm_api_management_product.apim_v2_product_notifications.product_id]
+  subscription_required = true
+  service_url           = null
+
+  description  = "IO Messages Citizen - L2 - API"
+  display_name = "IO Messages Citizen - L2 - API"
+  path         = "l2/api/v1/"
+  protocols    = ["https"]
+
+  content_format = "openapi"
+  content_value  = data.http.messages_citizen_openapi.body
+
+  xml_content = file("./api/messages-citizen/v1/_base_policy_l2.xml")
 }

--- a/src/domains/messages-common/README.md
+++ b/src/domains/messages-common/README.md
@@ -16,6 +16,7 @@
 | <a name="module_apim_v2_messages_citizen_l2_api_v1"></a> [apim\_v2\_messages\_citizen\_l2\_api\_v1](#module\_apim\_v2\_messages\_citizen\_l2\_api\_v1) | github.com/pagopa/terraform-azurerm-v3//api_management_api | v8.17.0 |
 | <a name="module_apim_v2_messages_sending_external_api_v1"></a> [apim\_v2\_messages\_sending\_external\_api\_v1](#module\_apim\_v2\_messages\_sending\_external\_api\_v1) | github.com/pagopa/terraform-azurerm-v3//api_management_api | v8.17.0 |
 | <a name="module_apim_v2_messages_sending_internal_api_v1"></a> [apim\_v2\_messages\_sending\_internal\_api\_v1](#module\_apim\_v2\_messages\_sending\_internal\_api\_v1) | github.com/pagopa/terraform-azurerm-v3//api_management_api | v8.27.0 |
+| <a name="module_apim_v2_product_messages_backend"></a> [apim\_v2\_product\_messages\_backend](#module\_apim\_v2\_product\_messages\_backend) | github.com/pagopa/terraform-azurerm-v3//api_management_product | v8.27.0 |
 | <a name="module_apim_v2_product_notifications"></a> [apim\_v2\_product\_notifications](#module\_apim\_v2\_product\_notifications) | github.com/pagopa/terraform-azurerm-v3//api_management_product | v8.27.0 |
 | <a name="module_apim_v2_service_messages_internal_api_v1"></a> [apim\_v2\_service\_messages\_internal\_api\_v1](#module\_apim\_v2\_service\_messages\_internal\_api\_v1) | github.com/pagopa/terraform-azurerm-v3//api_management_api | v8.27.0 |
 | <a name="module_apim_v2_service_messages_manage_api_v1"></a> [apim\_v2\_service\_messages\_manage\_api\_v1](#module\_apim\_v2\_service\_messages\_manage\_api\_v1) | github.com/pagopa/terraform-azurerm-v3//api_management_api | v8.27.0 |
@@ -45,6 +46,7 @@
 | [azurerm_api_management_group_user.payment_group_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group_user) | resource |
 | [azurerm_api_management_group_user.reminder_group_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group_user) | resource |
 | [azurerm_api_management_named_value.io_p_messages_sending_func_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
+| [azurerm_api_management_subscription.messages_backend_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_subscription) | resource |
 | [azurerm_api_management_subscription.payment_updater_reminder_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_subscription) | resource |
 | [azurerm_api_management_subscription.reminder_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_subscription) | resource |
 | [azurerm_api_management_user.reminder_user_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_user) | resource |

--- a/src/domains/messages-common/README.md
+++ b/src/domains/messages-common/README.md
@@ -12,6 +12,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_apim_v2_messages_citizen_l1_api_v1"></a> [apim\_v2\_messages\_citizen\_l1\_api\_v1](#module\_apim\_v2\_messages\_citizen\_l1\_api\_v1) | github.com/pagopa/terraform-azurerm-v3//api_management_api | v8.17.0 |
+| <a name="module_apim_v2_messages_citizen_l2_api_v1"></a> [apim\_v2\_messages\_citizen\_l2\_api\_v1](#module\_apim\_v2\_messages\_citizen\_l2\_api\_v1) | github.com/pagopa/terraform-azurerm-v3//api_management_api | v8.17.0 |
 | <a name="module_apim_v2_messages_sending_external_api_v1"></a> [apim\_v2\_messages\_sending\_external\_api\_v1](#module\_apim\_v2\_messages\_sending\_external\_api\_v1) | github.com/pagopa/terraform-azurerm-v3//api_management_api | v8.17.0 |
 | <a name="module_apim_v2_messages_sending_internal_api_v1"></a> [apim\_v2\_messages\_sending\_internal\_api\_v1](#module\_apim\_v2\_messages\_sending\_internal\_api\_v1) | github.com/pagopa/terraform-azurerm-v3//api_management_api | v8.27.0 |
 | <a name="module_apim_v2_product_notifications"></a> [apim\_v2\_product\_notifications](#module\_apim\_v2\_product\_notifications) | github.com/pagopa/terraform-azurerm-v3//api_management_product | v8.27.0 |
@@ -113,6 +115,7 @@
 | [azurerm_user_assigned_identity.managed_identity_io_messages_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [azurerm_user_assigned_identity.managed_identity_io_messages_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [azurerm_virtual_network.vnet_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
+| [http_http.messages_citizen_openapi](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [http_http.messages_sending_external_openapi](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [http_http.messages_sending_internal_openapi](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [http_http.service_messages_internal_openapi](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |

--- a/src/domains/messages-common/api/messages-citizen/v1/_base_policy_l1.xml
+++ b/src/domains/messages-common/api/messages-citizen/v1/_base_policy_l1.xml
@@ -1,0 +1,19 @@
+<policies>
+    <inbound>
+        <base />
+        <ip-filter action="forbid">
+            <!-- io-p-appgateway-snet  -->
+            <address-range from="10.0.13.0" to="10.0.13.255" />
+        </ip-filter>
+        <set-backend-service base-url="https://io-p-app-messages-fn-1.azurewebsites.net/api/v1" />
+    </inbound>
+    <outbound>
+        <base />
+    </outbound>
+    <backend>
+        <base />
+    </backend>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/domains/messages-common/api/messages-citizen/v1/_base_policy_l2.xml
+++ b/src/domains/messages-common/api/messages-citizen/v1/_base_policy_l2.xml
@@ -1,0 +1,19 @@
+<policies>
+    <inbound>
+        <base />
+        <ip-filter action="forbid">
+            <!-- io-p-appgateway-snet  -->
+            <address-range from="10.0.13.0" to="10.0.13.255" />
+        </ip-filter>
+        <set-backend-service base-url="https://io-p-app-messages-fn-2.azurewebsites.net/api/v1" />
+    </inbound>
+    <outbound>
+        <base />
+    </outbound>
+    <backend>
+        <base />
+    </backend>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/domains/messages-common/api_product/backend/_base_policy.xml
+++ b/src/domains/messages-common/api_product/backend/_base_policy.xml
@@ -1,0 +1,19 @@
+<policies>
+    <inbound>
+        <base />
+        <!-- PRIVATE PRODUCT -->
+        <ip-filter action="allow">
+            <address-range from="10.0.0.0" to="10.255.255.255" />
+            <address-range from="172.16.2.0" to="172.16.2.255" />
+        </ip-filter>
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/domains/messages-common/api_product/backend/_base_policy.xml
+++ b/src/domains/messages-common/api_product/backend/_base_policy.xml
@@ -3,8 +3,8 @@
         <base />
         <!-- PRIVATE PRODUCT -->
         <ip-filter action="allow">
-            <address-range from="10.0.0.0" to="10.255.255.255" />
-            <address-range from="172.16.2.0" to="172.16.2.255" />
+            <address-range from="10.0.0.0" to="10.0.255.255" />
+            <address-range from="10.20.0.0" to="10.20.255.255" />
         </ip-filter>
     </inbound>
     <backend>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Added APIs to be called from `io-backend`, `l1` and `l2`, to retrieve citizens' messages.

### Motivation and context
We need to proxy `citizen-func` with APIM to allow for migrations and open to other possible needs.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No
