### PR TITLE
[#IOPID-2513] update Function Admin node version 18 -> 20

### DIFF
--- a/src/domains/functions/README.md
+++ b/src/domains/functions/README.md
@@ -130,7 +130,7 @@
 | <a name="input_lock_enable"></a> [lock\_enable](#input\_lock\_enable) | Apply locks to block accedentaly deletions. | `bool` | `false` | no |
 | <a name="input_pn_service_id"></a> [pn\_service\_id](#input\_pn\_service\_id) | The Service ID of PN service | `string` | `"01G40DWQGKY5GRWSNM4303VNRP"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | `"io"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | <pre>{<br/>  "CreatedBy": "Terraform"<br/>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | <pre>{<br>  "CreatedBy": "Terraform"<br>}</pre> | no |
 
 ## Outputs
 

--- a/src/domains/functions/README.md
+++ b/src/domains/functions/README.md
@@ -130,7 +130,7 @@
 | <a name="input_lock_enable"></a> [lock\_enable](#input\_lock\_enable) | Apply locks to block accedentaly deletions. | `bool` | `false` | no |
 | <a name="input_pn_service_id"></a> [pn\_service\_id](#input\_pn\_service\_id) | The Service ID of PN service | `string` | `"01G40DWQGKY5GRWSNM4303VNRP"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | `"io"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | <pre>{<br>  "CreatedBy": "Terraform"<br>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | <pre>{<br/>  "CreatedBy": "Terraform"<br/>}</pre> | no |
 
 ## Outputs
 

--- a/src/domains/functions/function_admin.tf
+++ b/src/domains/functions/function_admin.tf
@@ -204,7 +204,7 @@ module "function_admin" {
   domain              = "IO-COMMONS"
   health_check_path   = "/info"
 
-  node_version    = "18"
+  node_version    = "20"
   runtime_version = "~4"
 
   always_on                                = "true"
@@ -274,7 +274,7 @@ module "function_admin_staging_slot" {
   storage_account_access_key         = module.function_admin.storage_account.primary_access_key
   internal_storage_connection_string = module.function_admin.storage_account_internal_function.primary_connection_string
 
-  node_version                             = "18"
+  node_version                             = "20"
   always_on                                = "true"
   runtime_version                          = "~4"
   application_insights_instrumentation_key = data.azurerm_application_insights.application_insights.instrumentation_key


### PR DESCRIPTION
### Motivation and Context
Node 18 is deprecated, in order to get further microsoft's support on AppService/FunctionApp we need to update them to Node 20.
<!--- Why is this change required? What problem does it solve? -->

### Major Changes
- Functions Admin update Node Runtime from 18 to 20
<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing
Local Application Run
<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
