### PR TITLE
Update secondary regions of Cosmos API

### DIFF
--- a/src/common/_modules/cosmos_api/cosmos_account.tf
+++ b/src/common/_modules/cosmos_api/cosmos_account.tf
@@ -7,7 +7,7 @@ resource "azurerm_cosmosdb_account" "this" {
   free_tier_enabled   = false
   minimal_tls_version = "Tls"
 
-  automatic_failover_enabled = false
+  automatic_failover_enabled = true
   ip_range_filter            = local.ip_range_filter
 
   geo_location {

--- a/src/common/prod/tfmodules.lock.json
+++ b/src/common/prod/tfmodules.lock.json
@@ -5,8 +5,8 @@
   "apim_itn.iam_adgroup_svc_admins": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
   "apim_itn.iam_adgroup_wallet_admins": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
   "apim_itn.iam_cgn_pe_backend_app_01": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
-  "storage_accounts.exportdata_weu_01_com_admins": "5857038fb8bd4fd4209e97e49099b3a7b2dcf0010477fc3df9ea8a7e4993894f",
-  "storage_accounts.exportdata_weu_01_com_devs": "5857038fb8bd4fd4209e97e49099b3a7b2dcf0010477fc3df9ea8a7e4993894f",
+  "storage_accounts.exportdata_weu_01_com_admins": "decfb53e15ed88c5eabf1b01d966bf8dd03424070fa528c691b299dc0a171d42",
+  "storage_accounts.exportdata_weu_01_com_devs": "decfb53e15ed88c5eabf1b01d966bf8dd03424070fa528c691b299dc0a171d42",
   "cosmos_api_weu.cosno_api_auth_admins": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
   "cosmos_api_weu.cosno_api_auth_devs": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
   "cosmos_api_weu.cosno_api_com_admins": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
@@ -18,8 +18,8 @@
   "github_runner_itn.container_app_github_runner.naming_convention": "c71cfaa7ccaebb4dab588075d332bc788c21dc833f872218079e816c832aae69",
   "apim_itn.apim": "303103dc823c88aef01f89e4c1000d6c170c7cc1aa4b0adb1290eed11410216a",
   "apim_itn.apim.naming_convention": "c71cfaa7ccaebb4dab588075d332bc788c21dc833f872218079e816c832aae69",
-  "storage_accounts.retirements_itn_01_admins": "5857038fb8bd4fd4209e97e49099b3a7b2dcf0010477fc3df9ea8a7e4993894f",
-  "storage_accounts_itn.exportdata_weu_01_com_admins": "5857038fb8bd4fd4209e97e49099b3a7b2dcf0010477fc3df9ea8a7e4993894f",
-  "storage_accounts_itn.exportdata_weu_01_com_devs": "5857038fb8bd4fd4209e97e49099b3a7b2dcf0010477fc3df9ea8a7e4993894f",
-  "storage_accounts_itn.retirements_itn_01_admins": "5857038fb8bd4fd4209e97e49099b3a7b2dcf0010477fc3df9ea8a7e4993894f"
+  "storage_accounts.retirements_itn_01_admins": "decfb53e15ed88c5eabf1b01d966bf8dd03424070fa528c691b299dc0a171d42",
+  "storage_accounts_itn.exportdata_weu_01_com_admins": "decfb53e15ed88c5eabf1b01d966bf8dd03424070fa528c691b299dc0a171d42",
+  "storage_accounts_itn.exportdata_weu_01_com_devs": "decfb53e15ed88c5eabf1b01d966bf8dd03424070fa528c691b299dc0a171d42",
+  "storage_accounts_itn.retirements_itn_01_admins": "decfb53e15ed88c5eabf1b01d966bf8dd03424070fa528c691b299dc0a171d42"
 }

--- a/src/common/prod/westeurope.tf
+++ b/src/common/prod/westeurope.tf
@@ -376,7 +376,7 @@ module "cosmos_api_weu" {
   resource_group_internal        = local.core.resource_groups.westeurope.internal
   vnet_common                    = local.core.networking.weu.vnet_common
   pep_snet                       = local.core.networking.weu.pep_snet
-  secondary_location             = "westeurope"
+  secondary_location             = "spaincentral"
   secondary_location_pep_snet_id = local.core.networking.itn.pep_snet.id
   documents_dns_zone             = module.global.dns.private_dns_zones.documents
   allowed_subnets_ids            = values(data.azurerm_subnet.cosmos_api_allowed)[*].id


### PR DESCRIPTION
io-p-cosmos-api now uses spain central as secondary region, replacing west europe

Close IOPLT-896