### PR TITLE
[CES-68] Reduced instances for APIM ITN

### DIFF
--- a/src/common/_modules/apim/main.tf
+++ b/src/common/_modules/apim/main.tf
@@ -10,10 +10,10 @@ module "apim_v2" {
   notification_sender_email = data.azurerm_key_vault_secret.apim_publisher_email.value
   sku_name                  = var.migration ? "Premium_1" : "Premium_2"
   virtual_network_type      = "Internal"
-  zones                     = ["1", "2"]
+  zones                     = var.migration ? ["1"] : ["1", "2"]
 
   redis_cache_id       = null
-  public_ip_address_id = azurerm_public_ip.apim.id
+  public_ip_address_id = var.migration ? azurerm_public_ip.apim_tmp[0].id : azurerm_public_ip.apim.id
 
   hostname_configuration = {
     proxy = [

--- a/src/common/_modules/apim/networking.tf
+++ b/src/common/_modules/apim/networking.tf
@@ -89,3 +89,18 @@ resource "azurerm_private_dns_a_record" "apim_scm_azure_api_net" {
 
   tags = var.tags
 }
+
+# Delete when return to 2 instances
+resource "azurerm_public_ip" "apim_tmp" {
+  count = var.migration ? 1 : 0
+
+  name                = try(local.nonstandard[var.location_short].pip_name, "${var.project}-apim-tmp-pip-01")
+  resource_group_name = var.resource_group_common
+  location            = var.location
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  domain_name_label   = "apimiotmp"
+  zones               = ["1", "2", "3"]
+
+  tags = var.tags
+}


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To reduce costs during migration the number of instances for ITN apim was scaled to 1.
To do this is necessary to change the public ip with a new one (temporary), when will be scaled to 2 instances is needed the old one.

### Major Changes

<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
