### PR TITLE
[#IOPID-2550] Disable HandlePubkeyRevoke queue trigger old fn-lollipop

### DIFF
--- a/src/domains/citizen-auth-app/04_function_lollipop.tf
+++ b/src/domains/citizen-auth-app/04_function_lollipop.tf
@@ -118,7 +118,7 @@ module "function_lollipop_itn" {
 
   app_settings = merge(
     local.function_lollipop.app_settings,
-    { "AzureWebJobs.HandlePubKeyRevoke.Disabled" = "0" },
+    { "AzureWebJobs.HandlePubKeyRevoke.Disabled" = "1" },
   )
 
   sticky_app_setting_names = ["AzureWebJobs.HandlePubKeyRevoke.Disabled"]


### PR DESCRIPTION
### Motivation and Context
The new `fn-lollipop` infrastructure, migrated into the A&I monorepo is now in production and the only one that read from the revoke queue.
<!--- Why is this change required? What problem does it solve? -->

### Major Changes

<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
