### PR TITLE
[#IOPID-2413, #IOPID-2415, #IOPID-2346] Move A&I export to domain EH

### DIFF
--- a/src/domains/elt/_modules/function_apps/data.tf
+++ b/src/domains/elt/_modules/function_apps/data.tf
@@ -115,14 +115,14 @@ data "azurerm_eventhub_authorization_rule" "evh_ns_io_cosmos_profiles_fn" {
 data "azurerm_eventhub_authorization_rule" "evh_ns_service_preferences_send_auth_rule" {
   name                = "io-fn-elt"
   namespace_name      = "${var.project}-itn-auth-elt-evhns-01"
-  eventhub_name       = "pdnd-io-cosmosdb-service-preferences"
+  eventhub_name       = "${var.project}-itn-auth-elt-service-preferences-01"
   resource_group_name = "${var.project}-itn-auth-elt-rg-01"
 }
 
 data "azurerm_eventhub_authorization_rule" "evh_ns_profiles_send_auth_rule" {
   name                = "io-fn-elt"
   namespace_name      = "${var.project}-itn-auth-elt-evhns-01"
-  eventhub_name       = "pdnd-io-cosmosdb-profiles"
+  eventhub_name       = "${var.project}-itn-auth-elt-profiles-01"
   resource_group_name = "${var.project}-itn-auth-elt-rg-01"
 }
 
@@ -130,7 +130,7 @@ data "azurerm_eventhub_authorization_rule" "evh_ns_profiles_send_auth_rule" {
 data "azurerm_eventhub_authorization_rule" "evh_ns_profile_deletion_send_auth_rule" {
   name                = "io-fn-elt"
   namespace_name      = "${var.project}-itn-auth-elt-evhns-01"
-  eventhub_name       = "pdnd-io-cosmosdb-profile-deletion"
+  eventhub_name       = "${var.project}-itn-auth-elt-profile-deletion-01"
   resource_group_name = "${var.project}-itn-auth-elt-rg-01"
 }
 

--- a/src/domains/elt/_modules/function_apps/data.tf
+++ b/src/domains/elt/_modules/function_apps/data.tf
@@ -108,6 +108,37 @@ data "azurerm_eventhub_authorization_rule" "evh_ns_io_cosmos_profiles_fn" {
   resource_group_name = "${var.project}-evt-rg"
 }
 
+// ---------------------
+// A&I Event Hub Topic
+// ---------------------
+
+data "azurerm_eventhub_authorization_rule" "evh_ns_service_preferences_send_auth_rule" {
+  name                = "io-fn-elt"
+  namespace_name      = "${var.project}-itn-auth-elt-evhns-01"
+  eventhub_name       = "pdnd-io-cosmosdb-service-preferences"
+  resource_group_name = "${var.project}-itn-auth-elt-rg-01"
+}
+
+data "azurerm_eventhub_authorization_rule" "evh_ns_profiles_send_auth_rule" {
+  name                = "io-fn-elt"
+  namespace_name      = "${var.project}-itn-auth-elt-evhns-01"
+  eventhub_name       = "pdnd-io-cosmosdb-profiles"
+  resource_group_name = "${var.project}-itn-auth-elt-rg-01"
+}
+
+
+data "azurerm_eventhub_authorization_rule" "evh_ns_profile_deletion_send_auth_rule" {
+  name                = "io-fn-elt"
+  namespace_name      = "${var.project}-itn-auth-elt-evhns-01"
+  eventhub_name       = "pdnd-io-cosmosdb-profile-deletion"
+  resource_group_name = "${var.project}-itn-auth-elt-rg-01"
+}
+
+// ---------------------
+// /end A&I Event Hub Topic
+// ---------------------
+
+
 data "azurerm_key_vault" "kv_common" {
   name                = "${var.project}-kv-common"
   resource_group_name = local.resource_group_name_common

--- a/src/domains/elt/_modules/function_apps/function_app_elt.tf
+++ b/src/domains/elt/_modules/function_apps/function_app_elt.tf
@@ -54,7 +54,7 @@ locals {
       TARGETKAFKAAUTH_transactionalId     = "IO_ELT"
       TARGETKAFKAAUTH_topic               = "dummy" #Needed by KafkaProducerTopicConfig decoder
 
-      SERVICE_PREFERENCES_TOPIC_NAME              = data.azurerm_eventhub_authorization_rule.evh_ns_profiles_send_auth_rule.eventhub_name
+      SERVICE_PREFERENCES_TOPIC_NAME              = data.azurerm_eventhub_authorization_rule.evh_ns_service_preferences_send_auth_rule.eventhub_name
       SERVICE_PREFERENCES_TOPIC_CONNECTION_STRING = data.azurerm_eventhub_authorization_rule.evh_ns_service_preferences_send_auth_rule.primary_connection_string
       SERVICE_PREFERENCES_LEASES_PREFIX           = "service-preferences-003"
 

--- a/src/domains/elt/_modules/function_apps/function_app_elt.tf
+++ b/src/domains/elt/_modules/function_apps/function_app_elt.tf
@@ -52,22 +52,19 @@ locals {
       TARGETKAFKAAUTH_maxInFlightRequests = "1"
       TARGETKAFKAAUTH_idempotent          = "true"
       TARGETKAFKAAUTH_transactionalId     = "IO_ELT"
-      TARGETKAFKAAUTH_sasl_mechanism      = "plain"
-      TARGETKAFKAAUTH_sasl_username       = "$ConnectionString"
-      TARGETKAFKAAUTH_sasl_password       = data.azurerm_eventhub_authorization_rule.evh_ns_service_preferences_send_auth_rule.primary_connection_string
-      TARGETKAFKAAUTH_topic               = "pdnd-io-cosmosdb-service-preferences"
+      TARGETKAFKAAUTH_topic               = "dummy" #Needed by KafkaProducerTopicConfig decoder
 
-      SERVICE_PREFERENCES_TOPIC_NAME              = "pdnd-io-cosmosdb-service-preferences"
+      SERVICE_PREFERENCES_TOPIC_NAME              = data.azurerm_eventhub_authorization_rule.evh_ns_profiles_send_auth_rule.eventhub_name
       SERVICE_PREFERENCES_TOPIC_CONNECTION_STRING = data.azurerm_eventhub_authorization_rule.evh_ns_service_preferences_send_auth_rule.primary_connection_string
       SERVICE_PREFERENCES_LEASES_PREFIX           = "service-preferences-003"
 
-      PROFILES_TOPIC_NAME              = "pdnd-io-cosmosdb-profiles"
+      PROFILES_TOPIC_NAME              = data.azurerm_eventhub_authorization_rule.evh_ns_profiles_send_auth_rule.eventhub_name
       PROFILES_TOPIC_CONNECTION_STRING = data.azurerm_eventhub_authorization_rule.evh_ns_profiles_send_auth_rule.primary_connection_string
       PROFILES_LEASES_PREFIX           = "profiles-003"
 
-      PROFILE_DELETION_TOPIC_NAME              = "pdnd-io-cosmosdb-profile-deletion"
-      PROFILE_DELETION_TOPIC_CONNECTION_STRING = data.azurerm_eventhub_authorization_rule.evh_ns_profile_deletion_send_auth_rule.primary_connection_string
-      PROFILE_DELETION_LEASES_PREFIX           = "profile-deletion-001"
+      DELETES_TOPIC_NAME              = data.azurerm_eventhub_authorization_rule.evh_ns_profile_deletion_send_auth_rule.eventhub_name
+      DELETES_TOPIC_CONNECTION_STRING = data.azurerm_eventhub_authorization_rule.evh_ns_profile_deletion_send_auth_rule.primary_connection_string
+      DELETES_LEASES_PREFIX           = "profile-deletion-001"
 
 
       ERROR_STORAGE_ACCOUNT                   = var.storage_account_name
@@ -114,7 +111,7 @@ locals {
       SERVICES_FAILURE_QUEUE_NAME            = "pdnd-io-cosmosdb-services-failure"
       SERVICE_PREFERENCES_FAILURE_QUEUE_NAME = local.service_preferences_failure_queue_name
       PROFILES_FAILURE_QUEUE_NAME            = local.profiles_failure_queue_name
-      PROFILE_DELETION_FAILURE_QUEUE_NAME    = local.profile_deletion_failure_queue_name
+      DELETES_FAILURE_QUEUE_NAME             = local.profile_deletion_failure_queue_name
 
       # PDV integration env variables
       PDV_TOKENIZER_API_KEY   = data.azurerm_key_vault_secret.pdv_tokenizer_api_key.value,
@@ -152,7 +149,7 @@ module "function_elt" {
   app_service_plan_info = {
     kind                         = "elastic"
     sku_tier                     = "ElasticPremium"
-    sku_size                     = "EP1"
+    sku_size                     = "EP2"
     maximum_elastic_worker_count = 1
     worker_count                 = null
     zone_balancing_enabled       = null
@@ -171,7 +168,7 @@ module "function_elt" {
       "AzureWebJobs.AnalyticsServiceStorageQueueInboundProcessorAdapter.Disabled"          = "0"
       "AzureWebJobs.AnalyticsServicePreferencesChangeFeedInboundProcessorAdapter.Disabled" = "1"
       "AzureWebJobs.AnalyticsProfilesChangeFeedInboundProcessorAdapter.Disabled"           = "1"
-      "AzureWebJobs.AnalyticsDeletesChangeFeedInboundProcessorAdapter.Disabled"            = "1"
+      "AzureWebJobs.AnalyticsUserDataProcessingChangeFeedInboundProcessorAdapter.Disabled" = "1"
     }
   )
 

--- a/src/domains/elt/_modules/function_apps/locals.tf
+++ b/src/domains/elt/_modules/function_apps/locals.tf
@@ -12,10 +12,12 @@ locals {
     "51.144.56.176/28",
   ]
 
-  event_hub_connection = "${format("%s-evh-ns", var.project)}.servicebus.windows.net:9093"
+  event_hub_connection      = "${format("%s-evh-ns", var.project)}.servicebus.windows.net:9093"
+  auth_event_hub_connection = "${format("%s-itn-auth-elt-evhns-01", var.project)}.servicebus.windows.net:9093"
 
   pn_service_id = "01G40DWQGKY5GRWSNM4303VNRP"
 
   service_preferences_failure_queue_name = "pdnd-io-cosmosdb-service-preferences-failure"
   profiles_failure_queue_name            = "pdnd-io-cosmosdb-profiles-failure"
+  profile_deletion_failure_queue_name    = "pdnd-io-cosmosdb-profile-deletion-failure"
 }


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Move A&I export to domain Event Hub

### Major Changes

<!--- Describe the major changes introduced by this PR -->

- Add new `TARGETKAFKAAUTH_` config for link a second Event Hub to fn-elt
- upgrade fn-elt plan to EP2
- add new `profile-deletion` topic
- Add new `AnalyticsDeletesChangeFeedInboundProcessorAdapter` reference to fn-elt

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->
This PR depends on https://github.com/pagopa/io-auth-n-identity-domain/pull/110

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
