### PR TITLE
[CES-708] Add Role Based Access Control Administrator role to CD identity with entire subscription as scope

### DIFF
--- a/src/identity/prod/README.md
+++ b/src/identity/prod/README.md
@@ -26,10 +26,10 @@
 | Name | Type |
 |------|------|
 | [azurerm_role_assignment.cd_cgn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.cd_cgn_postgresql](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cd_cgn_iac_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.cd_selc_evhns](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.ci_cgn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_postgresql_server.cgn_psql](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/postgresql_server) | data source |
+| [azurerm_role_assignment.ci_cgn_iac_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_subscription.cgn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs

--- a/src/identity/prod/main.tf
+++ b/src/identity/prod/main.tf
@@ -77,17 +77,9 @@ module "federated_identities" {
         "Storage Queue Data Contributor",
         "Storage Table Data Contributor",
         "Key Vault Contributor",
+        "Role Based Access Control Administrator",
       ]
       resource_groups = {
-        io-p-itn-common-rg-01 = [
-          "Role Based Access Control Administrator"
-        ],
-        io-p-rg-internal = [
-          "Role Based Access Control Administrator"
-        ],
-        io-p-rg-linux = [
-          "Role Based Access Control Administrator"
-        ]
       }
     }
   }


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Terraform sets role to different resource groups. Identity should not depends on other TF configs

### Major Changes

<!--- Describe the major changes introduced by this PR -->
Add Role Based Access Control Administrator role to CD identity with entire subscription as scope

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
