### PR TITLE
[#IOPID-1971] Change configurations to pointing new webprof fn in ITN

### DIFF
--- a/src/domains/citizen-auth-app/09_function_profile.tf
+++ b/src/domains/citizen-auth-app/09_function_profile.tf
@@ -121,7 +121,7 @@ locals {
 
       # Login Email variables
       MAGIC_LINK_SERVICE_API_KEY    = data.azurerm_key_vault_secret.ioweb_profile_function_api_key.value
-      MAGIC_LINK_SERVICE_PUBLIC_URL = format("https://%s-%s-%s-ioweb-profile-fn.azurewebsites.net", var.prefix, var.env_short, var.location_short)
+      MAGIC_LINK_SERVICE_PUBLIC_URL = format("https://%s-auth-webprof-func-01.azurewebsites.net", local.common_project_itn)
       IOWEB_ACCESS_REF              = "https://ioapp.it"
       #
 

--- a/src/domains/ioweb-app/07_apim_itn.tf
+++ b/src/domains/ioweb-app/07_apim_itn.tf
@@ -7,7 +7,7 @@ module "apim_itn_bff_api" {
   product_ids           = ["io-web-api"]
   subscription_required = false
 
-  service_url = format(local.bff_backend_url, module.function_ioweb_profile.default_hostname)
+  service_url = format(local.bff_backend_url, data.azurerm_linux_function_app.function_web_profile.default_hostname)
 
   description  = "Bff API for IO Web platform"
   display_name = "IO Web - Bff"

--- a/src/domains/ioweb-app/07_apim_v2.tf
+++ b/src/domains/ioweb-app/07_apim_v2.tf
@@ -7,7 +7,7 @@ module "apim_v2_bff_api" {
   product_ids           = ["io-web-api"]
   subscription_required = false
 
-  service_url = format(local.bff_backend_url, module.function_ioweb_profile.default_hostname)
+  service_url = format(local.bff_backend_url, data.azurerm_linux_function_app.function_web_profile.default_hostname)
 
   description  = "Bff API for IO Web platform"
   display_name = "IO Web - Bff"

--- a/src/domains/ioweb-app/99_data.tf
+++ b/src/domains/ioweb-app/99_data.tf
@@ -24,3 +24,12 @@ data "azurerm_key_vault_secret" "io_fn3_services_key_secret" {
   name         = "ioweb-profile-api-key-apim"
   key_vault_id = data.azurerm_key_vault.key_vault_common.id
 }
+
+###########################
+# Function io-web-profile #
+###########################
+
+data "azurerm_linux_function_app" "function_web_profile" {
+  name                = format("%s-webprof-func-01", local.short_project_itn)
+  resource_group_name = format("%s-webprof-rg-01", local.short_project_itn)
+}

--- a/src/domains/ioweb-app/README.md
+++ b/src/domains/ioweb-app/README.md
@@ -65,6 +65,7 @@
 | [azurerm_key_vault_secret.io_fn3_services_key_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.spid_login_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.spid_login_jwt_pub_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_linux_function_app.function_web_profile](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
 | [azurerm_log_analytics_workspace.log_analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.error_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |


### PR DESCRIPTION
### Motivation and Context
A new `io-web-profile` function was created into the ITN region. All the services that use the function as dependency must use the new instance.
<!--- Why is this change required? What problem does it solve? -->

### Major Changes

<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
