### PR TITLE
Added rule exclusion

### DIFF
--- a/src/common/_modules/application_gateway/firewall.tf
+++ b/src/common/_modules/application_gateway/firewall.tf
@@ -62,6 +62,14 @@ resource "azurerm_web_application_firewall_policy" "api_app" {
       }
 
       rule_group_override {
+        rule_group_name = "REQUEST-931-APPLICATION-ATTACK-RFI"
+        rule {
+          id      = "931130"
+          enabled = false
+        }
+      }
+
+      rule_group_override {
         rule_group_name = "REQUEST-932-APPLICATION-ATTACK-RCE"
         rule {
           id      = "932150"


### PR DESCRIPTION
Excluded rule 931130 of REQUEST-931-APPLICATION-ATTACK-RFI because it's matching redirects and other url-like query params breaking OAUTH authentication.