### PR TITLE
[#IOPID-2432] Remove no more used `MIT_VOUCHER` variables from `io-backend`

### DIFF
--- a/src/common/_modules/app_backend/app_settings.tf
+++ b/src/common/_modules/app_backend/app_settings.tf
@@ -56,7 +56,6 @@ locals {
     CGN_API_BASE_PATH                 = "/api/v1/cgn"
     CGN_OPERATOR_SEARCH_API_BASE_PATH = "/api/v1/cgn/operator-search"
     EUCOVIDCERT_API_BASE_PATH         = "/api/v1/eucovidcert"
-    MIT_VOUCHER_API_BASE_PATH         = "/api/v1/mitvoucher/auth"
     IO_SIGN_API_BASE_PATH             = "/api/v1/sign"
     LOLLIPOP_API_BASE_PATH            = "/api/v1"
     TRIAL_SYSTEM_API_BASE_PATH        = "/api/v1"
@@ -85,12 +84,6 @@ locals {
     MYPORTAL_BASE_PATH             = "/myportal/api/v1"
     ALLOW_MYPORTAL_IP_SOURCE_RANGE = data.azurerm_key_vault_secret.app_backend_ALLOW_MYPORTAL_IP_SOURCE_RANGE.value
 
-    // MIT_VOUCHER JWT
-    JWT_MIT_VOUCHER_TOKEN_ISSUER         = "app-backend.io.italia.it"
-    JWT_MIT_VOUCHER_TOKEN_EXPIRATION     = 1200
-    JWT_MIT_VOUCHER_TOKEN_PRIVATE_ES_KEY = data.azurerm_key_vault_secret.app_backend_JWT_MIT_VOUCHER_TOKEN_PRIVATE_ES_KEY.value
-    JWT_MIT_VOUCHER_TOKEN_AUDIENCE       = data.azurerm_key_vault_secret.app_backend_JWT_MIT_VOUCHER_TOKEN_AUDIENCE.value
-
     // BPD
     JWT_SUPPORT_TOKEN_PRIVATE_RSA_KEY = data.azurerm_key_vault_secret.app_backend_JWT_SUPPORT_TOKEN_PRIVATE_RSA_KEY.value
 
@@ -107,7 +100,6 @@ locals {
     FF_BONUS_ENABLED           = 1
     FF_CGN_ENABLED             = 1
     FF_EUCOVIDCERT_ENABLED     = 1
-    FF_MIT_VOUCHER_ENABLED     = 1
     FF_IO_SIGN_ENABLED         = 1
     FF_IO_WALLET_ENABLED       = 1
     FF_IO_WALLET_TRIAL_ENABLED = 1

--- a/src/common/_modules/app_backend/data_kv.tf
+++ b/src/common/_modules/app_backend/data_kv.tf
@@ -50,16 +50,6 @@ data "azurerm_key_vault_secret" "app_backend_TEST_CGN_FISCAL_CODES" {
   key_vault_id = var.key_vault_common.id
 }
 
-data "azurerm_key_vault_secret" "app_backend_JWT_MIT_VOUCHER_TOKEN_PRIVATE_ES_KEY" {
-  name         = "appbackend-mitvoucher-JWT-PRIVATE-ES-KEY"
-  key_vault_id = var.key_vault_common.id
-}
-
-data "azurerm_key_vault_secret" "app_backend_JWT_MIT_VOUCHER_TOKEN_AUDIENCE" {
-  name         = "appbackend-mitvoucher-JWT-AUDIENCE"
-  key_vault_id = var.key_vault_common.id
-}
-
 data "azurerm_key_vault_secret" "app_backend_PECSERVER_TOKEN_SECRET" {
   name         = "appbackend-PECSERVER-TOKEN-SECRET"
   key_vault_id = var.key_vault_common.id

--- a/src/common/_modules/cosmos_api/locals.tf
+++ b/src/common/_modules/cosmos_api/locals.tf
@@ -55,7 +55,7 @@ locals {
       partition_key_version = null
       default_ttl           = -1
       autoscale_settings = {
-        max_throughput = 200000
+        max_throughput = 67000
       }
     },
     {
@@ -72,7 +72,7 @@ locals {
       partition_key_version = null
       default_ttl           = -1
       autoscale_settings = {
-        max_throughput = 100000
+        max_throughput = 46000
       }
     },
     {
@@ -124,7 +124,7 @@ locals {
       partition_key_path    = "/fiscalCode"
       partition_key_version = null
       autoscale_settings = {
-        max_throughput = 100000
+        max_throughput = 48000
       }
     },
     {


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

MitVoucher endpoint has beed removed from io-backend with PR https://github.com/pagopa/io-backend/pull/1158, we can cleanup its variables as well

⚠️ A double deploy is needed to update both prod and staging slots before removing variables. Done: 2/2 ✅ 

### Major Changes

<!--- Describe the major changes introduced by this PR -->

- Removed all MIT_VOUCHER variables
- Removed related KV data

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->
This PR depends on https://github.com/pagopa/io-backend/pull/1158

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->
N/A

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
