### PR TITLE
[#IOPID-1969] Add Access Policy to ioweb-kv for citizen auth monorepo pipelines

### DIFF
--- a/src/domains/ioweb-common/02_security.tf
+++ b/src/domains/ioweb-common/02_security.tf
@@ -66,6 +66,32 @@ resource "azurerm_key_vault_access_policy" "access_policy_io_infra_cd" {
   certificate_permissions = ["Get", "List"]
 }
 
+# -----------------------------------
+#  Auth&Identity monorepo pipelines
+# -----------------------------------
+
+resource "azurerm_key_vault_access_policy" "access_policy_auth_n_identity_infra_ci" {
+  key_vault_id = module.key_vault.id
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_user_assigned_identity.managed_identity_auth_n_identity_infra_ci.principal_id
+
+  key_permissions         = ["Get", "List", "GetRotationPolicy"]
+  secret_permissions      = ["Get", "List"]
+  certificate_permissions = ["Get", "List"]
+}
+
+resource "azurerm_key_vault_access_policy" "access_policy_auth_n_identity_infra_cd" {
+  key_vault_id = module.key_vault.id
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_user_assigned_identity.managed_identity_auth_n_identity_infra_cd.principal_id
+
+  key_permissions         = ["Get", "List", "GetRotationPolicy"]
+  secret_permissions      = ["Get", "List", "Set"]
+  certificate_permissions = ["Get", "List", "Create", "Update"]
+}
+
 #
 # Azure DevOps policy
 #

--- a/src/domains/ioweb-common/07_data.tf
+++ b/src/domains/ioweb-common/07_data.tf
@@ -12,6 +12,16 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
   resource_group_name = "${local.product}-identity-rg"
 }
 
+data "azurerm_user_assigned_identity" "managed_identity_auth_n_identity_infra_ci" {
+  name                = "${local.product}-auth-github-ci-identity"
+  resource_group_name = "${local.product}-identity-rg"
+}
+
+data "azurerm_user_assigned_identity" "managed_identity_auth_n_identity_infra_cd" {
+  name                = "${local.product}-auth-github-cd-identity"
+  resource_group_name = "${local.product}-identity-rg"
+}
+
 ########
 # APIM #
 ########

--- a/src/domains/ioweb-common/README.md
+++ b/src/domains/ioweb-common/README.md
@@ -39,6 +39,8 @@
 |------|------|
 | [azurerm_api_management_api_operation_policy.spid_acs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.spid_acs_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
+| [azurerm_key_vault_access_policy.access_policy_auth_n_identity_infra_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.access_policy_auth_n_identity_infra_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.access_policy_io_infra_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.access_policy_io_infra_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
@@ -83,6 +85,8 @@
 | [azurerm_subnet.ioweb_profile_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.private_endpoints_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+| [azurerm_user_assigned_identity.managed_identity_auth_n_identity_infra_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
+| [azurerm_user_assigned_identity.managed_identity_auth_n_identity_infra_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [azurerm_user_assigned_identity.managed_identity_io_infra_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [azurerm_user_assigned_identity.managed_identity_io_infra_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [azurerm_virtual_network.vnet_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |


### PR DESCRIPTION


### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The `io-auth-n-identity` monorepo needs to access to `io-web` keyvault.

### Major Changes

<!--- Describe the major changes introduced by this PR -->
Create new keyvault access policy for `ioweb`keyvault

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
