### PR TITLE
Added cie.app.io.pagopa.it txt record for maven validation

### DIFF
--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   labeler:
     name: PR Labeler
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0

--- a/src/common/_modules/global/modules/dns/dns_io_pagopa_it.tf
+++ b/src/common/_modules/global/modules/dns/dns_io_pagopa_it.tf
@@ -155,3 +155,15 @@ resource "azurerm_dns_ns_record" "wallet_io_pagopa_it_ns" {
   ttl                 = var.dns_default_ttl_sec
   tags                = var.tags
 }
+
+# TXT for cie.app.io.pagopa.it Maven namespace verification
+resource "azurerm_dns_txt_record" "cie_app_io_pagopa_it" {
+  name                = "cie.app"
+  zone_name           = azurerm_dns_zone.io_pagopa_it.name
+  resource_group_name = var.resource_groups.external
+  ttl                 = 3600
+  record {
+    value = "up2m9zskaf"
+  }
+  tags = var.tags
+}


### PR DESCRIPTION
The cie.app.io.pagopa.it maven package will be released. To enable this, dns validation is needed.

Fixed also ubuntu version in labeler workflow due to deprecation of ubuntu 20.04