### PR TITLE
[FIX] Replaced id with object_id for data service principals in common

### DIFF
--- a/src/common/prod/iam.tf
+++ b/src/common/prod/iam.tf
@@ -21,7 +21,7 @@ data "azuread_service_principal" "apim_client_svc" {
 
 resource "azurerm_role_assignment" "apim_client_role" {
   for_each             = toset(local.role_definition_names.apim_client)
-  principal_id         = data.azuread_service_principal.apim_client_svc.id
+  principal_id         = data.azuread_service_principal.apim_client_svc.object_id
   role_definition_name = each.value
   scope                = module.apim_itn.id
 }
@@ -34,7 +34,7 @@ data "azuread_service_principal" "dev_portal_svc" {
 
 resource "azurerm_role_assignment" "dev_portal_role" {
   for_each             = toset(local.role_definition_names.dev_portal)
-  principal_id         = data.azuread_service_principal.dev_portal_svc.id
+  principal_id         = data.azuread_service_principal.dev_portal_svc.object_id
   role_definition_name = each.value
   scope                = module.apim_itn.id
 }


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To resolve a Drift in common we have replaced id with object id for apim service principals

### Major Changes

<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
