### PR TITLE
[CES-729] Allow teams to operate on io-p-cosmos-api database

### DIFF
--- a/src/common/_modules/cosmos_api/iam.tf
+++ b/src/common/_modules/cosmos_api/iam.tf
@@ -44,7 +44,7 @@ module "cosno_api_com_admins" {
     {
       account_name        = azurerm_cosmosdb_account.this.name
       resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
-      database            = azurerm_cosmosdb_sql_database.db.id
+      database            = azurerm_cosmosdb_sql_database.db.name
       role                = "reader"
     }
   ]
@@ -54,13 +54,13 @@ module "cosno_api_com_devs" {
   source  = "pagopa/dx-azure-role-assignments/azurerm"
   version = "~>0"
 
-  principal_id          = var.azure_adgroup_com_devs_object_id
+  principal_id = var.azure_adgroup_com_devs_object_id
 
   cosmos = [
     {
       account_name        = azurerm_cosmosdb_account.this.name
       resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
-      database            = azurerm_cosmosdb_sql_database.db.id
+      database            = azurerm_cosmosdb_sql_database.db.name
       role                = "reader"
     }
   ]
@@ -69,13 +69,13 @@ module "cosno_api_svc_admins" {
   source  = "pagopa/dx-azure-role-assignments/azurerm"
   version = "~>0"
 
-  principal_id          = var.azure_adgroup_svc_admins_object_id
+  principal_id = var.azure_adgroup_svc_admins_object_id
 
   cosmos = [
     {
       account_name        = azurerm_cosmosdb_account.this.name
       resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
-      database            = azurerm_cosmosdb_sql_database.db.id
+      database            = azurerm_cosmosdb_sql_database.db.name
       role                = "reader"
     }
   ]
@@ -84,13 +84,13 @@ module "cosno_api_svc_devs" {
   source  = "pagopa/dx-azure-role-assignments/azurerm"
   version = "~>0"
 
-  principal_id          = var.azure_adgroup_svc_devs_object_id
+  principal_id = var.azure_adgroup_svc_devs_object_id
 
   cosmos = [
     {
       account_name        = azurerm_cosmosdb_account.this.name
       resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
-      database            = azurerm_cosmosdb_sql_database.db.id
+      database            = azurerm_cosmosdb_sql_database.db.name
       role                = "reader"
     }
   ]
@@ -99,13 +99,13 @@ module "cosno_api_auth_admins" {
   source  = "pagopa/dx-azure-role-assignments/azurerm"
   version = "~>0"
 
-  principal_id          = var.azure_adgroup_auth_admins_object_id
+  principal_id = var.azure_adgroup_auth_admins_object_id
 
   cosmos = [
     {
       account_name        = azurerm_cosmosdb_account.this.name
       resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
-      database            = azurerm_cosmosdb_sql_database.db.id
+      database            = azurerm_cosmosdb_sql_database.db.name
       role                = "reader"
     }
   ]
@@ -114,13 +114,13 @@ module "cosno_api_auth_devs" {
   source  = "pagopa/dx-azure-role-assignments/azurerm"
   version = "~>0"
 
-  principal_id          = var.azure_adgroup_auth_devs_object_id
+  principal_id = var.azure_adgroup_auth_devs_object_id
 
   cosmos = [
     {
       account_name        = azurerm_cosmosdb_account.this.name
       resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
-      database            = azurerm_cosmosdb_sql_database.db.id
+      database            = azurerm_cosmosdb_sql_database.db.name
       role                = "reader"
     }
   ]

--- a/src/common/_modules/cosmos_api/iam.tf
+++ b/src/common/_modules/cosmos_api/iam.tf
@@ -49,3 +49,79 @@ module "cosno_api_com_admins" {
     }
   ]
 }
+
+module "cosno_api_com_devs" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~>0"
+
+  principal_id          = var.azure_adgroup_com_devs_object_id
+
+  cosmos = [
+    {
+      account_name        = azurerm_cosmosdb_account.this.name
+      resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
+      database            = azurerm_cosmosdb_sql_database.db.id
+      role                = "reader"
+    }
+  ]
+}
+module "cosno_api_svc_admins" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~>0"
+
+  principal_id          = var.azure_adgroup_svc_admins_object_id
+
+  cosmos = [
+    {
+      account_name        = azurerm_cosmosdb_account.this.name
+      resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
+      database            = azurerm_cosmosdb_sql_database.db.id
+      role                = "reader"
+    }
+  ]
+}
+module "cosno_api_svc_devs" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~>0"
+
+  principal_id          = var.azure_adgroup_svc_devs_object_id
+
+  cosmos = [
+    {
+      account_name        = azurerm_cosmosdb_account.this.name
+      resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
+      database            = azurerm_cosmosdb_sql_database.db.id
+      role                = "reader"
+    }
+  ]
+}
+module "cosno_api_auth_admins" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~>0"
+
+  principal_id          = var.azure_adgroup_auth_admins_object_id
+
+  cosmos = [
+    {
+      account_name        = azurerm_cosmosdb_account.this.name
+      resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
+      database            = azurerm_cosmosdb_sql_database.db.id
+      role                = "reader"
+    }
+  ]
+}
+module "cosno_api_auth_devs" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~>0"
+
+  principal_id          = var.azure_adgroup_auth_devs_object_id
+
+  cosmos = [
+    {
+      account_name        = azurerm_cosmosdb_account.this.name
+      resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
+      database            = azurerm_cosmosdb_sql_database.db.id
+      role                = "reader"
+    }
+  ]
+}

