### PR TITLE
[#IOPID-2793] Disable `MigrateServicePreferenceFromLegacy` from fn-profile-async

### DIFF
--- a/src/domains/citizen-auth-app/09_function_profile_async.tf
+++ b/src/domains/citizen-auth-app/09_function_profile_async.tf
@@ -41,6 +41,7 @@ module "function_profile_async" {
 
   app_settings = merge(
     local.function_profile_async.app_settings_common, {
+      "AzureWebJobs.MigrateServicePreferenceFromLegacy.Disabled" = "1",
     }
   )
 


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

[#IOPID-2778] Migrate fn-profile-async on A&I monorepo

### Major Changes

<!--- Describe the major changes introduced by this PR -->

[Disable MigrateServicePreferenceFromLegacy from fn-profile-async](https://github.com/pagopa/io-infra/commit/9832c00a0db160805ebddb4b1caeaf28bea5e58c)

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->


### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
