### PR TITLE
[CES-552] Add assistenza.ioapp.it cname record pointing to zendesk

### DIFF
--- a/src/common/_modules/global/modules/dns/dns_ioweb_it.tf
+++ b/src/common/_modules/global/modules/dns/dns_ioweb_it.tf
@@ -25,3 +25,12 @@ resource "azurerm_dns_caa_record" "ioweb_it" {
 
   tags = var.tags
 }
+
+# CNAME for zendesk help center
+resource "azurerm_dns_cname_record" "zendesk" {
+  name                = "assistenza"
+  zone_name           = azurerm_dns_zone.ioweb_it.name
+  resource_group_name = var.resource_groups.external
+  ttl                 = var.dns_default_ttl_sec
+  record              = "hc-io.zendesk.com"
+}


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This cname record is needed to enable the "Centro Assistenza Cittadini" via zendesk
### Major Changes

<!--- Describe the major changes introduced by this PR -->
Added assistenza.ioapp.it cname record pointing to zendesk

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
