### PR TITLE
[#IOPID-2078] removed FF env variable of well established features

### DIFF
--- a/src/domains/citizen-auth-app/08_session_manager.tf
+++ b/src/domains/citizen-auth-app/08_session_manager.tf
@@ -140,7 +140,6 @@ locals {
     FAST_LOGIN_API_URL = var.fastlogin_enabled ? "https://${module.function_fast_login[0].default_hostname}" : ""
 
     # Functions Lollipop config
-    FF_LOLLIPOP_ENABLED    = "1"
     LOLLIPOP_API_BASE_PATH = "/api/v1"
     LOLLIPOP_API_URL       = "https://${module.function_lollipop_itn.default_hostname}"
     LOLLIPOP_API_KEY       = data.azurerm_key_vault_secret.functions_lollipop_api_key.value
@@ -151,10 +150,6 @@ locals {
     # Fast Login config
     FF_FAST_LOGIN = "ALL"
     LV_TEST_USERS = module.tests.test_users.all
-
-    # UNIQUE EMAIL ENFORCEMENT
-    FF_UNIQUE_EMAIL_ENFORCEMENT    = "ALL"
-    UNIQUE_EMAIL_ENFORCEMENT_USERS = data.azurerm_key_vault_secret.session_manager_UNIQUE_EMAIL_ENFORCEMENT_USER.value
 
     # MITIGATION APP BUG EMAIL VALIDATION
     IS_SPID_EMAIL_PERSISTENCE_ENABLED = "false"
@@ -219,9 +214,6 @@ locals {
     # PAGOPA config
     PAGOPA_BASE_PATH             = "/pagopa/api/v1"
     ALLOW_PAGOPA_IP_SOURCE_RANGE = data.azurerm_key_vault_secret.session_manager_ALLOW_PAGOPA_IP_SOURCE_RANGE.value
-
-    # Feature Flag
-    FF_USER_AGE_LIMIT_ENABLED = 1
   }
 }
 


### PR DESCRIPTION
## ⚠️ This PR depends on https://github.com/pagopa/io-auth-n-identity-domain/pull/99 
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
* [[#IOPID-2078] removed FF env variable of wel established features](https://github.com/pagopa/io-infra/commit/e896367e2ae5352c6c6c848720b01465b2694da2)
<!--- Describe your changes in detail -->

### Motivation and context
this well established features don't need a feature flag anymore

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
