### PR TITLE
[#IOPID-2203] Remove unused variables from `session-manager` and `fn-public`

### DIFF
--- a/src/domains/citizen-auth-app/08_session_manager.tf
+++ b/src/domains/citizen-auth-app/08_session_manager.tf
@@ -151,9 +151,6 @@ locals {
     FF_FAST_LOGIN = "ALL"
     LV_TEST_USERS = module.tests.test_users.all
 
-    # MITIGATION APP BUG EMAIL VALIDATION
-    IS_SPID_EMAIL_PERSISTENCE_ENABLED = "false"
-
     # IOLOGIN redirect
     FF_IOLOGIN         = "BETA"
     IOLOGIN_TEST_USERS = data.azurerm_key_vault_secret.session_manager_IOLOGIN_TEST_USERS.value

--- a/src/domains/functions/function_public.tf
+++ b/src/domains/functions/function_public.tf
@@ -20,8 +20,6 @@ locals {
       FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
       # UNIQUE EMAIL ENFORCEMENT
-      FF_UNIQUE_EMAIL_ENFORCEMENT             = "ALL"
-      UNIQUE_EMAIL_ENFORCEMENT_USERS          = jsonencode(split(",", data.azurerm_key_vault_secret.app_backend_UNIQUE_EMAIL_ENFORCEMENT_USER.value))
       PROFILE_EMAIL_STORAGE_CONNECTION_STRING = data.azurerm_storage_account.citizen_auth_common.primary_connection_string
       PROFILE_EMAIL_STORAGE_TABLE_NAME        = "profileEmails"
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR depends on https://github.com/pagopa/io-functions-public/pull/83
This PR depends on https://github.com/pagopa/io-auth-n-identity-domain/pull/103

### List of changes

<!--- Describe your changes in detail -->

- Remove `IS_SPID_EMAIL_PERSISTENCE_ENABLED` from `session-manager`
- Remove `FF_UNIQUE_EMAIL_ENFORCEMENT` and `UNIQUE_EMAIL_ENFORCEMENT_USERS` from `fn-public`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Remove unused variables from `session-manager` and `fn-public` after cleaning up the code

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
