### PR TITLE
[CES-584] Give access to common IO KeyVaults to new AD groups

### DIFF
--- a/src/core/_modules/key_vaults/kv.tf
+++ b/src/core/_modules/key_vaults/kv.tf
@@ -23,7 +23,7 @@ resource "azurerm_key_vault_access_policy" "kv_adgroup_admin" {
   key_vault_id = azurerm_key_vault.kv.id
 
   tenant_id = var.tenant_id
-  object_id = var.azure_ad_group_admin_object_id
+  object_id = var.azure_adgroup_admin_object_id
 
   key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
   secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
@@ -57,7 +57,7 @@ resource "azurerm_key_vault_access_policy" "kv_adgroup_developers" {
   key_vault_id = azurerm_key_vault.kv.id
 
   tenant_id = var.tenant_id
-  object_id = var.azure_ad_group_developers_object_id
+  object_id = var.azure_adgroup_developers_object_id
 
   key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
   secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
@@ -85,4 +85,124 @@ resource "azurerm_key_vault_access_policy" "kv_azdevops_platform_iac" {
   secret_permissions      = ["Get", "List", "Set", ]
   storage_permissions     = []
   certificate_permissions = ["SetIssuers", "DeleteIssuers", "Purge", "List", "Get", "ManageContacts", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_adgroup_wallet_admins" {
+  key_vault_id = azurerm_key_vault.kv.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_wallet_admins_object_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_adgroup_wallet_devs" {
+  key_vault_id = azurerm_key_vault.kv.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_wallet_devs_object_id
+
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  storage_permissions     = []
+  certificate_permissions = []
+}
+
+resource "azurerm_key_vault_access_policy" "kv_adgroup_com_admins" {
+  key_vault_id = azurerm_key_vault.kv.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_com_admins_object_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_adgroup_com_devs" {
+  key_vault_id = azurerm_key_vault.kv.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_com_devs_object_id
+
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  storage_permissions     = []
+  certificate_permissions = []
+}
+
+resource "azurerm_key_vault_access_policy" "kv_adgroup_svc_admins" {
+  key_vault_id = azurerm_key_vault.kv.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_svc_admins_object_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_adgroup_svc_devs" {
+  key_vault_id = azurerm_key_vault.kv.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_svc_devs_object_id
+
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  storage_permissions     = []
+  certificate_permissions = []
+}
+
+resource "azurerm_key_vault_access_policy" "kv_adgroup_auth_admins" {
+  key_vault_id = azurerm_key_vault.kv.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_auth_devs_object_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_adgroup_auth_devs" {
+  key_vault_id = azurerm_key_vault.kv.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_auth_devs_object_id
+
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  storage_permissions     = []
+  certificate_permissions = []
+}
+
+resource "azurerm_key_vault_access_policy" "kv_adgroup_bonus_admins" {
+  key_vault_id = azurerm_key_vault.kv.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_bonus_admins_object_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_adgroup_bonus_devs" {
+  key_vault_id = azurerm_key_vault.kv.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_bonus_devs_object_id
+
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  storage_permissions     = []
+  certificate_permissions = []
 }

--- a/src/core/_modules/key_vaults/kv_common.tf
+++ b/src/core/_modules/key_vaults/kv_common.tf
@@ -23,7 +23,7 @@ resource "azurerm_key_vault_access_policy" "kv_common_adgroup_admin" {
   key_vault_id = azurerm_key_vault.common.id
 
   tenant_id = var.tenant_id
-  object_id = var.azure_ad_group_admin_object_id
+  object_id = var.azure_adgroup_admin_object_id
 
   key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
   secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
@@ -57,7 +57,7 @@ resource "azurerm_key_vault_access_policy" "kv_common_adgroup_developers" {
   key_vault_id = azurerm_key_vault.common.id
 
   tenant_id = var.tenant_id
-  object_id = var.azure_ad_group_developers_object_id
+  object_id = var.azure_adgroup_developers_object_id
 
   key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
   secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
@@ -99,4 +99,124 @@ resource "azurerm_key_vault_access_policy" "kv_common_azdevops_platform_iac" {
   secret_permissions      = ["Get", "List", "Set", ]
   storage_permissions     = []
   certificate_permissions = ["SetIssuers", "DeleteIssuers", "Purge", "List", "Get", "ManageContacts", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_common_adgroup_wallet_admins" {
+  key_vault_id = azurerm_key_vault.common.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_wallet_admins_object_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_common_adgroup_wallet_devs" {
+  key_vault_id = azurerm_key_vault.common.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_wallet_devs_object_id
+
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  storage_permissions     = []
+  certificate_permissions = []
+}
+
+resource "azurerm_key_vault_access_policy" "kv_common_adgroup_com_admins" {
+  key_vault_id = azurerm_key_vault.common.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_com_admins_object_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_common_adgroup_com_devs" {
+  key_vault_id = azurerm_key_vault.common.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_com_devs_object_id
+
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  storage_permissions     = []
+  certificate_permissions = []
+}
+
+resource "azurerm_key_vault_access_policy" "kv_common_adgroup_svc_admins" {
+  key_vault_id = azurerm_key_vault.common.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_svc_admins_object_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_common_adgroup_svc_devs" {
+  key_vault_id = azurerm_key_vault.common.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_svc_devs_object_id
+
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  storage_permissions     = []
+  certificate_permissions = []
+}
+
+resource "azurerm_key_vault_access_policy" "kv_common_adgroup_auth_admins" {
+  key_vault_id = azurerm_key_vault.common.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_auth_devs_object_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_common_adgroup_auth_devs" {
+  key_vault_id = azurerm_key_vault.common.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_auth_devs_object_id
+
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  storage_permissions     = []
+  certificate_permissions = []
+}
+
+resource "azurerm_key_vault_access_policy" "kv_common_adgroup_bonus_admins" {
+  key_vault_id = azurerm_key_vault.common.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_bonus_admins_object_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_common_adgroup_bonus_devs" {
+  key_vault_id = azurerm_key_vault.common.id
+
+  tenant_id = var.tenant_id
+  object_id = var.azure_adgroup_bonus_devs_object_id
+
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  storage_permissions     = []
+  certificate_permissions = []
 }

--- a/src/core/_modules/key_vaults/variables.tf
+++ b/src/core/_modules/key_vaults/variables.tf
@@ -34,12 +34,62 @@ variable "tenant_id" {
   description = "Azure tenant id"
 }
 
-variable "azure_ad_group_admin_object_id" {
+variable "azure_adgroup_wallet_admins_object_id" {
   type        = string
   description = "Object Id of the Entra group for subscription admins"
 }
 
-variable "azure_ad_group_developers_object_id" {
+variable "azure_adgroup_wallet_devs_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_com_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_com_devs_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_svc_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_svc_devs_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_auth_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_auth_devs_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_bonus_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_bonus_devs_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_admin_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_developers_object_id" {
   type        = string
   description = "Object Id of the Entra group for subscription developers"
 }

--- a/src/core/prod/README.md
+++ b/src/core/prod/README.md
@@ -43,8 +43,18 @@
 | [azurerm_resource_group.linux_weu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.role_assignment_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.sec_weu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
-| [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.auth_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.auth_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.bonus_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.bonus_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.com_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.com_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.developers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.svc_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.svc_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.wallet_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.wallet_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_service_principal.platform_iac_sp](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |

--- a/src/core/prod/data.tf
+++ b/src/core/prod/data.tf
@@ -7,15 +7,54 @@ data "azurerm_virtual_network" "weu_prod01" {
   resource_group_name = "${local.project_weu}-prod01-vnet-rg"
 }
 
-data "azuread_group" "adgroup_admin" {
+data "azuread_group" "admin" {
   display_name = "${local.prefix}-${local.env_short}-adgroup-admin"
 }
 
-data "azuread_group" "adgroup_developers" {
+data "azuread_group" "developers" {
   display_name = "${local.prefix}-${local.env_short}-adgroup-developers"
 }
 
-#pagopaspa-cstar-platform-iac-projects-{subscription}
+data "azuread_group" "wallet_admins" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-wallet-admins"
+}
+
+data "azuread_group" "wallet_devs" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-wallet-developers"
+}
+
+data "azuread_group" "com_admins" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-com-admins"
+}
+
+data "azuread_group" "com_devs" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-com-developers"
+}
+
+data "azuread_group" "svc_admins" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-svc-admins"
+}
+
+data "azuread_group" "svc_devs" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-svc-developers"
+}
+
+data "azuread_group" "auth_admins" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-auth-admins"
+}
+
+data "azuread_group" "auth_devs" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-auth-developers"
+}
+
+data "azuread_group" "bonus_admins" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-bonus-admins"
+}
+
+data "azuread_group" "bonus_devs" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-bonus-developers"
+}
+
 data "azuread_service_principal" "platform_iac_sp" {
   display_name = "pagopaspa-io-platform-iac-projects-${data.azurerm_subscription.current.subscription_id}"
 }

--- a/src/core/prod/westeurope.tf
+++ b/src/core/prod/westeurope.tf
@@ -68,8 +68,18 @@ module "key_vault_weu" {
   resource_group_common = azurerm_resource_group.common_weu.name
   tenant_id             = data.azurerm_client_config.current.tenant_id
 
-  azure_ad_group_admin_object_id            = data.azuread_group.adgroup_admin.object_id
-  azure_ad_group_developers_object_id       = data.azuread_group.adgroup_developers.object_id
+  azure_adgroup_admin_object_id             = data.azuread_group.admin.object_id
+  azure_adgroup_developers_object_id        = data.azuread_group.developers.object_id
+  azure_adgroup_wallet_admins_object_id     = data.azuread_group.wallet_admins.object_id
+  azure_adgroup_wallet_devs_object_id       = data.azuread_group.wallet_devs.object_id
+  azure_adgroup_com_admins_object_id        = data.azuread_group.com_admins.object_id
+  azure_adgroup_com_devs_object_id          = data.azuread_group.com_devs.object_id
+  azure_adgroup_svc_admins_object_id        = data.azuread_group.svc_admins.object_id
+  azure_adgroup_svc_devs_object_id          = data.azuread_group.svc_devs.object_id
+  azure_adgroup_auth_admins_object_id       = data.azuread_group.auth_admins.object_id
+  azure_adgroup_auth_devs_object_id         = data.azuread_group.auth_devs.object_id
+  azure_adgroup_bonus_admins_object_id      = data.azuread_group.bonus_admins.object_id
+  azure_adgroup_bonus_devs_object_id        = data.azuread_group.bonus_devs.object_id
   io_infra_ci_managed_identity_principal_id = data.azurerm_user_assigned_identity.managed_identity_io_infra_ci.principal_id
   io_infra_cd_managed_identity_principal_id = data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id
   platform_iac_sp_object_id                 = data.azuread_service_principal.platform_iac_sp.object_id


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

General AD groups are going to be dismissed very soon, so each IO domain AD group needs to get access to common KeyVaults

### Major Changes

<!--- Describe the major changes introduced by this PR -->

Add access policies to allow AD groups to access common IO KeyVaults

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
