### PR TITLE
Update Platform operations adding missing HEAD on ping and status

### DIFF
--- a/src/common/_modules/platform_api_gateway/api_platform.tf
+++ b/src/common/_modules/platform_api_gateway/api_platform.tf
@@ -35,7 +35,7 @@ resource "azurerm_api_management_api" "platform_legacy" {
   import {
     content_format = "openapi-link"
     # The commit id refers to the last commit of refactor-openapi-specs branch.
-    content_value  = "https://raw.githubusercontent.com/pagopa/io-backend/a412560082e748d972107759ad32a54938efe878/openapi/generated/api_platform_legacy.yaml"
+    content_value = "https://raw.githubusercontent.com/pagopa/io-backend/a412560082e748d972107759ad32a54938efe878/openapi/generated/api_platform_legacy.yaml"
   }
 }
 

--- a/src/common/_modules/platform_api_gateway/api_platform.tf
+++ b/src/common/_modules/platform_api_gateway/api_platform.tf
@@ -34,7 +34,7 @@ resource "azurerm_api_management_api" "platform_legacy" {
 
   import {
     content_format = "openapi-link"
-    content_value  = "https://raw.githubusercontent.com/pagopa/io-backend/refs/heads/refactor-openapi-specs/openapi/generated/api_platform_legacy.yaml"
+    content_value  = "https://raw.githubusercontent.com/pagopa/io-backend/a412560082e748d972107759ad32a54938efe878/openapi/generated/api_platform_legacy.yaml"
   }
 }
 

--- a/src/common/_modules/platform_api_gateway/api_platform.tf
+++ b/src/common/_modules/platform_api_gateway/api_platform.tf
@@ -34,6 +34,7 @@ resource "azurerm_api_management_api" "platform_legacy" {
 
   import {
     content_format = "openapi-link"
+    # The commit id refers to the last commit of refactor-openapi-specs branch.
     content_value  = "https://raw.githubusercontent.com/pagopa/io-backend/a412560082e748d972107759ad32a54938efe878/openapi/generated/api_platform_legacy.yaml"
   }
 }

--- a/src/common/prod/tfmodules.lock.json
+++ b/src/common/prod/tfmodules.lock.json
@@ -15,11 +15,11 @@
   "cosmos_api_weu.cosno_api_svc_devs": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
   "assets_cdn_weu.roles_svc_devs": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
   "github_runner_itn.container_app_github_runner": "df0074e2b91c6153a80a9e208a152e9c060936c85b5f7b1f2ced9a9f5aa901ec",
-  "apim_itn.apim": "e5925e67525443282aef8f432f9a2cfe2357acbfd20c86a753f890ac4fa65056",
+  "apim_itn.apim": "3cb279a9513f855c5f99711bd4a2ee372dd5939d14686a620774c45dc01ba571",
   "storage_accounts.retirements_itn_01_admins": "07cdce758d809d16a5154b997dcb2b017b7b443c53f5a6de776b9f0de6b19c9e",
   "storage_accounts_itn.exportdata_weu_01_com_admins": "07cdce758d809d16a5154b997dcb2b017b7b443c53f5a6de776b9f0de6b19c9e",
   "storage_accounts_itn.exportdata_weu_01_com_devs": "07cdce758d809d16a5154b997dcb2b017b7b443c53f5a6de776b9f0de6b19c9e",
   "storage_accounts_itn.retirements_itn_01_admins": "07cdce758d809d16a5154b997dcb2b017b7b443c53f5a6de776b9f0de6b19c9e",
   "platform_api_gateway_apim_itn.iam_adgroup_product_admins": "07cdce758d809d16a5154b997dcb2b017b7b443c53f5a6de776b9f0de6b19c9e",
-  "platform_api_gateway_apim_itn.platform_api_gateway": "e5925e67525443282aef8f432f9a2cfe2357acbfd20c86a753f890ac4fa65056"
+  "platform_api_gateway_apim_itn.platform_api_gateway": "3cb279a9513f855c5f99711bd4a2ee372dd5939d14686a620774c45dc01ba571"
 }


### PR DESCRIPTION
The client use `HEAD` api to call `/api/v1/ping` and `/api/v1/status` APIs. In order to perform this requests the APIM must have the operations for this HTTP verbs.