### PR TITLE
[CES-584] Add roles to CD infra identity

### DIFF
--- a/src/identity/prod/locals.tf
+++ b/src/identity/prod/locals.tf
@@ -9,10 +9,11 @@ locals {
   repo_name = "io-infra"
 
   tags = {
-    CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
-    CreatedBy   = "Terraform"
-    Environment = "Prod"
-    Owner       = "IO"
-    Source      = "https://github.com/pagopa/io-infra/blob/main/src/identity/prod"
+    CostCenter     = "TS000 - Tecnologia e Servizi"
+    CreatedBy      = "Terraform"
+    Environment    = "Prod"
+    BusinessUnit   = "App IO"
+    Source         = "https://github.com/pagopa/io-infra/blob/main/src/identity/prod"
+    ManagementTeam = "IO Platform"
   }
 }

--- a/src/identity/prod/main.tf
+++ b/src/identity/prod/main.tf
@@ -78,7 +78,17 @@ module "federated_identities" {
         "Storage Table Data Contributor",
         "Key Vault Contributor",
       ]
-      resource_groups = {}
+      resource_groups = {
+        io-p-itn-common-rg-01 = [
+          "Role Based Access Control Administrator"
+        ],
+        io-p-rg-internal = [
+          "Role Based Access Control Administrator"
+        ],
+        io-p-rg-linux = [
+          "Role Based Access Control Administrator"
+        ]
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
CD Infra Identity should be able to manage IAM on APIM and AppBackend's resource groups, as role assignments are defined in Terraform configuration

### Major Changes

<!--- Describe the major changes introduced by this PR -->
Add `Role Based Access Control Administrator` in APIM and AppBackend's resource groups to CD Infra Identity

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
