### PR TITLE
[CES-213] Removed io-p-app-snet-1 and io-p-app-snet-2 in ioweb-app infrastructure

### DIFF
--- a/src/domains/ioweb-app/01_network.tf
+++ b/src/domains/ioweb-app/01_network.tf
@@ -67,13 +67,6 @@ data "azurerm_subnet" "apim_v2_snet" {
   resource_group_name  = local.vnet_common_resource_group_name
 }
 
-data "azurerm_subnet" "function_app_snet" {
-  count                = 2
-  name                 = format("%s-app-snet-%d", local.product, count.index + 1)
-  virtual_network_name = local.vnet_common_name
-  resource_group_name  = local.vnet_common_resource_group_name
-}
-
 data "azurerm_subnet" "azdoa_snet" {
   count                = var.enable_azdoa ? 1 : 0
   name                 = "azure-devops"

--- a/src/domains/ioweb-app/06_function_ioweb_profile.tf
+++ b/src/domains/ioweb-app/06_function_ioweb_profile.tf
@@ -164,8 +164,6 @@ module "function_ioweb_profile" {
   allowed_subnets = [
     module.ioweb_profile_snet.id,
     data.azurerm_subnet.apim_v2_snet.id,
-    data.azurerm_subnet.function_app_snet[0].id,
-    data.azurerm_subnet.function_app_snet[1].id,
     data.azurerm_subnet.function_profile_snet[0].id,
     data.azurerm_subnet.function_profile_snet[1].id,
   ]
@@ -212,8 +210,6 @@ module "function_ioweb_profile_staging_slot" {
     module.ioweb_profile_snet.id,
     data.azurerm_subnet.azdoa_snet[0].id,
     data.azurerm_subnet.apim_v2_snet.id,
-    data.azurerm_subnet.function_app_snet[0].id,
-    data.azurerm_subnet.function_app_snet[1].id,
     data.azurerm_subnet.function_profile_snet[0].id,
     data.azurerm_subnet.function_profile_snet[1].id,
   ]

--- a/src/domains/ioweb-app/README.md
+++ b/src/domains/ioweb-app/README.md
@@ -79,7 +79,6 @@
 | [azurerm_storage_container.immutable_audit_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container) | data source |
 | [azurerm_subnet.apim_v2_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.azdoa_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
-| [azurerm_subnet.function_app_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.function_profile_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.private_endpoints_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The terraform plan fails because it cannot find these two subnets (`io-p-app-snet-1` and `io-p-app-snet-2`) which no longer exist, so they have been removed from the terraform infrastructure.

### Major Changes

<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
