### PR TITLE
[#IOPID-2321] Disable public access to lv functions

### DIFF
--- a/src/domains/citizen-auth-app/04_function_lollipop.tf
+++ b/src/domains/citizen-auth-app/04_function_lollipop.tf
@@ -90,6 +90,8 @@ module "function_lollipop_itn" {
   health_check_path            = "/info"
   health_check_maxpingfailures = "2"
 
+  enable_function_app_public_network_access = false
+
   storage_account_info = {
     account_kind                      = "StorageV2"
     account_tier                      = "Standard"

--- a/src/domains/citizen-auth-app/07_function_fast_login.tf
+++ b/src/domains/citizen-auth-app/07_function_fast_login.tf
@@ -118,7 +118,7 @@ module "fast_login_snet_itn" {
 }
 
 module "function_fast_login_itn" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app?ref=v8.22.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app?ref=v8.44.0"
 
   resource_group_name          = azurerm_resource_group.fast_login_rg_itn.name
   name                         = format("%s-auth-lv-fn-01", local.common_project_itn)
@@ -181,7 +181,7 @@ module "function_fast_login_itn" {
 }
 
 module "function_fast_login_staging_slot_itn" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app_slot?ref=v8.22.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app_slot?ref=v8.44.0"
 
   name                = "staging"
   location            = local.itn_location

--- a/src/domains/citizen-auth-app/07_function_fast_login.tf
+++ b/src/domains/citizen-auth-app/07_function_fast_login.tf
@@ -127,6 +127,8 @@ module "function_fast_login_itn" {
   health_check_path            = "/info"
   health_check_maxpingfailures = "2"
 
+  enable_function_app_public_network_access = false
+
   node_version    = "18"
   runtime_version = "~4"
 
@@ -165,12 +167,6 @@ module "function_fast_login_itn" {
   subnet_id = module.fast_login_snet_itn.id
 
   allowed_subnets = [
-    module.fast_login_snet_itn.id,
-    data.azurerm_subnet.apim_v2_snet.id,
-    data.azurerm_subnet.app_backend_l1_snet.id,
-    data.azurerm_subnet.app_backend_l2_snet.id,
-    data.azurerm_subnet.ioweb_profile_snet.id,
-    module.session_manager_snet.id,
   ]
 
   # Action groups for alerts
@@ -194,6 +190,8 @@ module "function_fast_login_staging_slot_itn" {
   app_service_plan_id = module.function_fast_login_itn.app_service_plan_id
   health_check_path   = "/info"
 
+  enable_function_app_public_network_access = false
+
   storage_account_name               = module.function_fast_login_itn.storage_account.name
   storage_account_access_key         = module.function_fast_login_itn.storage_account.primary_access_key
   internal_storage_connection_string = module.function_fast_login_itn.storage_account_internal_function.primary_connection_string
@@ -214,11 +212,7 @@ module "function_fast_login_staging_slot_itn" {
   subnet_id = module.fast_login_snet_itn.id
 
   allowed_subnets = [
-    module.fast_login_snet_itn.id,
     data.azurerm_subnet.azdoa_snet[0].id,
-    data.azurerm_subnet.apim_v2_snet.id,
-    data.azurerm_subnet.app_backend_l1_snet.id,
-    data.azurerm_subnet.app_backend_l2_snet.id
   ]
 
   tags = var.tags

--- a/src/domains/citizen-auth-app/README.md
+++ b/src/domains/citizen-auth-app/README.md
@@ -17,10 +17,10 @@
 | <a name="module_fast_login_snet"></a> [fast\_login\_snet](#module\_fast\_login\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v8.22.0 |
 | <a name="module_fast_login_snet_itn"></a> [fast\_login\_snet\_itn](#module\_fast\_login\_snet\_itn) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v8.22.0 |
 | <a name="module_function_fast_login"></a> [function\_fast\_login](#module\_function\_fast\_login) | git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app | v8.22.0 |
-| <a name="module_function_fast_login_itn"></a> [function\_fast\_login\_itn](#module\_function\_fast\_login\_itn) | git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app | v8.22.0 |
+| <a name="module_function_fast_login_itn"></a> [function\_fast\_login\_itn](#module\_function\_fast\_login\_itn) | git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app | v8.44.0 |
 | <a name="module_function_fast_login_itn_autoscale"></a> [function\_fast\_login\_itn\_autoscale](#module\_function\_fast\_login\_itn\_autoscale) | github.com/pagopa/dx//infra/modules/azure_app_service_plan_autoscaler | 15236aabcaf855b5b00709bcbb9b0ec177ba71b9 |
 | <a name="module_function_fast_login_staging_slot"></a> [function\_fast\_login\_staging\_slot](#module\_function\_fast\_login\_staging\_slot) | git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app_slot | v8.22.0 |
-| <a name="module_function_fast_login_staging_slot_itn"></a> [function\_fast\_login\_staging\_slot\_itn](#module\_function\_fast\_login\_staging\_slot\_itn) | git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app_slot | v8.22.0 |
+| <a name="module_function_fast_login_staging_slot_itn"></a> [function\_fast\_login\_staging\_slot\_itn](#module\_function\_fast\_login\_staging\_slot\_itn) | git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app_slot | v8.44.0 |
 | <a name="module_function_lollipop_itn"></a> [function\_lollipop\_itn](#module\_function\_lollipop\_itn) | github.com/pagopa/terraform-azurerm-v3//function_app | v8.28.2 |
 | <a name="module_function_lollipop_staging_slot_itn"></a> [function\_lollipop\_staging\_slot\_itn](#module\_function\_lollipop\_staging\_slot\_itn) | github.com/pagopa/terraform-azurerm-v3//function_app_slot | v8.28.2 |
 | <a name="module_locked_profiles_storage"></a> [locked\_profiles\_storage](#module\_locked\_profiles\_storage) | github.com/pagopa/terraform-azurerm-v3//storage_account | v8.27.0 |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Disable public access to `fn-lv` and removed allowed subnet
<!--- Describe your changes in detail -->

### Motivation and context
The fn use private endpoint, subnet allowance are required only for Azure Dev Ops deploy pipeline
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
