### PR TITLE
[#IOPID-2697] Add `expired-user-sessions` queue and monitoring

### DIFF
--- a/src/domains/citizen-auth-common/01_monitor.tf
+++ b/src/domains/citizen-auth-common/01_monitor.tf
@@ -32,6 +32,11 @@ data "azurerm_monitor_action_group" "quarantine_error_action_group" {
   name                = "${var.prefix}${var.env_short}quarantineerror"
 }
 
+data "azurerm_monitor_action_group" "auth_n_identity_error_action_group" {
+  resource_group_name = var.monitor_resource_group_name
+  name                = "io-p-itn-auth-error-ag-01"
+}
+
 #tfsec:ignore:AZU023
 resource "azurerm_key_vault_secret" "appinsights_instrumentation_key" {
   name         = "appinsights-instrumentation-key"

--- a/src/domains/citizen-auth-common/01_monitor.tf
+++ b/src/domains/citizen-auth-common/01_monitor.tf
@@ -33,7 +33,7 @@ data "azurerm_monitor_action_group" "quarantine_error_action_group" {
 }
 
 data "azurerm_monitor_action_group" "auth_n_identity_error_action_group" {
-  resource_group_name = var.monitor_resource_group_name
+  resource_group_name = "io-p-itn-auth-common-rg-01"
   name                = "io-p-itn-auth-error-ag-01"
 }
 

--- a/src/domains/citizen-auth-common/03_storage.tf
+++ b/src/domains/citizen-auth-common/03_storage.tf
@@ -277,3 +277,74 @@ resource "azurerm_storage_queue" "profiles_to_sanitize" {
   name                 = "profiles-to-sanitize"
   storage_account_name = module.io_citizen_auth_storage.name
 }
+
+resource "azurerm_storage_queue" "expired_user_sessions" {
+  depends_on           = [module.io_citizen_auth_storage, azurerm_private_endpoint.queue]
+  name                 = "expired-user-sessions"
+  storage_account_name = module.io_citizen_auth_storage.name
+}
+
+resource "azurerm_storage_queue" "expired_user_sessions_poison" {
+  depends_on           = [module.io_citizen_auth_storage, azurerm_private_endpoint.queue]
+  name                 = "expired-user-sessions-poison"
+  storage_account_name = module.io_citizen_auth_storage.name
+}
+
+
+# Diagnostic settings
+
+resource "azurerm_monitor_diagnostic_setting" "io_citizen_auth_storage_diagnostic_setting" {
+  name                       = "${module.io_citizen_auth_storage.name}-ds-01"
+  target_resource_id         = "${module.io_citizen_auth_storage.id}/queueServices/default"
+  log_analytics_workspace_id = data.azurerm_application_insights.application_insights.workspace_id
+
+  enabled_log {
+    category = "StorageWrite"
+  }
+
+  metric {
+    category = "Capacity"
+    enabled  = false
+  }
+  metric {
+    category = "Transaction"
+    enabled  = false
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "expired_user_sessions_failure_alert_rule" {
+  enabled             = true
+  name                = "[CITIZEN-AUTH | ${module.io_citizen_auth_storage.name}] Failures on ${resource.azurerm_storage_queue.expired_user_sessions_poison.name} queue"
+  resource_group_name = azurerm_resource_group.data_rg.name
+  location            = var.location
+
+  scopes                  = [module.io_citizen_auth_storage.id]
+  description             = <<-EOT
+    Permanent failures processing ${resource.azurerm_storage_queue.expired_user_sessions.name} queue. REQUIRED MANUAL ACTION.
+  EOT
+  severity                = 1
+  auto_mitigation_enabled = false
+
+  // daily check
+  window_duration      = "P1D" # Select the interval that's used to group the data points by using the aggregation type function. Choose an Aggregation granularity (period) that's greater than the Frequency of evaluation to reduce the likelihood of missing the first evaluation period of an added time series.
+  evaluation_frequency = "P1D" # Select how often the alert rule is to be run. Select a frequency that's smaller than the aggregation granularity to generate a sliding window for the evaluation.
+
+  criteria {
+    query                   = <<-QUERY
+      StorageQueueLogs
+        | where OperationName contains "PutMessage"
+        | where Uri contains "${resource.azurerm_storage_queue.expired_user_sessions_poison.name}"
+      QUERY
+    operator                = "GreaterThan"
+    threshold               = 0
+    time_aggregation_method = "Count"
+  }
+
+  action {
+    action_groups = [
+      data.azurerm_monitor_action_group.auth_n_identity_error_action_group.id,
+    ]
+  }
+
+  tags = var.tags
+}

--- a/src/domains/citizen-auth-common/README.md
+++ b/src/domains/citizen-auth-common/README.md
@@ -91,7 +91,9 @@
 | [azurerm_key_vault_secret.fast_login_subscription_key_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.first_lollipop_consumer_subscription_key_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.first_lollipop_consumer_subscription_key_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_monitor_diagnostic_setting.io_citizen_auth_storage_diagnostic_setting](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.cosmosdb_account_normalized_RU_consumption_exceeded](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.expired_user_sessions_failure_alert_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_private_endpoint.cosmos_db](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.immutable_lv_audit_logs_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.lollipop_assertion_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
@@ -104,6 +106,8 @@
 | [azurerm_storage_container.immutable_lv_audit_logs_storage_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.lollipop_assertions_storage_assertions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_management_policy.immutable_lv_audit_logs_storage_management_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
+| [azurerm_storage_queue.expired_user_sessions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
+| [azurerm_storage_queue.expired_user_sessions_poison](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_queue.lollipop_assertions_storage_revoke_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_queue.lollipop_assertions_storage_revoke_queue_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_queue.profiles_to_sanitize](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
@@ -122,6 +126,7 @@
 | [azurerm_linux_function_app.functions_fast_login](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
 | [azurerm_linux_function_app.lollipop_function](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
 | [azurerm_log_analytics_workspace.log_analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
+| [azurerm_monitor_action_group.auth_n_identity_error_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.error_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.quarantine_error_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

[#IOPID-2693] User re-engagement on session expiration

### Major Changes

<!--- Describe the major changes introduced by this PR -->

- [add queue and monitoring](https://github.com/pagopa/io-infra/commit/eadb8a3adef5f41303e391896f1edf3dac60dc53)


### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
