### PR TITLE
[#IOPID-2792] Disable `StoreSpidLogs` on old fn-profile-async

### DIFF
--- a/src/domains/citizen-auth-app/09_function_profile_async.tf
+++ b/src/domains/citizen-auth-app/09_function_profile_async.tf
@@ -43,6 +43,7 @@ module "function_profile_async" {
     local.function_profile_async.app_settings_common, {
       "AzureWebJobs.MigrateServicePreferenceFromLegacy.Disabled" = "1",
       "AzureWebJobs.OnProfileUpdate.Disabled"                    = "1",
+      "AzureWebJobs.StoreSpidLogs.Disabled"                      = "1",
     }
   )
 


### PR DESCRIPTION
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

[#IOPID-2778] Migrate fn-profile-async on A&I monorepo

### Major Changes

<!--- Describe the major changes introduced by this PR -->

[disable StoreSpidLogs on old fn-profile-async](https://github.com/pagopa/io-infra/commit/0e3a134d680055d538f3116af6deb714f6c8f632)

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing

<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
