### PR TITLE
Enable FIMS

### DIFF
--- a/src/common/_modules/app_backend/app_settings.tf
+++ b/src/common/_modules/app_backend/app_settings.tf
@@ -104,7 +104,7 @@ locals {
     FF_CGN_ENABLED             = 1
     FF_EUCOVIDCERT_ENABLED     = 1
     FF_IO_SIGN_ENABLED         = 1
-    FF_IO_FIMS_ENABLED         = 0
+    FF_IO_FIMS_ENABLED         = 1
     FF_IO_WALLET_ENABLED       = 1
     FF_IO_WALLET_TRIAL_ENABLED = 1
 


### PR DESCRIPTION
### Motivation and Context
`FF_IO_FIMS_ENABLED` is the environment variable that is used to enable or disable the `FIMS` feature on `io-backend`.

### Major Changes
1. Set `FF_IO_FIMS_ENABLED` to `1`
