### PR TITLE
[#IOPLT-1120] Change redirect url to download page instead home page

### DIFF
--- a/.github/workflows/call_code_review.yaml
+++ b/.github/workflows/call_code_review.yaml
@@ -31,7 +31,7 @@ env:
 jobs:
   tf_plan:
     name: 'Terraform Plan'
-    runs-on: ${{ inputs.use_private_agent == true && 'self-hosted' || 'ubuntu-20.04' }}
+    runs-on: ${{ inputs.use_private_agent == true && 'self-hosted' || 'ubuntu-22.04' }}
     environment: ${{ inputs.environment }}-ci
     permissions:
       id-token: write

--- a/.github/workflows/call_release.yaml
+++ b/.github/workflows/call_release.yaml
@@ -32,7 +32,7 @@ jobs:
 
   tf_plan:
     name: 'Terraform Plan'
-    runs-on: ${{ inputs.use_private_agent == true && 'self-hosted' || 'ubuntu-20.04' }}
+    runs-on: ${{ inputs.use_private_agent == true && 'self-hosted' || 'ubuntu-22.04' }}
     environment: ${{ inputs.environment }}-ci
     permissions:
       id-token: write

--- a/src/domains/continua/_modules/app_services/app_service_continua.tf
+++ b/src/domains/continua/_modules/app_services/app_service_continua.tf
@@ -10,7 +10,7 @@ locals {
     PORT     = "3000"
 
     # Fallback
-    FALLBACK_URL            = "https://ioapp.it"
+    FALLBACK_URL            = "https://ioapp.it/scarica-io"
     FALLBACK_URL_ON_IOS     = "https://apps.apple.com/it/app/io/id1501681835"
     FALLBACK_URL_ON_ANDROID = "https://play.google.com/store/apps/details?id=it.pagopa.io.app"
 


### PR DESCRIPTION
Continua should redirect to the download page of the ioapp.it website instead the home page.