### PR TITLE
[EC-179] Add Terraform configuration to map Storage Accounts with Bonus data backup

### DIFF
--- a/.github/workflows/bonus_cd.yaml
+++ b/.github/workflows/bonus_cd.yaml
@@ -1,0 +1,19 @@
+name: Continuous Delivery on bonus
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/domains/bonus/**"
+
+jobs:
+  release_prod:
+    uses: pagopa/dx/.github/workflows/infra_apply.yaml@main
+    name: Terraform Apply
+    secrets: inherit
+    with:
+      environment: prod
+      base_path: "src/domains/bonus/prod"
+      use_private_agent: false

--- a/.github/workflows/bonus_cd.yaml
+++ b/.github/workflows/bonus_cd.yaml
@@ -15,5 +15,5 @@ jobs:
     secrets: inherit
     with:
       environment: prod
-      base_path: "src/domains/bonus/prod"
+      base_path: "src/domains/bonus"
       use_private_agent: false

--- a/.github/workflows/bonus_ci.yaml
+++ b/.github/workflows/bonus_ci.yaml
@@ -1,0 +1,25 @@
+name: Continuous Integration on bonus
+
+on:
+  merge_group:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - "src/domains/bonus/**"
+      - ".github/workflows/bonus_**"
+
+jobs:
+  code_review_prod:
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
+    name: Terraform Plan
+    secrets: inherit
+    with:
+      environment: prod
+      base_path: "src/domains/bonus/prod"
+      use_private_agent: false

--- a/.github/workflows/bonus_ci.yaml
+++ b/.github/workflows/bonus_ci.yaml
@@ -21,5 +21,5 @@ jobs:
     secrets: inherit
     with:
       environment: prod
-      base_path: "src/domains/bonus/prod"
+      base_path: "src/domains/bonus"
       use_private_agent: false

--- a/src/domains/bonus/prod/.terraform.lock.hcl
+++ b/src/domains/bonus/prod/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.16.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:7e25Wr4cpUvlAcwL+9ZOeeA1xha84LqTZNviDaVQFlo=",
+    "h1:HZdmFPnC/+x6si15pq4rGYv/1TrCcyQXLnDMqq1SONw=",
+    "h1:uIzu9HMGN1ySZ1s+iYCKY9UqsgCjgH05tnBg1DgHtV4=",
+    "h1:uulWiJ93kZmKKh6/EtHktJQ901npRmTb/ao7oTP402w=",
+    "zh:2035e461a94bd4180557a06f8e56f228a8a035608d0dac4d08e5870cf9265276",
+    "zh:3f15778a22ef1b9d0fa28670e5ea6ef1094b0be2533f43f350a2ef15d471b353",
+    "zh:4f1a4d03b008dd958bcd6bf82cf088fbaa9c121be2fd35e10e6b06c6e8f6aaa1",
+    "zh:5859f31c342364e849b4f8c437a46f33e927fa820244d0732b8d2ec74a95712d",
+    "zh:693d0f15512ca8c6b5e999b3a7551503feb06b408b3836bc6a6403e518b9ddab",
+    "zh:7f4912bec5b04f5156935292377c12484c13582151eb3c2555df409a7e5fb6e0",
+    "zh:bb9a509497f3a131c52fac32348919bf1b9e06c69a65f24607b03f7b56fb47b6",
+    "zh:c1b0c64e49ac591fd038ad71e71403ff71c07476e27e8da718c29f0028ea6d0d",
+    "zh:dd4ca432ee14eb0bb0cdc0bb463c8675b8ef02497be870a20d8dfee3e7fe52b3",
+    "zh:df58bb7fea984d2b11709567842ca4d55b3f24e187aa6be99e3677f55cbbe7da",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f7fb37704da50c096f9c7c25e8a95fe73ce1d3c5aab0d616d506f07bc5cfcdd8",
+  ]
+}

--- a/src/domains/bonus/prod/README.md
+++ b/src/domains/bonus/prod/README.md
@@ -1,0 +1,56 @@
+# IO Infra - Bonus
+
+<!-- markdownlint-disable -->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.16.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_resource_group.rg_itn_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_storage_account.bonus_backup_gwc_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
+| [azurerm_storage_account.bonus_backup_itn_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
+| [azurerm_storage_container.bonus_activations_gwc_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.bonus_activations_itn_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.bonus_gwc_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.bonus_itn_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.bonus_leases_gwc_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.bonus_leases_itn_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.bonus_processing_gwc_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.bonus_processing_itn_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.change_feed_leases_gwc_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.change_feed_leases_itn_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.eligibility_checks_gwc_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.eligibility_checks_itn_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.redeemed_requests_gwc_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.redeemed_requests_itn_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.user_bonuses_gwc_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.user_bonuses_itn_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_object_replication.itn_01_to_gwc_01](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_object_replication) | resource |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_storage_account_primary"></a> [storage\_account\_primary](#output\_storage\_account\_primary) | n/a |
+| <a name="output_storage_account_secondary"></a> [storage\_account\_secondary](#output\_storage\_account\_secondary) | n/a |
+<!-- END_TF_DOCS -->

--- a/src/domains/bonus/prod/locals.tf
+++ b/src/domains/bonus/prod/locals.tf
@@ -1,0 +1,20 @@
+locals {
+  prefix                   = "io"
+  env_short                = "p"
+  location                 = "italynorth"
+  location_short           = "itn"
+  secondary_location       = "germanywestcentral"
+  secondary_location_short = "gwc"
+  domain                   = "bonus"
+  project                  = "${local.prefix}-${local.env_short}-${local.location_short}-${local.domain}"
+  secondary_project        = "${local.prefix}-${local.env_short}-${local.secondary_location_short}-${local.domain}"
+
+  tags = {
+    CostCenter     = "TS000 - Tecnologia e Servizi"
+    CreatedBy      = "Terraform"
+    Environment    = "Prod"
+    BusinessUnit   = "App IO"
+    ManagementTeam = "IO Bonus & Pagamenti"
+    Source         = "https://github.com/pagopa/io-infra/blob/main/src/domains/bonus/prod"
+  }
+}

--- a/src/domains/bonus/prod/main.tf
+++ b/src/domains/bonus/prod/main.tf
@@ -1,0 +1,20 @@
+terraform {
+
+  backend "azurerm" {
+    resource_group_name  = "terraform-state-rg"
+    storage_account_name = "iopitntfst001"
+    container_name       = "terraform-state"
+    key                  = "io-infra.bonus.prod.tfstate"
+  }
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/src/domains/bonus/prod/outputs.tf
+++ b/src/domains/bonus/prod/outputs.tf
@@ -1,0 +1,15 @@
+output "storage_account_primary" {
+  value = {
+    id                  = azurerm_storage_account.bonus_backup_itn_01.id
+    name                = azurerm_storage_account.bonus_backup_itn_01.name
+    resource_group_name = azurerm_storage_account.bonus_backup_itn_01.resource_group_name
+  }
+}
+
+output "storage_account_secondary" {
+  value = {
+    id                  = azurerm_storage_account.bonus_backup_gwc_01.id
+    name                = azurerm_storage_account.bonus_backup_gwc_01.name
+    resource_group_name = azurerm_storage_account.bonus_backup_gwc_01.resource_group_name
+  }
+}

--- a/src/domains/bonus/prod/resource_group.tf
+++ b/src/domains/bonus/prod/resource_group.tf
@@ -1,0 +1,6 @@
+resource "azurerm_resource_group" "rg_itn_01" {
+  name     = "${local.project}-rg-01"
+  location = local.location
+
+  tags = local.tags
+}

--- a/src/domains/bonus/prod/storage_account.tf
+++ b/src/domains/bonus/prod/storage_account.tf
@@ -1,0 +1,125 @@
+resource "azurerm_storage_account" "bonus_backup_itn_01" {
+  name                = replace("${local.project}backupst01", "-", "")
+  resource_group_name = azurerm_resource_group.rg_itn_01.name
+  location            = local.location
+
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "ZRS"
+  access_tier              = "Cool"
+
+  public_network_access_enabled = true
+
+  shared_access_key_enabled       = false
+  default_to_oauth_authentication = true
+
+  blob_properties {
+    versioning_enabled       = true
+    change_feed_enabled      = true
+    last_access_time_enabled = true
+
+    delete_retention_policy {
+      days = 7
+    }
+
+    restore_policy {
+      days = 5
+    }
+
+    container_delete_retention_policy {
+      days = 10
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_storage_account" "bonus_backup_gwc_01" {
+  name                = replace("${local.secondary_project}backupst01", "-", "")
+  resource_group_name = azurerm_resource_group.rg_itn_01.name
+  location            = local.secondary_location
+
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "ZRS"
+  access_tier              = "Cool"
+
+  public_network_access_enabled = true
+
+  shared_access_key_enabled       = false
+  default_to_oauth_authentication = true
+
+  blob_properties {
+    versioning_enabled       = true
+    change_feed_enabled      = true
+    last_access_time_enabled = true
+
+    delete_retention_policy {
+      days = 7
+    }
+
+    restore_policy {
+      days = 5
+    }
+
+    container_delete_retention_policy {
+      days = 10
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_storage_object_replication" "itn_01_to_gwc_01" {
+  source_storage_account_id      = azurerm_storage_account.bonus_backup_itn_01.id
+  destination_storage_account_id = azurerm_storage_account.bonus_backup_gwc_01.id
+
+  rules {
+    source_container_name      = azurerm_storage_container.bonus_itn_01.name
+    destination_container_name = azurerm_storage_container.bonus_gwc_01.name
+    copy_blobs_created_after   = "Everything"
+  }
+
+  rules {
+    source_container_name      = azurerm_storage_container.redeemed_requests_itn_01.name
+    destination_container_name = azurerm_storage_container.redeemed_requests_gwc_01.name
+    copy_blobs_created_after   = "Everything"
+  }
+
+
+  rules {
+    source_container_name      = azurerm_storage_container.bonus_activations_itn_01.name
+    destination_container_name = azurerm_storage_container.bonus_activations_gwc_01.name
+    copy_blobs_created_after   = "Everything"
+  }
+
+  rules {
+    source_container_name      = azurerm_storage_container.bonus_leases_itn_01.name
+    destination_container_name = azurerm_storage_container.bonus_leases_gwc_01.name
+    copy_blobs_created_after   = "Everything"
+  }
+
+  rules {
+    source_container_name      = azurerm_storage_container.bonus_processing_itn_01.name
+    destination_container_name = azurerm_storage_container.bonus_processing_gwc_01.name
+    copy_blobs_created_after   = "Everything"
+  }
+
+  rules {
+    source_container_name      = azurerm_storage_container.change_feed_leases_itn_01.name
+    destination_container_name = azurerm_storage_container.change_feed_leases_gwc_01.name
+    copy_blobs_created_after   = "Everything"
+  }
+
+  rules {
+    source_container_name      = azurerm_storage_container.eligibility_checks_itn_01.name
+    destination_container_name = azurerm_storage_container.eligibility_checks_gwc_01.name
+    copy_blobs_created_after   = "Everything"
+  }
+
+  rules {
+    source_container_name      = azurerm_storage_container.user_bonuses_itn_01.name
+    destination_container_name = azurerm_storage_container.user_bonuses_gwc_01.name
+    copy_blobs_created_after   = "Everything"
+  }
+}

--- a/src/domains/bonus/prod/storage_account_containers.tf
+++ b/src/domains/bonus/prod/storage_account_containers.tf
@@ -1,0 +1,96 @@
+resource "azurerm_storage_container" "bonus_itn_01" {
+  name                  = "bonus"
+  storage_account_id    = azurerm_storage_account.bonus_backup_itn_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "bonus_gwc_01" {
+  name                  = "bonus"
+  storage_account_id    = azurerm_storage_account.bonus_backup_gwc_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "redeemed_requests_itn_01" {
+  name                  = "redeemed-requests"
+  storage_account_id    = azurerm_storage_account.bonus_backup_itn_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "redeemed_requests_gwc_01" {
+  name                  = "redeemed-requests"
+  storage_account_id    = azurerm_storage_account.bonus_backup_gwc_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "bonus_activations_itn_01" {
+  name                  = "bonus-activations"
+  storage_account_id    = azurerm_storage_account.bonus_backup_itn_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "bonus_activations_gwc_01" {
+  name                  = "bonus-activations"
+  storage_account_id    = azurerm_storage_account.bonus_backup_gwc_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "bonus_leases_itn_01" {
+  name                  = "bonus-leases"
+  storage_account_id    = azurerm_storage_account.bonus_backup_itn_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "bonus_leases_gwc_01" {
+  name                  = "bonus-leases"
+  storage_account_id    = azurerm_storage_account.bonus_backup_gwc_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "bonus_processing_itn_01" {
+  name                  = "bonus-processing"
+  storage_account_id    = azurerm_storage_account.bonus_backup_itn_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "bonus_processing_gwc_01" {
+  name                  = "bonus-processing"
+  storage_account_id    = azurerm_storage_account.bonus_backup_gwc_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "change_feed_leases_itn_01" {
+  name                  = "change-feed-leases"
+  storage_account_id    = azurerm_storage_account.bonus_backup_itn_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "change_feed_leases_gwc_01" {
+  name                  = "change-feed-leases"
+  storage_account_id    = azurerm_storage_account.bonus_backup_gwc_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "eligibility_checks_itn_01" {
+  name                  = "eligibility-checks"
+  storage_account_id    = azurerm_storage_account.bonus_backup_itn_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "eligibility_checks_gwc_01" {
+  name                  = "eligibility-checks"
+  storage_account_id    = azurerm_storage_account.bonus_backup_gwc_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "user_bonuses_itn_01" {
+  name                  = "user-bonuses"
+  storage_account_id    = azurerm_storage_account.bonus_backup_itn_01.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "user_bonuses_gwc_01" {
+  name                  = "user-bonuses"
+  storage_account_id    = azurerm_storage_account.bonus_backup_gwc_01.id
+  container_access_type = "private"
+}
+


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Bonus production data should be backed up and more expensive resources should be deleted (e.g. Cosmos DB).
This PR adds two storage accounts to keep data backups offline and not available.

A next PR will introduce an legal hold policy to ensure data will be immutable.

### Major Changes

<!--- Describe the major changes introduced by this PR -->
A Storage Account in Italy North with ZRS
A Storage Account in Germany West Central with ZRS

Both uses `cool` which eventually will become `archive`

Workflows for deployment

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
