### PR TITLE
Devs need write permissions to create leases on terraform blob storage

### DIFF
--- a/src/core/_modules/storage_accounts/iam.tf
+++ b/src/core/_modules/storage_accounts/iam.tf
@@ -38,7 +38,7 @@ module "iam_adgroup_wallet_devs" {
     {
       storage_account_name = azurerm_storage_account.terraform.name
       resource_group_name  = azurerm_storage_account.terraform.resource_group_name
-      role                 = "reader"
+      role                 = "writer"
     }
   ]
 }
@@ -68,7 +68,7 @@ module "iam_adgroup_com_devs" {
     {
       storage_account_name = azurerm_storage_account.terraform.name
       resource_group_name  = azurerm_storage_account.terraform.resource_group_name
-      role                 = "reader"
+      role                 = "writer"
     }
   ]
 }
@@ -98,7 +98,7 @@ module "iam_adgroup_svc_devs" {
     {
       storage_account_name = azurerm_storage_account.terraform.name
       resource_group_name  = azurerm_storage_account.terraform.resource_group_name
-      role                 = "reader"
+      role                 = "writer"
     }
   ]
 }
@@ -128,7 +128,7 @@ module "iam_adgroup_auth_devs" {
     {
       storage_account_name = azurerm_storage_account.terraform.name
       resource_group_name  = azurerm_storage_account.terraform.resource_group_name
-      role                 = "reader"
+      role                 = "writer"
     }
   ]
 }
@@ -158,7 +158,7 @@ module "iam_adgroup_bonus_devs" {
     {
       storage_account_name = azurerm_storage_account.terraform.name
       resource_group_name  = azurerm_storage_account.terraform.resource_group_name
-      role                 = "reader"
+      role                 = "writer"
     }
   ]
 }


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Developers currently have the "readers" role on the blob storage containing terraform states. This role does not allow the creation of leases.
Terraform uses leases to lock the state while performing operations.
### Major Changes

<!--- Describe the major changes introduced by this PR -->
Developers groups now have writer permissions on the blob storage containing terraform states

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
