### PR TITLE
[#IOPID-2535] Update autoscale shared AppServicePlan citizen auth

### DIFF
--- a/src/domains/citizen-auth-app/07_data.tf
+++ b/src/domains/citizen-auth-app/07_data.tf
@@ -1,0 +1,4 @@
+data "azurerm_linux_function_app" "function_web_profile" {
+  name                = format("%s-webprof-func-01", local.short_project_itn)
+  resource_group_name = format("%s-webprof-rg-01", local.short_project_itn)
+}

--- a/src/domains/citizen-auth-app/10_function_public.tf
+++ b/src/domains/citizen-auth-app/10_function_public.tf
@@ -152,6 +152,28 @@ resource "azurerm_monitor_autoscale_setting" "function_public_itn" {
 
     rule {
       metric_trigger {
+        metric_name              = "Requests"
+        metric_resource_id       = data.azurerm_linux_function_app.function_web_profile.id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "GreaterThan"
+        threshold                = 3000
+        divide_by_instance_count = false
+      }
+
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = "2"
+        cooldown  = "PT5M"
+      }
+    }
+
+    rule {
+      metric_trigger {
         metric_name              = "CpuPercentage"
         metric_resource_id       = module.function_public_itn.app_service_plan_id
         metric_namespace         = "microsoft.web/serverfarms"
@@ -176,6 +198,28 @@ resource "azurerm_monitor_autoscale_setting" "function_public_itn" {
       metric_trigger {
         metric_name              = "Requests"
         metric_resource_id       = module.function_public_itn.id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "LessThan"
+        threshold                = 2000
+        divide_by_instance_count = false
+      }
+
+      scale_action {
+        direction = "Decrease"
+        type      = "ChangeCount"
+        value     = "1"
+        cooldown  = "PT20M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name              = "Requests"
+        metric_resource_id       = data.azurerm_linux_function_app.function_web_profile.id
         metric_namespace         = "microsoft.web/sites"
         time_grain               = "PT1M"
         statistic                = "Average"

--- a/src/domains/citizen-auth-app/README.md
+++ b/src/domains/citizen-auth-app/README.md
@@ -117,6 +117,7 @@
 | [azurerm_key_vault_secret.session_manager_JWT_ZENDESK_SUPPORT_TOKEN_SECRET](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.session_manager_TEST_LOGIN_PASSWORD](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.session_manager_UNIQUE_EMAIL_ENFORCEMENT_USER](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_linux_function_app.function_web_profile](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
 | [azurerm_linux_function_app.itn_auth_lv_func](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
 | [azurerm_log_analytics_workspace.log_analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |


### PR DESCRIPTION
### Motivation and Context
The shared AppServicePlan between `io-function-public` and `ioweb-profile-backend` need specific metrics on the Requests for the both functions
<!--- Why is this change required? What problem does it solve? -->

### Major Changes
Add Request metric for `io-p-itn-auth-webprof-func-01` in scale-in and scale-out actions for `shared-asp-01`
<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing
local plan
<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