--- a/src/common/_modules/cosmos_api/iam.tf
+++ b/src/common/_modules/cosmos_api/iam.tf
@@ -1,0 +1,51 @@
+resource "azurerm_role_assignment" "cosno_api_com_admins" {
+  scope                = azurerm_cosmosdb_account.this.id
+  principal_id         = var.azure_adgroup_com_admins_object_id
+  role_definition_name = "DocumentDB Account Contributor"
+}
+
+resource "azurerm_role_assignment" "cosno_api_com_devs" {
+  scope                = azurerm_cosmosdb_account.this.id
+  principal_id         = var.azure_adgroup_com_devs_object_id
+  role_definition_name = "DocumentDB Account Contributor"
+}
+
+resource "azurerm_role_assignment" "cosno_api_svc_admins" {
+  scope                = azurerm_cosmosdb_account.this.id
+  principal_id         = var.azure_adgroup_svc_admins_object_id
+  role_definition_name = "DocumentDB Account Contributor"
+}
+
+resource "azurerm_role_assignment" "cosno_api_svc_devs" {
+  scope                = azurerm_cosmosdb_account.this.id
+  principal_id         = var.azure_adgroup_svc_devs_object_id
+  role_definition_name = "DocumentDB Account Contributor"
+}
+
+resource "azurerm_role_assignment" "cosno_api_auth_admins" {
+  scope                = azurerm_cosmosdb_account.this.id
+  principal_id         = var.azure_adgroup_auth_admins_object_id
+  role_definition_name = "DocumentDB Account Contributor"
+}
+
+resource "azurerm_role_assignment" "cosno_api_auth_devs" {
+  scope                = azurerm_cosmosdb_account.this.id
+  principal_id         = var.azure_adgroup_auth_devs_object_id
+  role_definition_name = "DocumentDB Account Contributor"
+}
+
+module "cosno_api_com_admins" {
+  source  = "pagopa/dx-azure-role-assignments/azurerm"
+  version = "~>0"
+
+  principal_id = var.azure_adgroup_com_admins_object_id
+
+  cosmos = [
+    {
+      account_name        = azurerm_cosmosdb_account.this.name
+      resource_group_name = azurerm_cosmosdb_account.this.resource_group_name
+      database            = azurerm_cosmosdb_sql_database.db.id
+      role                = "reader"
+    }
+  ]
+}

--- a/src/common/_modules/cosmos_api/variables.tf
+++ b/src/common/_modules/cosmos_api/variables.tf
@@ -71,3 +71,34 @@ variable "error_action_group_id" {
   type        = string
   description = "Azure Monitor error action group id"
 }
