### PR TITLE
[IOPAE-1783]change USE_SERVICE_PRINCIPAL for devportal

### DIFF
--- a/src/domains/selfcare/_modules/app_services/locals.tf
+++ b/src/domains/selfcare/_modules/app_services/locals.tf
@@ -210,7 +210,7 @@ locals {
       SERVICE_PRINCIPAL_CLIENT_ID = data.azurerm_key_vault_secret.apim_service_principal_client_id.value # Remove after ITN migration
       SERVICE_PRINCIPAL_SECRET    = data.azurerm_key_vault_secret.apim_service_principal_secret.value    # Remove after ITN migration
       SERVICE_PRINCIPAL_TENANT_ID = data.azurerm_client_config.current.tenant_id
-      USE_SERVICE_PRINCIPAL       = "1"
+      USE_SERVICE_PRINCIPAL       = "0"
 
       # devportal configs
       CLIENT_NAME                = "io-p-developer-portal-app"


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
after changing devportal auth method to managed identities we need to set USE_SERVICE_PRINCIPAL to 0 to use managed identities and not services principal
### Major Changes

<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing
tested using staging slot and local start 
<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
