### PR TITLE
[CES-107] Fix Private Endpoint definitions for Cosmos DBs

### DIFF
--- a/src/domains/messages-common/01_network.tf
+++ b/src/domains/messages-common/01_network.tf
@@ -57,7 +57,7 @@ resource "azurerm_private_endpoint" "cosno_reminder_itn" {
     name                           = "${local.project_itn}-msgs-reminder-cosno-pep-01"
     private_connection_resource_id = module.cosmosdb_account_mongodb_reminder.id
     is_manual_connection           = false
-    subresource_names              = ["Sql"]
+    subresource_names              = ["MongoDB"]
   }
 }
 
@@ -69,7 +69,7 @@ resource "azurerm_private_endpoint" "cosno_remote_content_itn" {
 
   private_service_connection {
     name                           = "${local.project_itn}-msgs-remote-content-cosno-pep-01"
-    private_connection_resource_id = module.cosmosdb_account_mongodb_reminder.id
+    private_connection_resource_id = module.cosmosdb_account_remote_content.id
     is_manual_connection           = false
     subresource_names              = ["Sql"]
   }

--- a/src/domains/payments-common/01_network.tf
+++ b/src/domains/payments-common/01_network.tf
@@ -30,6 +30,6 @@ resource "azurerm_private_endpoint" "cosno_payments_itn" {
     name                           = "${local.project_itn}-msgs-payments-cosno-pep-01"
     private_connection_resource_id = module.cosmosdb_account_mongodb.id
     is_manual_connection           = false
-    subresource_names              = ["Sql"]
+    subresource_names              = ["MongoDB"]
   }
 }


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
New PEPs for:
- `io-p-payments-mongodb-account`
- `io-p-messages-remote-content`
- `io-p-messages-reminder-mongodb-account`

Were not properly configured as two of them use Mongo DB drivers and the other had a wrong reference.

PEPs are not used yet until a failover switch would not be performed

### Major Changes

<!--- Describe the major changes introduced by this PR -->

Fixes to inactive PEPs

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
