### PR TITLE
[EC-318] Allowed GitHub Runner subnet for io-subscription-migration and io-developer-portal-service-data

### DIFF
--- a/src/domains/selfcare/_modules/app_services/data.tf
+++ b/src/domains/selfcare/_modules/app_services/data.tf
@@ -16,6 +16,12 @@ data "azurerm_subnet" "services_cms_backoffice_snet_itn" {
   resource_group_name  = "${var.project}-itn-common-rg-01"
 }
 
+data "azurerm_subnet" "self_hosted_runner_snet" {
+  name                 = "io-p-github-runner-snet"
+  virtual_network_name = local.vnet_name_common
+  resource_group_name  = local.resource_group_name_common
+}
+
 data "azurerm_cosmosdb_account" "cosmos_api" {
   name                = "${var.project}-cosmos-api"
   resource_group_name = "${var.project}-rg-internal"

--- a/src/domains/selfcare/_modules/app_services/function_devportal_service_data.tf
+++ b/src/domains/selfcare/_modules/app_services/function_devportal_service_data.tf
@@ -44,6 +44,9 @@ module "function_devportalservicedata" {
   subnet_id   = var.subnet_id
   allowed_ips = var.app_insights_ips
   allowed_subnets = [
+    # self hosted runners subnet
+    data.azurerm_subnet.self_hosted_runner_snet.id,
+    #
     var.subnet_id,
   ]
 
@@ -90,6 +93,9 @@ module "function_devportalservicedata_staging_slot" {
     [],
   )
   allowed_subnets = [
+    # self hosted runners subnet
+    data.azurerm_subnet.self_hosted_runner_snet.id,
+    #
     data.azurerm_subnet.snet_azdoa.id
   ]
 

--- a/src/domains/selfcare/_modules/app_services/function_subscription_migrations.tf
+++ b/src/domains/selfcare/_modules/app_services/function_subscription_migrations.tf
@@ -30,6 +30,9 @@ module "function_subscriptionmigrations" {
   subnet_id   = var.subnet_id
   allowed_ips = var.app_insights_ips
   allowed_subnets = [
+    # self hosted runners subnet
+    data.azurerm_subnet.self_hosted_runner_snet.id,
+    #
     var.subnet_id,
     data.azurerm_subnet.services_cms_backoffice_snet_itn.id
   ]
@@ -87,6 +90,9 @@ module "function_subscriptionmigrations_staging_slot" {
     [],
   )
   allowed_subnets = [
+    # self hosted runners subnet
+    data.azurerm_subnet.self_hosted_runner_snet.id,
+    #
     data.azurerm_subnet.snet_azdoa.id
   ]
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Added runner subnet as allowed for functions

- `io-subscription-migration`
- `io-developer-portal-service-data`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The functions need a selfhosted runner.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
