### PR TITLE
[CES-68] Edit DNS for new APIM in ITN

### DIFF
--- a/src/common/_modules/global/main.tf
+++ b/src/common/_modules/global/main.tf
@@ -13,7 +13,8 @@ module "dns" {
   app_gateway_public_ip = var.dns.app_gateway_public_ip
 
   # TODO: remove data when apim v2 module is implemented
-  apim_v2_private_ip = var.dns.apim_v2_private_ip
+  apim_v2_private_ip  = var.dns.apim_v2_private_ip
+  apim_itn_private_ip = var.dns.apim_itn_private_ip
 
   tags = var.tags
 }

--- a/src/common/_modules/global/modules/dns/dns_io_italia_it.tf
+++ b/src/common/_modules/global/modules/dns/dns_io_italia_it.tf
@@ -95,7 +95,7 @@ resource "azurerm_dns_a_record" "api_internal_io_italia_it" {
   name                = "api-internal"
   zone_name           = azurerm_dns_zone.io_italia_it.name
   resource_group_name = var.resource_groups.external
-  ttl                 = 10 # var.dns_default_ttl_sec
+  ttl                 = 10 # var.dns_default_ttl_sec Return to default after migration
   records             = [var.apim_v2_private_ip, var.apim_itn_private_ip]
 
   tags = var.tags

--- a/src/common/_modules/global/modules/dns/dns_io_italia_it.tf
+++ b/src/common/_modules/global/modules/dns/dns_io_italia_it.tf
@@ -96,7 +96,7 @@ resource "azurerm_dns_a_record" "api_internal_io_italia_it" {
   zone_name           = azurerm_dns_zone.io_italia_it.name
   resource_group_name = var.resource_groups.external
   ttl                 = 10 # var.dns_default_ttl_sec
-  records             = [var.apim_v2_private_ip]
+  records             = [var.apim_v2_private_ip, var.apim_itn_private_ip]
 
   tags = var.tags
 }

--- a/src/common/_modules/global/modules/dns/private_dns_zones.tf
+++ b/src/common/_modules/global/modules/dns/private_dns_zones.tf
@@ -12,7 +12,7 @@ resource "azurerm_private_dns_a_record" "api_app_internal_io" {
   zone_name           = azurerm_private_dns_zone.internal_io_pagopa_it.name
   resource_group_name = var.resource_groups.internal
   ttl                 = 10 # var.dns_default_ttl_sec
-  records             = [var.apim_v2_private_ip]
+  records             = [var.apim_v2_private_ip, var.apim_itn_private_ip]
 
   tags = var.tags
 }

--- a/src/common/_modules/global/modules/dns/private_dns_zones.tf
+++ b/src/common/_modules/global/modules/dns/private_dns_zones.tf
@@ -11,7 +11,7 @@ resource "azurerm_private_dns_a_record" "api_app_internal_io" {
   name                = "api-app"
   zone_name           = azurerm_private_dns_zone.internal_io_pagopa_it.name
   resource_group_name = var.resource_groups.internal
-  ttl                 = 10 # var.dns_default_ttl_sec
+  ttl                 = 10 # var.dns_default_ttl_sec Return to default after migration
   records             = [var.apim_v2_private_ip, var.apim_itn_private_ip]
 
   tags = var.tags

--- a/src/common/_modules/global/modules/dns/variables.tf
+++ b/src/common/_modules/global/modules/dns/variables.tf
@@ -54,3 +54,8 @@ variable "apim_v2_private_ip" {
   type        = string
   description = "Private IP of the API Management v2"
 }
+
+variable "apim_itn_private_ip" {
+  type        = string
+  description = "Private IP of the API Management ITN"
+}

--- a/src/common/_modules/global/variables.tf
+++ b/src/common/_modules/global/variables.tf
@@ -26,5 +26,6 @@ variable "dns" {
     })
     app_gateway_public_ip = string
     apim_v2_private_ip    = string
+    apim_itn_private_ip   = string
   })
 }

--- a/src/common/prod/global.tf
+++ b/src/common/prod/global.tf
@@ -41,7 +41,8 @@ module "global" {
     app_gateway_public_ip = module.application_gateway_weu.public_ip.address
 
     # TODO: remove when apim v2 module is implemented
-    apim_v2_private_ip = module.apim_weu.private_ips[0]
+    apim_v2_private_ip  = module.apim_weu.private_ips[0]
+    apim_itn_private_ip = module.apim_itn.private_ips[0]
   }
 
   tags = local.tags


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
For the APIM migration from weu to itn the DNS Records configuration about `api_internal_io_italia_it` and `app_api_internal_io` will be changed

### Major Changes

<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
