### PR TITLE
[CES-586] Replace old identities with new ones in auth domain

### DIFF
--- a/src/domains/citizen-auth-app/01_network.tf
+++ b/src/domains/citizen-auth-app/01_network.tf
@@ -139,7 +139,7 @@ module "session_manager_snet" {
 resource "azurerm_private_endpoint" "session_manager_sites" {
   name                = "${local.common_project}-session-manager-app-pep-01"
   location            = var.location
-  resource_group_name = azurerm_resource_group.session_manager_rg_weu.name
+  resource_group_name = data.azurerm_resource_group.session_manager_rg_weu.name
   subnet_id           = data.azurerm_subnet.private_endpoints_subnet.id
 
   private_service_connection {
@@ -160,7 +160,7 @@ resource "azurerm_private_endpoint" "session_manager_sites" {
 resource "azurerm_private_endpoint" "staging_session_manager_sites" {
   name                = "${local.common_project}-session-manager-staging-app-pep-01"
   location            = var.location
-  resource_group_name = azurerm_resource_group.session_manager_rg_weu.name
+  resource_group_name = data.azurerm_resource_group.session_manager_rg_weu.name
   subnet_id           = data.azurerm_subnet.private_endpoints_subnet.id
 
   private_service_connection {

--- a/src/domains/citizen-auth-app/01_network_itn.tf
+++ b/src/domains/citizen-auth-app/01_network_itn.tf
@@ -48,7 +48,7 @@ resource "azurerm_private_endpoint" "function_profile_itn_sites" {
   count               = var.function_profile_count
   name                = format("%s-profile-pep-0%d", local.common_project_itn, count.index + 1)
   location            = local.itn_location
-  resource_group_name = azurerm_resource_group.function_profile_rg[count.index].name
+  resource_group_name = data.azurerm_resource_group.function_profile_rg[count.index].name
   subnet_id           = data.azurerm_subnet.itn_pep.id
 
   private_service_connection {
@@ -70,7 +70,7 @@ resource "azurerm_private_endpoint" "staging_function_profile_itn_sites" {
   count               = var.function_profile_count
   name                = format("%s-profile-staging-pep-0%d", local.common_project_itn, count.index + 1)
   location            = local.itn_location
-  resource_group_name = azurerm_resource_group.function_profile_rg[count.index].name
+  resource_group_name = data.azurerm_resource_group.function_profile_rg[count.index].name
   subnet_id           = data.azurerm_subnet.itn_pep.id
 
   private_service_connection {

--- a/src/domains/citizen-auth-app/08_session_manager.tf
+++ b/src/domains/citizen-auth-app/08_session_manager.tf
@@ -83,11 +83,15 @@ data "azurerm_linux_function_app" "itn_auth_lv_func" {
 
 ###########
 
-resource "azurerm_resource_group" "session_manager_rg_weu" {
-  name     = format("%s-session-manager-rg-01", local.common_project)
-  location = var.location
+removed {
+  from = azurerm_resource_group.session_manager_rg_weu
+  lifecycle {
+    destroy = false
+  }
+}
 
-  tags = var.tags
+data "azurerm_resource_group" "session_manager_rg_weu" {
+  name = format("%s-session-manager-rg-01", local.common_project)
 }
 
 locals {
@@ -238,7 +242,7 @@ module "session_manager_weu" {
 
   # App service
   name                = "${local.app_name_weu}-03"
-  resource_group_name = azurerm_resource_group.session_manager_rg_weu.name
+  resource_group_name = data.azurerm_resource_group.session_manager_rg_weu.name
   location            = var.location
 
   always_on    = true
@@ -291,7 +295,7 @@ module "session_manager_weu_staging" {
   app_service_name = module.session_manager_weu.name
 
   name                = "staging"
-  resource_group_name = azurerm_resource_group.session_manager_rg_weu.name
+  resource_group_name = data.azurerm_resource_group.session_manager_rg_weu.name
   location            = var.location
 
   always_on    = true

--- a/src/domains/citizen-auth-app/README.md
+++ b/src/domains/citizen-auth-app/README.md
@@ -44,8 +44,6 @@
 | [azurerm_private_endpoint.session_manager_sites](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.staging_function_profile_itn_sites](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.staging_session_manager_sites](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
-| [azurerm_resource_group.function_profile_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.session_manager_rg_weu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_table.locked_profiles](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
 | [azurerm_subnet_nat_gateway_association.session_manager_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_nat_gateway_association) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
@@ -107,11 +105,13 @@
 | [azurerm_resource_group.core_domain_common_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.data_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.data_rg_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.function_profile_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.italy_north_common_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.monitor_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.rg_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.rg_external](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.rg_internal](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.session_manager_rg_weu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account.assets_cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.citizen_auth_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.iopstapp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |

--- a/src/domains/citizen-auth-common/02_key_vault.tf
+++ b/src/domains/citizen-auth-common/02_key_vault.tf
@@ -1,16 +1,20 @@
-resource "azurerm_resource_group" "sec_rg" {
-  name     = "${local.product}-${var.domain}-sec-rg"
-  location = var.location
+removed {
+  from = azurerm_resource_group.sec_rg
+  lifecycle {
+    destroy = false
+  }
+}
 
-  tags = var.tags
+data "azurerm_resource_group" "sec_rg" {
+  name = "${local.product}-${var.domain}-sec-rg"
 }
 
 module "key_vault" {
   source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault?ref=v8.44.1"
 
   name                       = "${local.product}-${var.domain}-kv"
-  location                   = azurerm_resource_group.sec_rg.location
-  resource_group_name        = azurerm_resource_group.sec_rg.name
+  location                   = data.azurerm_resource_group.sec_rg.location
+  resource_group_name        = data.azurerm_resource_group.sec_rg.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "premium"
   soft_delete_retention_days = 90

--- a/src/domains/citizen-auth-common/06_data.tf
+++ b/src/domains/citizen-auth-common/06_data.tf
@@ -13,13 +13,13 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_auth_n_identity_infra_ci" {
-  name                = "${local.product}-auth-github-ci-identity"
-  resource_group_name = "${local.product}-identity-rg"
+  name                = "${local.product}-itn-auth-infra-github-ci-id-01"
+  resource_group_name = "${local.product}-itn-auth-rg-01"
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_auth_n_identity_infra_cd" {
-  name                = "${local.product}-auth-github-cd-identity"
-  resource_group_name = "${local.product}-identity-rg"
+  name                = "${local.product}-itn-auth-infra-github-cd-id-01"
+  resource_group_name = "${local.product}-itn-auth-rg-01"
 }
 
 

--- a/src/domains/citizen-auth-common/README.md
+++ b/src/domains/citizen-auth-common/README.md
@@ -80,7 +80,6 @@
 | [azurerm_private_endpoint.table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.data_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.data_rg_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_container.data_factory_exports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.immutable_lv_audit_logs_storage_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.lollipop_assertions_storage_assertions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
@@ -117,6 +116,7 @@
 | [azurerm_private_dns_zone.privatelink_table_core](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_resource_group.lollipop_function_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.monitor_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subnet.azdoa_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.private_endpoints_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.private_endpoints_subnet_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |

--- a/src/domains/ioweb-common/07_data.tf
+++ b/src/domains/ioweb-common/07_data.tf
@@ -13,13 +13,13 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_auth_n_identity_infra_ci" {
-  name                = "${local.product}-auth-github-ci-identity"
-  resource_group_name = "${local.product}-identity-rg"
+  name                = "${local.product}-itn-auth-infra-github-ci-id-01"
+  resource_group_name = "${local.product}-itn-auth-rg-01"
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_auth_n_identity_infra_cd" {
-  name                = "${local.product}-auth-github-cd-identity"
-  resource_group_name = "${local.product}-identity-rg"
+  name                = "${local.product}-itn-auth-infra-github-cd-id-01"
+  resource_group_name = "${local.product}-itn-auth-rg-01"
 }
 
 ########


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
New identities with new roles and resource groups have been created in IO Autenticazione mono repositories

### Major Changes

<!--- Describe the major changes introduced by this PR -->
Replace access policies' targets
Remove resource groups from tf state as they've been moved to mono repositories

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->
Depends on [#192](https://github.com/pagopa/io-auth-n-identity-domain/pull/192)
Depends on [#202](https://github.com/pagopa/io-web-profile/pull/202)

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
