### PR TITLE
[#IOPLT-1012] Policy fragment for token instrospection io-proxy

### DIFF
--- a/src/common/_modules/apim/api/fragment/auth.xml
+++ b/src/common/_modules/apim/api/fragment/auth.xml
@@ -1,0 +1,37 @@
+<fragment>
+  <!-- Extract the token from the Authorization Header -->
+  <set-variable name="token" value="@(context.Request.Headers.GetValueOrDefault("Authorization","").Substring(7))" />
+  <send-request mode="new" response-variable-name="introspectionResponse" timeout="10" ignore-error="false">
+    <set-url>{{session-manager-baseurl}}{{introspection-endpoint}}</set-url>
+    <set-method>GET</set-method>
+    <set-header name="Content-Type" exists-action="override">
+      <value>application/json</value>
+    </set-header>
+  </send-request>
+  <choose>
+    <when condition="@(context.Variables["introspectionResponse"].StatusCode == 200)">
+      <!-- Parse the introspectionResponse -->
+      <set-variable name="userData" value="@context.Variables["introspectionResponse"].Body.As<JObject>()" />
+      <!-- Remove the Authorization Header -->
+      <set-headert name="Authorization" exists-action="delete"/>
+      <!-- Set the x-user header with the user data -->
+      <set-header name="x-user" exists-action="override">
+        <value>@(Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(context.Variables["userData"].ToString())))</value>
+      </set-header>
+    </when>
+    <when condition="@(context.Variables["introspectionResponse"].StatusCode == 401)">
+     <return-response response-variable-name="introspectionErrorResponse">
+       <set-status code="401" reason="Unauthorized" />
+     </return-response>
+    </when>
+    <otherwise>
+     <return-response response-variable-name="introspectionErrorResponse">
+      <set-status code="500" reason="Internal Server Error" />
+      <set-body>{"title": "Proxy Error", "status": 500, "detail": "The the token introspection-endpoint returns an error"}</set-body>
+      <set-header name="Content-Type" exists-action="override">
+        <value>application/json</value>
+      </set-header>
+     </return-response>
+    </otherwise>
+  </choose>
+</fragment>

--- a/src/common/_modules/apim/data.tf
+++ b/src/common/_modules/apim/data.tf
@@ -34,3 +34,19 @@ data "azurerm_linux_web_app" "cgn_pe_backend_app_01" {
   name                = "io-p-itn-cgn-pe-backend-app-01"
   resource_group_name = "io-p-itn-cgn-pe-rg-01"
 }
+
+data "azurerm_linux_web_app" "session-manager" {
+  provider = azurerm.prod-cgn
+
+  name                = "io-p-itn-cgn-pe-backend-app-02"
+  resource_group_name = "io-p-itn-cgn-pe-rg-01"
+}
+
+data "azurerm_resource_group" "session_manager_rg_weu" {
+  name = "io-p-weu-session-manager-rg-01"
+}
+
+data "azurerm_linux_web_app" "session_manager_app_weu" {
+  name                = "io-p-weu-session-manager-app-03"
+  resource_group_name = data.azurerm_resource_group.session_manager_rg_weu.name
+}

--- a/src/common/_modules/apim/named_values.tf
+++ b/src/common/_modules/apim/named_values.tf
@@ -1,0 +1,16 @@
+resource "azurerm_api_management_named_value" "session_manager_baseurl" {
+  name                = "session-manager-baseurl"
+  resource_group_name = var.resource_group_internal
+  api_management_name = try(local.nonstandard[var.location_short].apim_name, "${var.project}-apim-01")
+  display_name        = "session-manager-baseurl"
+  value               = data.azurerm_linux_web_app.session_manager_app_weu.default_hostname
+}
+
+resource "azurerm_api_management_named_value" "session_manager_introspection_url" {
+  name                = "session-manager-introspection-url"
+  resource_group_name = var.resource_group_internal
+  api_management_name = try(local.nonstandard[var.location_short].apim_name, "${var.project}-apim-01")
+  display_name        = "session-manager-introspection-url"
+  value               = "/api/v1/user-identity"
+}
+

--- a/src/common/_modules/apim/policy_fragment.tf
+++ b/src/common/_modules/apim/policy_fragment.tf
@@ -1,0 +1,6 @@
+resource "azurerm_api_management_policy_fragment" "auth" {
+  api_management_id = module.apim_v2.id
+  name              = "ioapp-authenticated"
+  format            = "xml"
+  value             = file("../_modules/apim/api/fragment/auth.xml")
+}


### PR DESCRIPTION
### Motivation and Context
Add a new fragment for testing `io-proxy` integration in authenticated requests with token introspection for IO app API calls.
<!--- Why is this change required? What problem does it solve? -->

### Major Changes
Add a new APIM policy fragment
<!--- Describe the major changes introduced by this PR -->

### Dependencies

<!--- If this PR depends on or is related to other PRs, 
list them here using the GitHub syntax: `depends on #123` -->

### Testing
not yet
<!--- Describe the testing steps you have performed -->
<!--- and/or if this PR is already (partially) applied and why -->

### Documentation

<!--- Are there any updates to the documentation? -->

### Other Considerations

<!--- Any additional context, such as breaking changes, security concerns, etc. -->
