### PR TITLE
[CES-107] Switch Messages Cosmos secondary location to ItalyNorth

### DIFF
--- a/src/domains/messages-common/03_database.tf
+++ b/src/domains/messages-common/03_database.tf
@@ -43,9 +43,9 @@ module "cosmosdb_account_mongodb_reminder" {
   main_geo_location_location       = azurerm_resource_group.data_rg.location
   main_geo_location_zone_redundant = false
   additional_geo_locations = [{
-    location          = "northeurope"
+    location          = "italynorth"
     failover_priority = 1
-    zone_redundant    = false
+    zone_redundant    = true
   }]
   consistency_policy = {
     consistency_level       = "Session"
@@ -303,9 +303,9 @@ module "cosmosdb_account_remote_content" {
   main_geo_location_zone_redundant = true
 
   additional_geo_locations = [{
-    location          = "northeurope"
+    location          = "italynorth"
     failover_priority = 1
-    zone_redundant    = false
+    zone_redundant    = true
   }]
 
   consistency_policy = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Replace NorthEurope with ItalyNorth region for data redundancy in read-only mode for messages namespace

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

ItalyNorth migration. This is a first step to have data in ItalyNorth without affecting operations on the main region, WestEurope

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
