### PR TITLE
[CES-742] Create new dns zone wallet.io.pagopa.it

### DIFF
--- a/src/common/_modules/global/modules/dns/dns_wallet_io_pagopa_it.tf
+++ b/src/common/_modules/global/modules/dns/dns_wallet_io_pagopa_it.tf
@@ -1,0 +1,6 @@
+resource "azurerm_dns_zone" "wallet_io_pagopa_it" {
+  name                = "wallet.io.pagopa.it"
+  resource_group_name = var.resource_groups.external
+
+  tags = var.tags
+}

--- a/src/common/_modules/global/modules/dns/dns_wallet_io_pagopa_it.tf
+++ b/src/common/_modules/global/modules/dns/dns_wallet_io_pagopa_it.tf
@@ -4,3 +4,15 @@ resource "azurerm_dns_zone" "wallet_io_pagopa_it" {
 
   tags = var.tags
 }
+
+# TXT for Maven verification
+resource "azurerm_dns_txt_record" "wallet_io_pagopa_it" {
+  name                = "@"
+  zone_name           = azurerm_dns_zone.wallet_io_pagopa_it.name
+  resource_group_name = var.resource_groups.external
+  ttl                 = var.dns_default_ttl_sec
+  record {
+    value = "qidvirtenu"
+  }
+  tags = var.tags
+}

--- a/src/common/_modules/global/modules/dns/dns_wallet_io_pagopa_it.tf
+++ b/src/common/_modules/global/modules/dns/dns_wallet_io_pagopa_it.tf
@@ -4,15 +4,3 @@ resource "azurerm_dns_zone" "wallet_io_pagopa_it" {
 
   tags = var.tags
 }
-
-# TXT for Maven verification
-resource "azurerm_dns_txt_record" "wallet_io_pagopa_it" {
-  name                = "@"
-  zone_name           = azurerm_dns_zone.wallet_io_pagopa_it.name
-  resource_group_name = var.resource_groups.external
-  ttl                 = var.dns_default_ttl_sec
-  record {
-    value = "qidvirtenu"
-  }
-  tags = var.tags
-}


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The wallet team detains the wallet.io.pagopa.it CNAME record in the root io.pagopa.it DNS zone.
The team needs to create a validation TXT record on the same wallet.io.pagopa.it. Moreover, creation of TXT records are not suggested on such wide DNS zones.

### Major Changes

<!--- Describe the major changes introduced by this PR -->
Created specific wallet.io.pagopa.it DNS zone without delegation.

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
