### PR TITLE
Fix creation APIM need public access

### DIFF
--- a/src/common/_modules/platform_api_gateway/main.tf
+++ b/src/common/_modules/platform_api_gateway/main.tf
@@ -17,7 +17,7 @@ module "platform_api_gateway" {
   publisher_name            = "IO"
   notification_sender_email = data.azurerm_key_vault_secret.apim_publisher_email.value
 
-  enable_public_network_access = false
+  enable_public_network_access = true
 
   virtual_network = {
     name                = var.vnet_common.name


### PR DESCRIPTION
Creating the APIM with public access to false cause an error on apply:
```
Error: creating/updating Service (Subscription: "***"
│ Resource Group Name: "io-p-itn-common-rg-01"
│ Service Name: "io-p-itn-platform-api-gateway-apim-01"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: NotSupported: Blocking all public network access by setting property `publicNetworkAccess` of API Management service /subscriptions/***/resourceGroups/io-p-itn-common-rg-01/providers/Microsoft.ApiManagement/service/io-p-itn-platform-api-gateway-apim-01 is not enabled during service creation.
│ 
│   with module.platform_api_gateway_apim_itn.module.platform_api_gateway.azurerm_api_management.this,
│   on .terraform/modules/platform_api_gateway_apim_itn.platform_api_gateway/main.tf line 18, in resource "azurerm_api_management" "this":
│   18: resource "azurerm_api_management" "this" {
```
