### PR TITLE
[#IOPID-2617] Enable diagnostic settings for CDN Frontdoor

### DIFF
--- a/src/domains/ioweb-common/06_cdn_itn.tf
+++ b/src/domains/ioweb-common/06_cdn_itn.tf
@@ -224,3 +224,21 @@ resource "azurerm_dns_txt_record" "dns_txt" {
   })
 }
 ####################
+
+#####################
+# CDN LOGS
+#####################
+
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_settings_cdn_frontdoor" {
+  name                       = "${azurerm_cdn_frontdoor_profile.portal_profile.name}-cdn-profile-diagnostic-settings"
+  target_resource_id         = azurerm_cdn_frontdoor_profile.portal_profile.id
+  log_analytics_workspace_id = data.azurerm_log_analytics_workspace.log_analytics.id
+
+  enabled_log {
+    category_group = "allLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+  }
+}

--- a/src/domains/ioweb-common/README.md
+++ b/src/domains/ioweb-common/README.md
@@ -63,6 +63,7 @@
 | [azurerm_key_vault_secret.appinsights_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appinsights_instrumentation_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.spid_login_jwt_pub_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_monitor_diagnostic_setting.diagnostic_settings_cdn_frontdoor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_private_endpoint.immutable_spid_logs_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.common_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.fe_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Enable `account.ioapp.it` CDN logs 

### Major Changes

<!--- Describe the major changes introduced by this PR -->

- Add `azurerm_monitor_diagnostic_setting` resource for CDN profile

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->
no

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->
tf plan

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
