### PR TITLE
[#IOPLT-945] AI instrumentation key deprecation on appbackend

### DIFF
--- a/src/common/_modules/app_backend/app_settings.tf
+++ b/src/common/_modules/app_backend/app_settings.tf
@@ -7,6 +7,8 @@ locals {
     WEBSITE_DNS_SERVER                              = "168.63.129.16"
 
     APPINSIGHTS_INSTRUMENTATIONKEY = var.ai_instrumentation_key
+    APPINSIGHTS_CONNECTION_STRING  = var.ai_connection_string
+    APPINSIGHTS_CLOUD_ROLE_NAME    = local.nonstandard.weu.app
 
     // ENVIRONMENT
     NODE_ENV = "production"

--- a/src/common/_modules/app_backend/main.tf
+++ b/src/common/_modules/app_backend/main.tf
@@ -30,6 +30,8 @@ module "appservice_app_backend" {
     var.app_settings_override
   )
 
+  sticky_settings = concat(["APPINSIGHTS_CLOUD_ROLE_NAME", "APPINSIGHTS_SAMPLING_PERCENTAGE"])
+
   ip_restriction_default_action = "Deny"
 
   allowed_subnets = var.allowed_subnets
@@ -69,7 +71,11 @@ module "appservice_app_backend_slot_staging" {
 
   app_settings = merge(
     local.app_settings_common,
-    var.app_settings_override
+    var.app_settings_override,
+    {
+      "APPINSIGHTS_SAMPLING_PERCENTAGE" : 100,
+      "APPINSIGHTS_CLOUD_ROLE_NAME" : "${local.nonstandard.weu.app}-staging"
+    }
   )
 
   ip_restriction_default_action = "Deny"

--- a/src/common/_modules/app_backend/variables.tf
+++ b/src/common/_modules/app_backend/variables.tf
@@ -112,6 +112,10 @@ variable "ai_instrumentation_key" {
   type = string
 }
 
+variable "ai_connection_string" {
+  type = string
+}
+
 variable "error_action_group_id" {
   type        = string
   description = "Azure Monitor error action group id"

--- a/src/common/_modules/monitoring/outputs.tf
+++ b/src/common/_modules/monitoring/outputs.tf
@@ -22,6 +22,11 @@ output "appi_instrumentation_key" {
   sensitive = true
 }
 
+output "appi_connection_string" {
+  value     = azurerm_application_insights.appi.connection_string
+  sensitive = true
+}
+
 output "log" {
   value = {
     id                  = azurerm_log_analytics_workspace.log.id

--- a/src/common/prod/westeurope.tf
+++ b/src/common/prod/westeurope.tf
@@ -467,6 +467,7 @@ module "app_backend_weu" {
   error_action_group_id  = module.monitoring_weu.action_groups.error
   application_insights   = module.monitoring_weu.appi
   ai_instrumentation_key = module.monitoring_weu.appi_instrumentation_key
+  ai_connection_string   = module.monitoring_weu.appi_connection_string
 
   redis_common = {
     hostname           = module.redis_weu.hostname
@@ -533,6 +534,7 @@ module "app_backend_li_weu" {
   error_action_group_id  = module.monitoring_weu.action_groups.error
   application_insights   = module.monitoring_weu.appi
   ai_instrumentation_key = module.monitoring_weu.appi_instrumentation_key
+  ai_connection_string   = module.monitoring_weu.appi_connection_string
 
   redis_common = {
     hostname           = module.redis_weu.hostname


### PR DESCRIPTION
### Motivation and Context
The AI instrumentation kay will be depracated by Azure, connections string is now required
<!--- Why is this change required? What problem does it solve? -->

### Major Changes

<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
