### PR TITLE
[#IOPLT-932] Update node version v20 `io-backend`

### DIFF
--- a/src/common/_modules/app_backend/main.tf
+++ b/src/common/_modules/app_backend/main.tf
@@ -11,7 +11,7 @@ module "appservice_app_backend" {
   resource_group_name = var.resource_group_linux
   location            = var.location
 
-  node_version                 = "18-lts"
+  node_version                 = "20-lts"
   always_on                    = true
   app_command_line             = local.app_command_line
   health_check_path            = "/ping"
@@ -55,7 +55,7 @@ module "appservice_app_backend_slot_staging" {
   location            = var.location
 
   always_on         = true
-  node_version      = "18-lts"
+  node_version      = "20-lts"
   app_command_line  = local.app_command_line
   health_check_path = "/ping"
 


### PR DESCRIPTION
### Motivation and Context
Support for Node v18 is deprecated by Azure, we need update node v20 to `io-backend`
<!--- Why is this change required? What problem does it solve? -->

### Major Changes
Update node version to v20 to App Service for `io-backend`
<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing
Testing into the slot with canary traffic
<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
