### PR TITLE
[#IOPID-3189] Remove user-login queue references from service manager

### DIFF
--- a/src/domains/citizen-auth-app/08_session_manager.tf
+++ b/src/domains/citizen-auth-app/08_session_manager.tf
@@ -206,10 +206,6 @@ locals {
     ALLOWED_CIE_TEST_FISCAL_CODES = data.azurerm_key_vault_secret.app_backend_ALLOWED_CIE_TEST_FISCAL_CODES.value
     CIE_TEST_METADATA_URL         = "https://collaudo.idserver.servizicie.interno.gov.it/idp/shibboleth"
 
-    // USERSLOGIN
-    USERS_LOGIN_QUEUE_NAME                = local.storage_account_notifications_queue_userslogin
-    USERS_LOGIN_STORAGE_CONNECTION_STRING = data.azurerm_storage_account.logs.primary_connection_string
-
     PUSH_NOTIFICATIONS_STORAGE_CONNECTION_STRING = data.azurerm_storage_account.push_notifications_storage.primary_connection_string
     PUSH_NOTIFICATIONS_QUEUE_NAME                = local.storage_account_notifications_queue_push_notifications
 

--- a/src/domains/citizen-auth-app/99_locals.tf
+++ b/src/domains/citizen-auth-app/99_locals.tf
@@ -26,7 +26,6 @@ locals {
 
   appgw_resource_group_name = "${local.product}-rg-external"
 
-  storage_account_notifications_queue_userslogin         = "userslogin"
   storage_account_notifications_queue_push_notifications = "push-notifications"
 
 }


### PR DESCRIPTION
Remove `user-login` storage account queue references from service manager, cuz is no longer used