### PR TITLE
[CES-635] Replace terraform-azurerm-vx VNet and subnet modules with resources

### DIFF
--- a/src/core/_modules/networking/outputs.tf
+++ b/src/core/_modules/networking/outputs.tf
@@ -1,17 +1,17 @@
 output "vnet_common" {
   value = {
-    id                  = module.vnet_common.id
-    name                = module.vnet_common.name
-    address_space       = module.vnet_common.address_space
-    resource_group_name = module.vnet_common.resource_group_name
+    id                  = azurerm_virtual_network.common.id
+    name                = azurerm_virtual_network.common.name
+    address_space       = azurerm_virtual_network.common.address_space
+    resource_group_name = azurerm_virtual_network.common.resource_group_name
   }
 }
 
 output "pep_snet" {
   value = {
-    id               = module.pep_snet.id
-    name             = module.pep_snet.name
-    address_prefixes = module.pep_snet.address_prefixes
+    id               = azurerm_subnet.pep.id
+    name             = azurerm_subnet.pep.name
+    address_prefixes = azurerm_subnet.pep.address_prefixes
   }
 }
 

--- a/src/core/_modules/networking/snet_private_endpoints.tf
+++ b/src/core/_modules/networking/snet_private_endpoints.tf
@@ -1,9 +1,6 @@
-module "pep_snet" {
-  source               = "github.com/pagopa/terraform-azurerm-v3//subnet?ref=v8.27.0"
+resource "azurerm_subnet" "pep" {
   name                 = try(local.nonstandard[var.location_short].pep-snet, "${var.project}-pep-snet-01")
   address_prefixes     = var.pep_snet_cidr
+  virtual_network_name = azurerm_virtual_network.common.name
   resource_group_name  = var.resource_group_name
-  virtual_network_name = module.vnet_common.name
-
-  private_endpoint_network_policies_enabled = false
 }

--- a/src/core/_modules/networking/vnet_common.tf
+++ b/src/core/_modules/networking/vnet_common.tf
@@ -1,12 +1,13 @@
-module "vnet_common" {
-  source = "github.com/pagopa/terraform-azurerm-v3//virtual_network?ref=v8.27.0"
-
+resource "azurerm_virtual_network" "common" {
   name                = try(local.nonstandard[var.location_short].vnet, "${var.project}-common-vnet-01")
-  location            = var.location
   resource_group_name = var.resource_group_name
+  location            = var.location
+  address_space       = [var.vnet_cidr_block]
 
-  address_space        = [var.vnet_cidr_block]
-  ddos_protection_plan = local.ddos_protection_plan
+  ddos_protection_plan {
+    id     = local.ddos_protection_plan.id
+    enable = local.ddos_protection_plan.enable
+  }
 
   tags = var.tags
 }

--- a/src/core/_modules/vpn/main.tf
+++ b/src/core/_modules/vpn/main.tf
@@ -1,13 +1,8 @@
-## VPN
-
-module "vpn_snet" {
-  source                                    = "github.com/pagopa/terraform-azurerm-v3//subnet?ref=v8.33.1"
-  name                                      = "GatewaySubnet"
-  address_prefixes                          = var.vpn_cidr_subnet
-  resource_group_name                       = var.resource_group_name
-  virtual_network_name                      = var.vnet_common.name
-  service_endpoints                         = []
-  private_endpoint_network_policies_enabled = false
+resource "azurerm_subnet" "vpn" {
+  name                 = "GatewaySubnet"
+  address_prefixes     = var.vpn_cidr_subnet
+  virtual_network_name = var.vnet_common.name
+  resource_group_name  = var.resource_group_name
 }
 
 module "vpn" {
@@ -18,7 +13,7 @@ module "vpn" {
   resource_group_name = var.resource_group_name
   sku                 = var.vpn_sku
   pip_sku             = var.vpn_pip_sku
-  subnet_id           = module.vpn_snet.id
+  subnet_id           = azurerm_subnet.vpn.id
 
   vpn_client_configuration = [
     {

--- a/src/core/prod/moved.tf
+++ b/src/core/prod/moved.tf
@@ -1,0 +1,30 @@
+moved {
+  from = module.vpn_weu.module.vpn_snet.azurerm_subnet.this
+  to   = module.vpn_weu.azurerm_subnet.vpn
+}
+
+moved {
+  from = module.vpn_weu.module.vpn_snet.azurerm_subnet.this
+  to   = module.vpn_weu.azurerm_subnet.vpn
+}
+
+moved {
+  from = module.networking_itn.module.pep_snet.azurerm_subnet.this
+  to   = module.networking_itn.azurerm_subnet.pep
+}
+
+moved {
+  from = module.networking_weu.module.pep_snet.azurerm_subnet.this
+  to   = module.networking_weu.azurerm_subnet.pep
+}
+
+moved {
+  from = module.networking_weu.module.vnet_common.azurerm_virtual_network.this
+  to   = module.networking_weu.azurerm_virtual_network.common
+}
+
+moved {
+  from = module.networking_itn.module.vnet_common.azurerm_virtual_network.this
+  to   = module.networking_itn.azurerm_virtual_network.common
+}
+


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The Terraform modules terraform-azurerm-vx of VNets and subnets are nothing more than wrappers of the azurerm resources. Therefore, having this dependency on terraform-azurerm-vx is not only unnecessary but also expensive when you want to upgrade the provider version. This PR eliminates the dependency allowing quicker upgrades

### Major Changes

<!--- Describe the major changes introduced by this PR -->

Replace VNet and subnet module references

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
