### PR TITLE
[CES-204] Enable enable_modified_files_detection into static analysis

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -14,10 +14,10 @@ on:
 
 jobs:
   static_analysis:
-    uses:  pagopa/dx/.github/workflows/static_analysis.yaml@workflow-functions-test #main
+    uses:  pagopa/dx/.github/workflows/static_analysis.yaml@main
     name: Terraform Validation
     secrets: inherit
     with:
       terraform_version: "1.7.5"
       pre_commit_tf_tag: "v1.96.1@sha256:9aea677ac51d67eb96b3bbb4cf93b16afdde5476f984e75e87888850d18146c9"
-      enable_modified_files_detection: false
+      enable_modified_files_detection: true

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   static_analysis:
-    uses:  pagopa/dx/.github/workflows/static_analysis.yaml@main
+    uses:  pagopa/dx/.github/workflows/static_analysis.yaml@workflow-functions-test #main
     name: Terraform Validation
     secrets: inherit
     with:


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

### Major Changes

<!--- Describe the major changes introduced by this PR -->
The _pre-commit_ configuration in the static analysis has been modified to allow better control over the files being checked when you don’t want to run the `pre-commit` on the entire repository. This is achieved by leveraging the native `from-ref` and `to-ref` functionality of `pre-commit`.

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->
By utilizing this feature, you can speed up the execution of the action, especially for larger repositories.

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
