### PR TITLE
[#IOPID-2180] Add Runbook link into the descr of fn-elt Alets

### DIFF
--- a/src/domains/elt/_modules/function_apps/monitor.tf
+++ b/src/domains/elt/_modules/function_apps/monitor.tf
@@ -25,7 +25,11 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "service_preferences_f
   location            = var.location
 
   scopes                  = [data.azurerm_storage_account.function_elt_internal_storage.id]
-  description             = "Permanent failures processing Service Preferences export to PDND. REQUIRED MANUAL ACTION"
+  description             = <<-EOT
+    Permanent failures processing Service Preferences export to PDND. REQUIRED MANUAL ACTION.
+    For more info see runbook
+    https://pagopa.atlassian.net/wiki/spaces/IAEI/pages/1417412755/Fallimenti+ingestion+data-lake
+  EOT
   severity                = 1
   auto_mitigation_enabled = false
 
@@ -59,7 +63,11 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "profiles_failure_aler
   location            = var.location
 
   scopes                  = [data.azurerm_storage_account.function_elt_internal_storage.id]
-  description             = "Permanent failures processing Profiles export to PDND. REQUIRED MANUAL ACTION"
+  description             = <<-EOT
+    Permanent failures processing Profiles export to PDND. REQUIRED MANUAL ACTION.
+    For more info see runbook
+    https://pagopa.atlassian.net/wiki/spaces/IAEI/pages/1417412755/Fallimenti+ingestion+data-lake
+  EOT
   severity                = 1
   auto_mitigation_enabled = false
 
@@ -93,7 +101,11 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "profile_deletion_fail
   location            = var.location
 
   scopes                  = [data.azurerm_storage_account.function_elt_internal_storage.id]
-  description             = "Permanent failures processing Profiles export to PDND. REQUIRED MANUAL ACTION"
+  description             = <<-EOT
+    Permanent failures processing Profiles deletions export to PDND. REQUIRED MANUAL ACTION.
+    For more info see runbook
+    https://pagopa.atlassian.net/wiki/spaces/IAEI/pages/1417412755/Fallimenti+ingestion+data-lake
+  EOT
   severity                = 1
   auto_mitigation_enabled = false
 


### PR DESCRIPTION
### Motivation and Context
The existings alerts for errors processing documents for ingestion into PDND must have a link to the new Runbook.
<!--- Why is this change required? What problem does it solve? -->

### Major Changes

<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
