### PR TITLE
[DEVEX-179] Few fix for PagoPA Opex Dashboards Contributor custom role definition

### DIFF
--- a/src/core/_modules/custom_roles/pagopa_opex_role.tf
+++ b/src/core/_modules/custom_roles/pagopa_opex_role.tf
@@ -8,7 +8,6 @@ resource "azurerm_role_definition" "pagopa_opex_contributor" {
       "Microsoft.Portal/dashboards/write",
       "Microsoft.Portal/dashboards/read",
       "Microsoft.Portal/dashboards/delete",
-      "Microsoft.Portal/dashboards/sharedDashboard/principalAssignments/write",
     ]
     not_actions = []
   }

--- a/src/core/_modules/custom_roles/pagopa_opex_role.tf
+++ b/src/core/_modules/custom_roles/pagopa_opex_role.tf
@@ -1,5 +1,5 @@
 resource "azurerm_role_definition" "pagopa_opex_contributor" {
-  name        = "PagoPA Opex Contributor"
+  name        = "PagoPA Opex Dashboards Contributor"
   scope       = var.subscription_id
   description = "Role to manage the Opex Dashboards creation, modification and deletion"
 
@@ -14,6 +14,6 @@ resource "azurerm_role_definition" "pagopa_opex_contributor" {
   }
 
   assignable_scopes = [
-    "/subscriptions/${var.subscription_id}"
+    var.subscription_id
   ]
 }


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Few fixes to the custom role created to manage Opex dashboards

### Major Changes

<!--- Describe the major changes introduced by this PR -->

Rename `PagoPA Opex Contributor` to `PagoPA Opex Dashboards Contributor`
Remove `Microsoft.Portal/dashboards/sharedDashboard/principalAssignments/write` action as it doesn't exist anymore
Fix assignable scope variable syntax

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
