### PR TITLE
[CES-708] Import existing storage account with TF state files and assign roles

### DIFF
--- a/src/core/_modules/storage_accounts/iam.tf
+++ b/src/core/_modules/storage_accounts/iam.tf
@@ -1,0 +1,89 @@
+module "iam_adgroup_admins" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~> 0"
+
+  principal_id = var.azure_adgroup_admin_object_id
+
+  storage_blob = [
+    {
+      storage_account_name = azurerm_storage_account.terraform.name
+      resource_group_name  = azurerm_storage_account.terraform.resource_group_name
+      role                 = "owner"
+    }
+  ]
+}
+
+module "iam_adgroup_wallet_admins" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~> 0"
+
+  principal_id = var.azure_adgroup_wallet_admins_object_id
+
+  storage_blob = [
+    {
+      storage_account_name = azurerm_storage_account.terraform.name
+      resource_group_name  = azurerm_storage_account.terraform.resource_group_name
+      role                 = "writer"
+    }
+  ]
+}
+
+module "iam_adgroup_com_admins" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~> 0"
+
+  principal_id = var.azure_adgroup_com_admins_object_id
+
+  storage_blob = [
+    {
+      storage_account_name = azurerm_storage_account.terraform.name
+      resource_group_name  = azurerm_storage_account.terraform.resource_group_name
+      role                 = "writer"
+    }
+  ]
+}
+
+module "iam_adgroup_svc_admins" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~> 0"
+
+  principal_id = var.azure_adgroup_svc_admins_object_id
+
+  storage_blob = [
+    {
+      storage_account_name = azurerm_storage_account.terraform.name
+      resource_group_name  = azurerm_storage_account.terraform.resource_group_name
+      role                 = "writer"
+    }
+  ]
+}
+
+module "iam_adgroup_auth_admins" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~> 0"
+
+  principal_id = var.azure_adgroup_auth_admins_object_id
+
+  storage_blob = [
+    {
+      storage_account_name = azurerm_storage_account.terraform.name
+      resource_group_name  = azurerm_storage_account.terraform.resource_group_name
+      role                 = "writer"
+    }
+  ]
+}
+
+module "iam_adgroup_bonus_admins" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~> 0"
+
+  principal_id = var.azure_adgroup_bonus_admins_object_id
+
+  storage_blob = [
+    {
+      storage_account_name = azurerm_storage_account.terraform.name
+      resource_group_name  = azurerm_storage_account.terraform.resource_group_name
+      role                 = "writer"
+    }
+  ]
+}

--- a/src/core/_modules/storage_accounts/terraform_states.tf
+++ b/src/core/_modules/storage_accounts/terraform_states.tf
@@ -1,0 +1,15 @@
+resource "azurerm_storage_account" "terraform" {
+  name                = replace("${var.project}tfst001", "-", "")
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  account_tier             = "Standard"
+  access_tier              = "Hot"
+  account_kind             = "StorageV2"
+  account_replication_type = "ZRS"
+
+  allow_nested_items_to_be_public  = false
+  cross_tenant_replication_enabled = false
+
+  tags = var.tags
+}

--- a/src/core/_modules/storage_accounts/variables.tf
+++ b/src/core/_modules/storage_accounts/variables.tf
@@ -1,0 +1,49 @@
+variable "project" {
+  type        = string
+  description = "IO prefix, short environment and short location"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group where create resources"
+}
+
+variable "tags" {
+  type        = map(any)
+  description = "Resource tags"
+}
+
+variable "azure_adgroup_admin_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_wallet_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_com_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_svc_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_auth_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}
+
+variable "azure_adgroup_bonus_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for subscription admins"
+}

--- a/src/core/prod/README.md
+++ b/src/core/prod/README.md
@@ -23,6 +23,7 @@
 | <a name="module_key_vault_weu"></a> [key\_vault\_weu](#module\_key\_vault\_weu) | ../_modules/key_vaults | n/a |
 | <a name="module_networking_itn"></a> [networking\_itn](#module\_networking\_itn) | ../_modules/networking | n/a |
 | <a name="module_networking_weu"></a> [networking\_weu](#module\_networking\_weu) | ../_modules/networking | n/a |
+| <a name="module_storage_accounts_itn"></a> [storage\_accounts\_itn](#module\_storage\_accounts\_itn) | ../_modules/storage_accounts | n/a |
 | <a name="module_vnet_peering_itn"></a> [vnet\_peering\_itn](#module\_vnet\_peering\_itn) | ../_modules/vnet_peering | n/a |
 | <a name="module_vnet_peering_weu"></a> [vnet\_peering\_weu](#module\_vnet\_peering\_weu) | ../_modules/vnet_peering | n/a |
 | <a name="module_vpn_weu"></a> [vpn\_weu](#module\_vpn\_weu) | ../_modules/vpn | n/a |
@@ -43,6 +44,7 @@
 | [azurerm_resource_group.linux_weu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.role_assignment_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.sec_weu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.terraform_weu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azuread_group.admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.auth_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.auth_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |

--- a/src/core/prod/italynorth.tf
+++ b/src/core/prod/italynorth.tf
@@ -50,3 +50,20 @@ module "custom_roles" {
 
   subscription_id = data.azurerm_subscription.current.id
 }
+
+module "storage_accounts_itn" {
+  source = "../_modules/storage_accounts"
+
+  project             = local.project_itn
+  location            = "italynorth"
+  resource_group_name = azurerm_resource_group.terraform_weu.name
+
+  azure_adgroup_admin_object_id         = data.azuread_group.admin.object_id
+  azure_adgroup_wallet_admins_object_id = data.azuread_group.wallet_admins.object_id
+  azure_adgroup_com_admins_object_id    = data.azuread_group.com_admins.object_id
+  azure_adgroup_svc_admins_object_id    = data.azuread_group.svc_admins.object_id
+  azure_adgroup_auth_admins_object_id   = data.azuread_group.auth_admins.object_id
+  azure_adgroup_bonus_admins_object_id  = data.azuread_group.bonus_admins.object_id
+
+  tags = local.tags
+}

--- a/src/core/prod/resource_groups.tf
+++ b/src/core/prod/resource_groups.tf
@@ -34,6 +34,13 @@ resource "azurerm_resource_group" "github_managed_identity_itn" {
   tags = local.tags
 }
 
+resource "azurerm_resource_group" "terraform_weu" {
+  name     = "terraform-state-rg"
+  location = "westeurope"
+
+  tags = local.tags
+}
+
 resource "azurerm_resource_group" "internal_weu" {
   name     = format("%s-rg-internal", local.project_weu_legacy)
   location = "westeurope"


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Domain monorepositories are converging in the use of a single Storage Account, `iopitntfst001`. Therefore, it is necessary to define this Storage Account via Terraform, and assign the necessary permissions to the AD groups to be able to operate on it.

### Major Changes

<!--- Describe the major changes introduced by this PR -->
Import `iopitntfst001` and define roles over it

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->

I'll import the resource into state after the approval to minimise disruptive changes
