### PR TITLE
[CES-118] Update Cosmos Citizen network settings after manual failover 

### DIFF
--- a/src/domains/citizen-auth-app/99_variables.tf
+++ b/src/domains/citizen-auth-app/99_variables.tf
@@ -341,7 +341,7 @@ variable "plan_shared_1_sku_size" {
 variable "plan_shared_1_sku_capacity" {
   description = "Shared functions app plan capacity"
   type        = number
-  default     = 1
+  default     = 3
 }
 ###########################
 ################################

--- a/src/domains/citizen-auth-app/README.md
+++ b/src/domains/citizen-auth-app/README.md
@@ -229,7 +229,7 @@
 | <a name="input_lollipop_enabled"></a> [lollipop\_enabled](#input\_lollipop\_enabled) | Lollipop function enabled? | `bool` | `false` | no |
 | <a name="input_monitor_resource_group_name"></a> [monitor\_resource\_group\_name](#input\_monitor\_resource\_group\_name) | Monitor resource group name | `string` | n/a | yes |
 | <a name="input_plan_shared_1_kind"></a> [plan\_shared\_1\_kind](#input\_plan\_shared\_1\_kind) | App service plan kind | `string` | `null` | no |
-| <a name="input_plan_shared_1_sku_capacity"></a> [plan\_shared\_1\_sku\_capacity](#input\_plan\_shared\_1\_sku\_capacity) | Shared functions app plan capacity | `number` | `1` | no |
+| <a name="input_plan_shared_1_sku_capacity"></a> [plan\_shared\_1\_sku\_capacity](#input\_plan\_shared\_1\_sku\_capacity) | Shared functions app plan capacity | `number` | `3` | no |
 | <a name="input_plan_shared_1_sku_size"></a> [plan\_shared\_1\_sku\_size](#input\_plan\_shared\_1\_sku\_size) | App service plan sku size | `string` | `null` | no |
 | <a name="input_plan_shared_1_sku_tier"></a> [plan\_shared\_1\_sku\_tier](#input\_plan\_shared\_1\_sku\_tier) | App service plan sku tier | `string` | `null` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | n/a | yes |

--- a/src/domains/citizen-auth-common/01_network.tf
+++ b/src/domains/citizen-auth-common/01_network.tf
@@ -70,6 +70,11 @@ resource "azurerm_private_endpoint" "cosmos_db" {
     is_manual_connection           = false
     subresource_names              = ["Sql"]
   }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-group"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.privatelink_documents_azure_com.id]
+  }
 }
 
 ## Redis Common subnet

--- a/src/domains/citizen-auth-common/05_database.tf
+++ b/src/domains/citizen-auth-common/05_database.tf
@@ -16,10 +16,10 @@ module "cosmosdb_account" {
   enable_free_tier    = false
   kind                = "GlobalDocumentDB"
 
-  public_network_access_enabled       = false
-  private_endpoint_enabled            = false
-  subnet_id                           = data.azurerm_subnet.private_endpoints_subnet.id
-  is_virtual_network_filter_enabled   = false
+  public_network_access_enabled     = false
+  private_endpoint_enabled          = false
+  subnet_id                         = data.azurerm_subnet.private_endpoints_subnet.id
+  is_virtual_network_filter_enabled = false
 
   main_geo_location_location       = "italynorth"
   main_geo_location_zone_redundant = true

--- a/src/domains/citizen-auth-common/05_database.tf
+++ b/src/domains/citizen-auth-common/05_database.tf
@@ -17,17 +17,14 @@ module "cosmosdb_account" {
   kind                = "GlobalDocumentDB"
 
   public_network_access_enabled       = false
-  private_endpoint_enabled            = true
-  private_endpoint_sql_name           = "${local.product}-citizen-auth-account"
-  private_service_connection_sql_name = "${local.product}-citizen-auth-account-private-endpoint"
-  private_dns_zone_sql_ids            = [data.azurerm_private_dns_zone.privatelink_documents_azure_com.id]
+  private_endpoint_enabled            = false
   subnet_id                           = data.azurerm_subnet.private_endpoints_subnet.id
   is_virtual_network_filter_enabled   = false
 
-  main_geo_location_location       = azurerm_resource_group.data_rg.location
+  main_geo_location_location       = "italynorth"
   main_geo_location_zone_redundant = true
   additional_geo_locations = [{
-    location          = "italynorth"
+    location          = azurerm_resource_group.data_rg.location
     failover_priority = 1
     zone_redundant    = true
   }]


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Update Cosmos DB connectivity after manual failover between WEU and ITN.

### Major Changes

<!--- Describe the major changes introduced by this PR -->

Set Italy North as Cosmos DB primary region
Delete WEU private endpoint
Attach ITN private endpoint to the private DNS zone

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
