### PR TITLE
[#IOPID-2451] Add kv read/write permission to A&I monorepo pipelines

### DIFF
--- a/src/domains/citizen-auth-common/02_key_vault.tf
+++ b/src/domains/citizen-auth-common/02_key_vault.tf
@@ -67,6 +67,38 @@ resource "azurerm_key_vault_access_policy" "access_policy_io_infra_cd" {
   certificate_permissions = ["Get", "List"]
 }
 
+
+# -----------------------------------
+#  Auth&Identity monorepo pipelines
+# -----------------------------------
+
+resource "azurerm_key_vault_access_policy" "access_policy_auth_n_identity_infra_ci" {
+  key_vault_id = module.key_vault.id
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_user_assigned_identity.managed_identity_auth_n_identity_infra_ci.principal_id
+
+  key_permissions         = ["Get", "List", "GetRotationPolicy"]
+  secret_permissions      = ["Get", "List"]
+  certificate_permissions = ["Get", "List"]
+}
+
+resource "azurerm_key_vault_access_policy" "access_policy_auth_n_identity_infra_cd" {
+  key_vault_id = module.key_vault.id
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_user_assigned_identity.managed_identity_auth_n_identity_infra_cd.principal_id
+
+  key_permissions         = ["Get", "List", "GetRotationPolicy"]
+  secret_permissions      = ["Get", "List", "Set"]
+  certificate_permissions = ["Get", "List"]
+}
+
+
+
+
+
+
 #
 # azure devops policy
 #

--- a/src/domains/citizen-auth-common/06_data.tf
+++ b/src/domains/citizen-auth-common/06_data.tf
@@ -12,6 +12,17 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
   resource_group_name = "${local.product}-identity-rg"
 }
 
+data "azurerm_user_assigned_identity" "managed_identity_auth_n_identity_infra_ci" {
+  name                = "${local.product}-auth-github-ci-identity"
+  resource_group_name = "${local.product}-identity-rg"
+}
+
+data "azurerm_user_assigned_identity" "managed_identity_auth_n_identity_infra_cd" {
+  name                = "${local.product}-auth-github-cd-identity"
+  resource_group_name = "${local.product}-identity-rg"
+}
+
+
 # ITN LOLLIPOP FUNCTION
 data "azurerm_resource_group" "lollipop_function_rg" {
   name = format("%s-itn-lollipop-rg-01", local.product)

--- a/src/domains/citizen-auth-common/README.md
+++ b/src/domains/citizen-auth-common/README.md
@@ -56,6 +56,8 @@
 | [azurerm_api_management_user.pagopa_user_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_user) | resource |
 | [azurerm_api_management_user.pn_user_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_user) | resource |
 | [azurerm_cosmosdb_sql_container.lollipop_pubkeys](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_container) | resource |
+| [azurerm_key_vault_access_policy.access_policy_auth_n_identity_infra_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.access_policy_auth_n_identity_infra_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.access_policy_io_infra_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.access_policy_io_infra_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
@@ -112,6 +114,8 @@
 | [azurerm_subnet.private_endpoints_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.private_endpoints_subnet_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+| [azurerm_user_assigned_identity.managed_identity_auth_n_identity_infra_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
+| [azurerm_user_assigned_identity.managed_identity_auth_n_identity_infra_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [azurerm_user_assigned_identity.managed_identity_io_infra_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [azurerm_user_assigned_identity.managed_identity_io_infra_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [azurerm_virtual_network.vnet_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
A&I monorepo pipelines cannot access domain KV

### Major Changes

<!--- Describe the major changes introduced by this PR -->
- [add kv read/write permission to monorepo pipelines](https://github.com/pagopa/io-infra/commit/e930a94d2b2dac78b034d6279ba671db6245b22c)

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