+
+variable "azure_adgroup_com_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for IO COM admins"
+}
+
+
+variable "azure_adgroup_com_devs_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for IO COM devs"
+}
+
+variable "azure_adgroup_svc_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for IO SVC admins"
+}
+
+variable "azure_adgroup_svc_devs_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for IO SVC devs"
+}
+
+variable "azure_adgroup_auth_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for IO AUTH admins"
+}
+
+variable "azure_adgroup_auth_devs_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for IO AUTH devs"
+}

--- a/src/common/prod/README.md
+++ b/src/common/prod/README.md
@@ -41,10 +41,12 @@
 | [azurerm_role_assignment.apim_client_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.dev_portal_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azuread_group.auth_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.auth_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.bonus_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.com_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.com_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.svc_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.svc_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.wallet_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_service_principal.apim_client_svc](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
 | [azuread_service_principal.dev_portal_svc](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |

--- a/src/common/prod/data.tf
+++ b/src/common/prod/data.tf
@@ -39,8 +39,16 @@ data "azuread_group" "svc_admins" {
   display_name = "${local.prefix}-${local.env_short}-adgroup-svc-admins"
 }
 
+data "azuread_group" "svc_devs" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-svc-developers"
+}
+
 data "azuread_group" "auth_admins" {
   display_name = "${local.prefix}-${local.env_short}-adgroup-auth-admins"
+}
+
+data "azuread_group" "auth_devs" {
+  display_name = "${local.prefix}-${local.env_short}-adgroup-auth-developers"
 }
 
 data "azuread_group" "bonus_admins" {

--- a/src/common/prod/tfmodules.lock.json
+++ b/src/common/prod/tfmodules.lock.json
@@ -12,5 +12,11 @@
   "apim_weu.iam_adgroup_wallet_admins": "70538ac55deebe95f1379ec5abe1f3dd207b468c18f69cdb1bc3e6a946e50b56",
   "apim_weu.iam_cgn_pe_backend_app_01": "70538ac55deebe95f1379ec5abe1f3dd207b468c18f69cdb1bc3e6a946e50b56",
   "storage_accounts.exportdata_weu_01_com_admins": "70538ac55deebe95f1379ec5abe1f3dd207b468c18f69cdb1bc3e6a946e50b56",
-  "storage_accounts.exportdata_weu_01_com_devs": "70538ac55deebe95f1379ec5abe1f3dd207b468c18f69cdb1bc3e6a946e50b56"
+  "storage_accounts.exportdata_weu_01_com_devs": "70538ac55deebe95f1379ec5abe1f3dd207b468c18f69cdb1bc3e6a946e50b56",
+  "cosmos_api_weu.cosno_api_auth_admins": "70538ac55deebe95f1379ec5abe1f3dd207b468c18f69cdb1bc3e6a946e50b56",
+  "cosmos_api_weu.cosno_api_auth_devs": "70538ac55deebe95f1379ec5abe1f3dd207b468c18f69cdb1bc3e6a946e50b56",
+  "cosmos_api_weu.cosno_api_com_admins": "70538ac55deebe95f1379ec5abe1f3dd207b468c18f69cdb1bc3e6a946e50b56",
+  "cosmos_api_weu.cosno_api_com_devs": "70538ac55deebe95f1379ec5abe1f3dd207b468c18f69cdb1bc3e6a946e50b56",
+  "cosmos_api_weu.cosno_api_svc_admins": "70538ac55deebe95f1379ec5abe1f3dd207b468c18f69cdb1bc3e6a946e50b56",
+  "cosmos_api_weu.cosno_api_svc_devs": "70538ac55deebe95f1379ec5abe1f3dd207b468c18f69cdb1bc3e6a946e50b56"
 }

--- a/src/common/prod/westeurope.tf
+++ b/src/common/prod/westeurope.tf
@@ -414,6 +414,13 @@ module "cosmos_api_weu" {
 
   error_action_group_id = module.monitoring_weu.action_groups.error
 
+  azure_adgroup_com_admins_object_id  = data.azuread_group.com_admins.object_id
+  azure_adgroup_com_devs_object_id    = data.azuread_group.com_devs.object_id
+  azure_adgroup_svc_admins_object_id  = data.azuread_group.svc_admins.object_id
+  azure_adgroup_svc_devs_object_id    = data.azuread_group.svc_devs.object_id
+  azure_adgroup_auth_admins_object_id = data.azuread_group.auth_admins.object_id
+  azure_adgroup_auth_devs_object_id   = data.azuread_group.auth_devs.object_id
+
   tags = local.tags
 }
 

--- a/src/domains/bonus/prod/.terraform.lock.hcl
+++ b/src/domains/bonus/prod/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   hashes = [
     "h1:QY/V8YuAw2phme+ryKEbZ/9B+Xi7SfXAOVr4uBoRqpk=",
     "h1:UmSL7MD8ULg/WlRgwisD5lHsjcg9l8AO7AeO0XN96dU=",
+    "h1:oRliSu2DocxHIV4tIlr+jeOPw1IL8pipjAPNbXAWJD0=",
     "h1:sBGDtSwT8Cz4NLBdR+LPPZW0L7kEIzOyvPDjv31COMw=",
     "h1:ukyPZG2fnTkWoeOizY2c5s5OyOKIwNkkNdBtgnK9W60=",
     "zh:01b796cf12e93cc811cb15c8465605e75de170802060f9e2fe114835968960dd",

--- a/src/load-test/prod/.terraform.lock.hcl
+++ b/src/load-test/prod/.terraform.lock.hcl
@@ -9,6 +9,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "h1:AGR/aM9v/7MCHVWOn00fCaPgpJkoFnxxEVLwR5iWg2c=",
     "h1:LohUd1Yk1/eZsO1UlFlHFtxCfiW5q9YpY+uTj5ERmGU=",
     "h1:Mxe1/I27IZK3BP6cm84Gt0+7PXd2EDaDUMxuljm/rUA=",
+    "h1:P9K7gXiyVgoEY1eDe2ADSspiz1+Ky+N3G4fUUhtebG4=",
     "zh:07980d6fdc40c0adb670c8413a5c667917d6dbb51fcedc467c35d64c2f3a1f47",
     "zh:2e6e8491b1f089644b0d23f8da83398f1e10cf5a62b16efcef2b5454fe923038",
     "zh:450dbd72821c5619cc3bcdc20fdd0e29515147e44b733f9c79d3a75851810055",

--- a/src/repository/.terraform.lock.hcl
+++ b/src/repository/.terraform.lock.hcl
@@ -8,6 +8,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "h1:MK83TecMdabDD+HjbxdTt3emXp8G6djLj7KvvUGstM0=",
     "h1:OtWRTAMNOruOmwVB72QSGXC5IIGGQcHwEqnCCmsGbGM=",
     "h1:SOC7EdvKd5YowghQvb6hu209F1PQqtb8LulbQkxOZQQ=",
+    "h1:tEDW5rEALglcH1JRy31z6AzDULECYrAZOD24B4mqry8=",
     "h1:zWkzhP2fx0WQIAUp6Amk/We3WNcbtiWagpKF5PJP5+M=",
     "zh:2f81bca6a3bf3d37604bf99fdb2c77d6118520aa379ab65fd28e6b76bed399cd",
     "zh:3578eb79d175af9544b0dc543124d551c0fed4c48f51773ee17e1dc62e22833a",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/integrations/github" {
   constraints = "6.1.0"
   hashes = [
     "h1:0BC1bA6irof4GXsbOCltW2f18OB/vp3kYhQ598IvOu0=",
+    "h1:5XVBrozOHKNEyAx8zW60BHgxLbmJdlBpsmLLp4MImc0=",
     "h1:LZeec2qr5cNz6MIVrQArl11E1hRnEdzkS7JUrc/8cus=",
     "h1:MWD2GsKJ92kgyegYPGPjQKM0SqFaFbvOibMfDQdJsP0=",
     "h1:Z1C0pLLJQF2fit8PKwc1e5Vm64q73RpayCmkDSMihqw=",


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The refactoring of teams' access to Azure resource caused the lack of read permissions on cosmos-api database. This PR allows the team read access to its data plane and contributor access to the control plane for maintenance and development needs.
### Major Changes

<!--- Describe the major changes introduced by this PR -->
Allow teams to operate on io-p-cosmos-api database
### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
