### PR TITLE
[DEVEX-179] Add custom role to manage Opex dashboard

### DIFF
--- a/src/core/_modules/custom_roles/outputs.tf
+++ b/src/core/_modules/custom_roles/outputs.tf
@@ -1,0 +1,6 @@
+output "pagopa_opex_contributor" {
+  value = {
+    id   = azurerm_role_definition.pagopa_opex_contributor.id
+    name = azurerm_role_definition.pagopa_opex_contributor.name
+  }
+}

--- a/src/core/_modules/custom_roles/pagopa_opex_role.tf
+++ b/src/core/_modules/custom_roles/pagopa_opex_role.tf
@@ -1,0 +1,19 @@
+resource "azurerm_role_definition" "pagopa_opex_contributor" {
+  name        = "PagoPA Opex Contributor"
+  scope       = var.subscription_id
+  description = "Role to manage the Opex Dashboards creation, modification and deletion"
+
+  permissions {
+    actions = [
+      "Microsoft.Portal/dashboards/write",
+      "Microsoft.Portal/dashboards/read",
+      "Microsoft.Portal/dashboards/delete",
+      "Microsoft.Portal/dashboards/sharedDashboard/principalAssignments/write",
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    "/subscriptions/${var.subscription_id}"
+  ]
+}

--- a/src/core/_modules/custom_roles/variables.tf
+++ b/src/core/_modules/custom_roles/variables.tf
@@ -1,0 +1,4 @@
+variable "subscription_id" {
+  type        = string
+  description = "Id of the subscription to use as roles' scope"
+}

--- a/src/core/_modules/custom_roles/variables.tf
+++ b/src/core/_modules/custom_roles/variables.tf
@@ -1,4 +1,4 @@
 variable "subscription_id" {
   type        = string
-  description = "Id of the subscription to use as roles' scope"
+  description = "The subscription ID used as the scope for role definitions."
 }

--- a/src/core/prod/README.md
+++ b/src/core/prod/README.md
@@ -19,6 +19,7 @@
 |------|--------|---------|
 | <a name="module_azdoa_weu"></a> [azdoa\_weu](#module\_azdoa\_weu) | ../_modules/azure_devops_agent | n/a |
 | <a name="module_container_registry"></a> [container\_registry](#module\_container\_registry) | ../_modules/container_registry | n/a |
+| <a name="module_custom_roles"></a> [custom\_roles](#module\_custom\_roles) | ../_modules/custom_roles | n/a |
 | <a name="module_key_vault_weu"></a> [key\_vault\_weu](#module\_key\_vault\_weu) | ../_modules/key_vaults | n/a |
 | <a name="module_networking_itn"></a> [networking\_itn](#module\_networking\_itn) | ../_modules/networking | n/a |
 | <a name="module_networking_weu"></a> [networking\_weu](#module\_networking\_weu) | ../_modules/networking | n/a |

--- a/src/core/prod/italynorth.tf
+++ b/src/core/prod/italynorth.tf
@@ -54,3 +54,9 @@ module "vnet_peering_itn" {
     }
   }
 }
+
+module "custom_roles" {
+  source = "../_modules/custom_roles"
+
+  subscription_id = data.azurerm_subscription.current.id
+}


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We need a custom role to give the minimum permissions to identities to manage Opex dashboards, as they will fall into the same resource group among other resources.

### Major Changes

<!--- Describe the major changes introduced by this PR -->

This new role `PagoPA Opex Contributor` can be used in any scope of the `PROD-IO` subscription. Actions are limited to dashboard management (creation, deletion, modification and role assignment)

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
