### PR TITLE
[IOPAE-1639] add selfcare eventhub private endpoint

### DIFF
--- a/src/common/_modules/private_endpoint/locals.tf
+++ b/src/common/_modules/private_endpoint/locals.tf
@@ -7,5 +7,12 @@ locals {
         private_dns_zone_id = var.dns_zones.postgres.id
       }
     }
+    "selc-evhns" = {
+      "01" = {
+        resource_id         = "/subscriptions/813119d7-0943-46ed-8ebe-cebe24f9106c/resourceGroups/selc-p-event-rg/providers/Microsoft.EventHub/namespaces/selc-p-eventhub-ns"
+        subresource_names   = ["namespace"]
+        private_dns_zone_id = var.dns_zones.servicebus.id
+      }
+    }
   }
 }


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

CMS needs to consume SelfCare Event Hub messages, and this PR adds a private endpoint to allow IO resources to connect to it.

Until now, this associations has been made through IP whitelist, using public network which is not recommended.

### Major Changes

<!--- Describe the major changes introduced by this PR -->

Add private endpoint to SelfCare Event Hub

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
