### PR TITLE
Fix operation name getServerInfo

### DIFF
--- a/src/common/_modules/platform_api_gateway/api_platform.tf
+++ b/src/common/_modules/platform_api_gateway/api_platform.tf
@@ -73,7 +73,7 @@ resource "azurerm_api_management_api_operation_policy" "platform_legacy_get_serv
   api_name            = azurerm_api_management_api.platform_legacy.name
   api_management_name = module.platform_api_gateway.name
   resource_group_name = module.platform_api_gateway.resource_group_name
-  operation_id        = "getServicesStatus"
+  operation_id        = "getServerInfo"
   xml_content         = file("${path.module}/policies/platform/v1/get_server_info/policy.xml")
 }
 


### PR DESCRIPTION
Fix the operation name used inside the `platform_legacy_get_server_info` operation policy