### PR TITLE
[CES-709] Move TF state file of Core config to another Storage Account

### DIFF
--- a/.github/workflows/core_code_review.yaml
+++ b/.github/workflows/core_code_review.yaml
@@ -27,3 +27,4 @@ jobs:
     with:
       environment: prod
       base_path: src/core
+      use_private_agent: true

--- a/.github/workflows/core_deploy.yaml
+++ b/.github/workflows/core_deploy.yaml
@@ -23,3 +23,4 @@ jobs:
     with:
       environment: prod
       base_path: src/core
+      use_private_agent: true

--- a/src/core/prod/main.tf
+++ b/src/core/prod/main.tf
@@ -2,9 +2,10 @@ terraform {
 
   backend "azurerm" {
     resource_group_name  = "terraform-state-rg"
-    storage_account_name = "iopitntfst001"
+    storage_account_name = "iopitntfst02"
     container_name       = "terraform-state"
-    key                  = "io-infra.core.prod.italynorth.tfstate"
+    key                  = "io-infra.core.prod.tfstate"
+    use_azuread_auth     = true
   }
 
   required_providers {


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The Terraform state of io-infra core must be hosted on a different Storage Account, for the following reasons:
- domain teams must not have access
- this state, contains the definition of the storage account containing the TF states used by domain teams

### Major Changes

<!--- Describe the major changes introduced by this PR -->
Move TF state file of Core config to another Storage Account

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
