### PR TITLE
[CES-124] Add new Session Manager instance to AppGw backend pool

### DIFF
--- a/src/common/_modules/application_gateway/data.tf
+++ b/src/common/_modules/application_gateway/data.tf
@@ -12,8 +12,13 @@ data "azurerm_linux_web_app" "appservice_continua" {
   resource_group_name = "${var.project}-continua-rg"
 }
 
-data "azurerm_linux_web_app" "session_manager" {
+data "azurerm_linux_web_app" "session_manager_03" {
   name                = "io-p-weu-session-manager-app-03"
+  resource_group_name = "io-p-weu-session-manager-rg-01"
+}
+
+data "azurerm_linux_web_app" "session_manager_04" {
+  name                = "io-p-weu-session-manager-app-04"
   resource_group_name = "io-p-weu-session-manager-rg-01"
 }
 

--- a/src/common/_modules/application_gateway/main.tf
+++ b/src/common/_modules/application_gateway/main.tf
@@ -48,7 +48,8 @@ module "app_gw" {
       port         = 443
       ip_addresses = null # with null value use fqdns
       fqdns = [
-        data.azurerm_linux_web_app.session_manager.default_hostname
+        data.azurerm_linux_web_app.session_manager_03.default_hostname,
+        data.azurerm_linux_web_app.session_manager_04.default_hostname
       ]
       probe                       = "/healthcheck"
       probe_name                  = "probe-session-manager-app"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add new Session Manager instance to AppGw backend pool

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Split incoming traffic to the two Session Manager instances using round robin pattern

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Depends On [#1193](https://github.com/pagopa/io-auth-n-identity-domain/pull/106)

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
