### PR TITLE
[CES-205] Added outputs into common resources module

### DIFF
--- a/src/_modules/common_values/data.tf
+++ b/src/_modules/common_values/data.tf
@@ -3,13 +3,13 @@ data "azurerm_virtual_network" "weu_prod01" {
   resource_group_name = "${local.project_weu}-prod01-vnet-rg"
 }
 
-data "terraform_remote_state" "core" {
+data "terraform_remote_state" "common" {
   backend = "azurerm"
 
   config = {
     resource_group_name  = "terraform-state-rg"
     storage_account_name = "iopitntfst001"
     container_name       = "terraform-state"
-    key                  = "io-infra.core.prod.italynorth.tfstate"
+    key                  = "io-infra.common.prod.tfstate"
   }
 }

--- a/src/_modules/common_values/locals.tf
+++ b/src/_modules/common_values/locals.tf
@@ -10,5 +10,5 @@ locals {
   project_itn        = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}"
   project_weu        = "${local.prefix}-${local.env_short}-${local.location_short.westeurope}"
   project_weu_legacy = "${local.prefix}-${local.env_short}"
-  core               = data.terraform_remote_state.core.outputs
+  common               = data.terraform_remote_state.common.outputs
 }

--- a/src/_modules/common_values/locals.tf
+++ b/src/_modules/common_values/locals.tf
@@ -10,5 +10,5 @@ locals {
   project_itn        = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}"
   project_weu        = "${local.prefix}-${local.env_short}-${local.location_short.westeurope}"
   project_weu_legacy = "${local.prefix}-${local.env_short}"
-  common               = data.terraform_remote_state.common.outputs
+  common             = data.terraform_remote_state.common.outputs
 }

--- a/src/_modules/common_values/outputs_network.tf
+++ b/src/_modules/common_values/outputs_network.tf
@@ -5,14 +5,20 @@ output "virtual_networks" {
   EOF
   value = {
     itn = {
-      common = local.core.networking.itn.vnet_common
+      id                  = local.common.virtual_networks.itn.id
+      name                = local.common.virtual_networks.itn.name
+      resource_group_name = local.common.virtual_networks.itn.resource_group_name
     }
     weu = {
-      common = local.core.networking.weu.vnet_common
-      prod01 = {
-        name                = data.azurerm_virtual_network.weu_prod01.name
-        resource_group_name = data.azurerm_virtual_network.weu_prod01.resource_group_name
-      }
+      id                  = local.common.virtual_networks.weu.id
+      name                = local.common.virtual_networks.weu.name
+      resource_group_name = local.common.virtual_networks.weu.resource_group_name
+    }
+
+    prod01 = {
+      id                  = local.common.virtual_networks.prod01.id
+      name                = local.common.virtual_networks.prod01.name
+      resource_group_name = local.common.virtual_networks.prod01.resource_group_name
     }
   }
 }
@@ -23,10 +29,10 @@ output "pep_subnets" {
   EOF
   value = {
     itn = {
-      id = local.core.networking.itn.pep_snet.id
+      id = local.common.pep_subnets.itn.id
     },
     weu = {
-      id = local.core.networking.weu.pep_snet.id
+      id = local.common.pep_subnets.weu.id
     }
   }
 }

--- a/src/common/prod/README.md
+++ b/src/common/prod/README.md
@@ -66,5 +66,10 @@ No inputs.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_apim"></a> [apim](#output\_apim) | n/a |
+| <a name="output_pep_subnets"></a> [pep\_subnets](#output\_pep\_subnets) | n/a |
+| <a name="output_private_endpoints"></a> [private\_endpoints](#output\_private\_endpoints) | n/a |
+| <a name="output_virtual_networks"></a> [virtual\_networks](#output\_virtual\_networks) | n/a |
 <!-- END_TF_DOCS -->

--- a/src/common/prod/outputs.tf
+++ b/src/common/prod/outputs.tf
@@ -1,0 +1,49 @@
+output "apim" {
+  value = {
+    itn = {
+      id                      = module.apim_itn.id
+      resource_group_common   = local.resource_groups.itn.common
+      resource_group_internal = local.resource_groups.itn.internal
+    }
+    weu = {
+      id                      = module.apim_weu.id
+      resource_group_common   = local.core.resource_groups.westeurope.common
+      resource_group_internal = local.core.resource_groups.westeurope.internal
+    }
+  }
+}
+
+output "private_endpoints" {
+  value = module.private_endpoints.private_endpoints
+}
+
+output "virtual_networks" {
+  value = {
+    weu = {
+      id                  = local.core.networking.weu.vnet_common.id
+      name                = local.core.networking.weu.vnet_common.name
+      resource_group_name = local.core.networking.weu.vnet_common.resource_group_name
+    }
+    itn = {
+      id                  = local.core.networking.itn.vnet_common.id
+      name                = local.core.networking.itn.vnet_common.name
+      resource_group_name = local.core.networking.itn.vnet_common.resource_group_name
+    }
+    prod01 = {
+      id                  = data.azurerm_virtual_network.weu_prod01.id
+      name                = data.azurerm_virtual_network.weu_prod01.name
+      resource_group_name = data.azurerm_virtual_network.weu_prod01.resource_group_name
+    }
+  }
+}
+
+output "pep_subnets" {
+  value = {
+    itn = {
+      id = local.core.networking.itn.pep_snet.id
+    },
+    weu = {
+      id = local.core.networking.weu.pep_snet.id
+    }
+  }
+}


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To avoid using the `core`project as a reference, the outputs have been added to the `common` project, so that they can also be passed to the `common_values` ​​module and kept up to date.

### Major Changes

<!--- Describe the major changes introduced by this PR -->

- Added `outputs.tf` file into src/common
- Updated common_values outputs

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
