### PR TITLE
[B2BP-990] - Add dns validation for firma con io b2bportals website

### DIFF
--- a/src/common/_modules/global/modules/dns/dns_io_italia_it.tf
+++ b/src/common/_modules/global/modules/dns/dns_io_italia_it.tf
@@ -113,3 +113,12 @@ resource "azurerm_dns_cname_record" "sender" {
   ttl                 = var.dns_default_ttl_sec
   record              = "bounce.musvc.com"
 }
+
+# CNAME for firma con io AWS certificate
+resource "azurerm_dns_cname_record" "firmaconio" {
+  name                = "_c8fedcbb95e9a1a9970e790248192e40.firma.io.italia.it."
+  zone_name           = azurerm_dns_zone.io_italia_it.name
+  resource_group_name = var.resource_groups.external
+  ttl                 = var.dns_default_ttl_sec
+  record              = "_cb7cf3d1c765ecd7191512dc77371b57.djqtsrsxkq.acm-validations.aws."
+}


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Firma con IO website is being migrated to B2BPortals suite (PAWSBuilder). This PR inserts the CNAME required to validate the AWS SSL certificate.

### Major Changes

<!--- Describe the major changes introduced by this PR -->
This PR inserts the CNAME required to validate the AWS SSL certificate.

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
