### PR TITLE
[#IOPID-2503] add alerts for download/delete failures

### DIFF
--- a/src/domains/functions/README.md
+++ b/src/domains/functions/README.md
@@ -42,6 +42,8 @@
 | [azurerm_monitor_metric_alert.function_assets_health_check](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.function_assets_http_server_errors](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.function_assets_response_time](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.alert_failed_delete_procedure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.alert_failed_download_procedure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_resource_group.admin_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.services_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_app_service.appservice_app_backendli](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/app_service) | data source |
@@ -74,6 +76,7 @@
 | [azurerm_key_vault_secret.fn_services_webhook_channel_aks_url](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.fn_services_webhook_channel_url](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_monitor_action_group.error_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
+| [azurerm_monitor_action_group.io_auth_error_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.io_com_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_private_dns_zone.privatelink_blob_core](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.privatelink_queue_core](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |

--- a/src/domains/functions/data.tf
+++ b/src/domains/functions/data.tf
@@ -33,6 +33,11 @@ data "azurerm_monitor_action_group" "io_com_action_group" {
   resource_group_name = "io-p-itn-msgs-rg-01"
 }
 
+data "azurerm_monitor_action_group" "io_auth_error_action_group" {
+  name                = "io-p-itn-auth-error-ag-01"
+  resource_group_name = "io-p-itn-auth-common-rg-01"
+}
+
 data "azurerm_private_dns_zone" "privatelink_queue_core" {
   name                = "privatelink.queue.core.windows.net"
   resource_group_name = local.rg_common_name

--- a/src/domains/functions/function_admin.tf
+++ b/src/domains/functions/function_admin.tf
@@ -317,14 +317,15 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "alert_failed_delete_p
   auto_mitigation_enabled = false
   location                = azurerm_resource_group.admin_rg.location
 
-  // check once every minute(evaluation_frequency)
-  // on the last minute of data(window_duration)
+  // check once every day(evaluation_frequency)
+  // on the last 24 hours of data(window_duration)
   evaluation_frequency = "P1D"
   window_duration      = "P1D"
 
   criteria {
     query                   = <<-QUERY
 exceptions
+| where cloud_RoleName == "${module.function_admin.name}"
 | where customDimensions.name startswith "user.data.delete"
 | where customDimensions.isReplay == true
     QUERY
@@ -360,14 +361,15 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "alert_failed_download
   auto_mitigation_enabled = false
   location                = azurerm_resource_group.admin_rg.location
 
-  // check once every minute(evaluation_frequency)
-  // on the last minute of data(window_duration)
+  // check once every day(evaluation_frequency)
+  // on the last 24 hours of data(window_duration)
   evaluation_frequency = "P1D"
   window_duration      = "P1D"
 
   criteria {
     query                   = <<-QUERY
 exceptions
+| where cloud_RoleName == "${module.function_admin.name}"
 | where customDimensions.name startswith "user.data.download"
 | where customDimensions.isReplay == true
     QUERY

--- a/src/domains/functions/function_admin.tf
+++ b/src/domains/functions/function_admin.tf
@@ -327,7 +327,6 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "alert_failed_delete_p
 exceptions
 | where cloud_RoleName == "${module.function_admin.name}"
 | where customDimensions.name startswith "user.data.delete"
-| where customDimensions.isReplay == true
     QUERY
     operator                = "GreaterThanOrEqual"
     time_aggregation_method = "Count"
@@ -371,7 +370,6 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "alert_failed_download
 exceptions
 | where cloud_RoleName == "${module.function_admin.name}"
 | where customDimensions.name startswith "user.data.download"
-| where customDimensions.isReplay == true
     QUERY
     operator                = "GreaterThanOrEqual"
     time_aggregation_method = "Count"

--- a/src/domains/functions/function_admin.tf
+++ b/src/domains/functions/function_admin.tf
@@ -299,6 +299,96 @@ module "function_admin_staging_slot" {
   tags = var.tags
 }
 
+// ----------------------------------------------------
+// Alerts
+// ----------------------------------------------------
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "alert_failed_delete_procedure" {
+  enabled             = true
+  name                = "[IO-AUTH | ${module.function_admin.name}] Found one or more failed DELETE procedures"
+  resource_group_name = azurerm_resource_group.admin_rg.name
+  scopes              = [data.azurerm_application_insights.application_insights.id]
+  description         = <<EOT
+    Found one or more failed DELETE procedures.
+    Check ${local.function_admin.app_settings_common.FAILED_USER_DATA_PROCESSING_TABLE} table in
+    ${data.azurerm_storage_account.storage_api.name} storage account for more details
+    EOT
+
+  severity                = 1
+  auto_mitigation_enabled = false
+  location                = azurerm_resource_group.admin_rg.location
+
+  // check once every minute(evaluation_frequency)
+  // on the last minute of data(window_duration)
+  evaluation_frequency = "P1D"
+  window_duration      = "P1D"
+
+  criteria {
+    query                   = <<-QUERY
+exceptions
+| where customDimensions.name startswith "user.data.delete"
+| where customDimensions.isReplay == true
+    QUERY
+    operator                = "GreaterThanOrEqual"
+    time_aggregation_method = "Count"
+    threshold               = 1
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  # Action groups for alerts
+  action {
+    action_groups = [data.azurerm_monitor_action_group.io_auth_error_action_group.id]
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "alert_failed_download_procedure" {
+  enabled             = true
+  name                = "[IO-AUTH | ${module.function_admin.name}] Found one or more failed DOWNLOAD procedures"
+  resource_group_name = azurerm_resource_group.admin_rg.name
+  scopes              = [data.azurerm_application_insights.application_insights.id]
+  description         = <<EOT
+    Found one or more failed DOWNLOAD procedures.
+    Check ${local.function_admin.app_settings_common.FAILED_USER_DATA_PROCESSING_TABLE} table in
+    ${data.azurerm_storage_account.storage_api.name} storage account for more details
+    EOT
+
+  severity                = 1
+  auto_mitigation_enabled = false
+  location                = azurerm_resource_group.admin_rg.location
+
+  // check once every minute(evaluation_frequency)
+  // on the last minute of data(window_duration)
+  evaluation_frequency = "P1D"
+  window_duration      = "P1D"
+
+  criteria {
+    query                   = <<-QUERY
+exceptions
+| where customDimensions.name startswith "user.data.download"
+| where customDimensions.isReplay == true
+    QUERY
+    operator                = "GreaterThanOrEqual"
+    time_aggregation_method = "Count"
+    threshold               = 1
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  # Action groups for alerts
+  action {
+    action_groups = [data.azurerm_monitor_action_group.io_auth_error_action_group.id]
+  }
+
+  tags = var.tags
+}
+// -----------------------------------------------------
+
 resource "azurerm_monitor_autoscale_setting" "function_admin" {
   name                = format("%s-autoscale", module.function_admin.name)
   resource_group_name = azurerm_resource_group.admin_rg.name


### PR DESCRIPTION
### ⚠️ This PR depends on https://github.com/pagopa/io-functions-admin/pull/248

### Motivation and Context
add alerts for download/delete procedures failures
<!--- Why is this change required? What problem does it solve? -->

### Major Changes

<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
