### PR TITLE
[#IOPLT-1056] New Auth & Identity product, auth API Group, routing

### DIFF
--- a/src/common/_modules/app_backend/data.tf
+++ b/src/common/_modules/app_backend/data.tf
@@ -8,11 +8,6 @@ data "azurerm_storage_account" "notifications" {
   resource_group_name = var.resource_group_internal
 }
 
-data "azurerm_storage_account" "push_notifications_storage" {
-  name                = replace(format("${var.project}-weu-messages-notifst"), "-", "")
-  resource_group_name = "${var.project}-weu-messages-notifications-rg"
-}
-
 data "azurerm_storage_account" "itn_com_st" {
   name                = "iopitncomst01"
   resource_group_name = "io-p-itn-com-rg-01"

--- a/src/common/_modules/app_backend/secrets.tf
+++ b/src/common/_modules/app_backend/secrets.tf
@@ -17,15 +17,6 @@ resource "azurerm_key_vault_secret" "appbackend-SPID-LOG-STORAGE" {
 }
 
 #tfsec:ignore:AZU023
-resource "azurerm_key_vault_secret" "appbackend-PUSH-NOTIFICATIONS-STORAGE" {
-  count        = var.index == 1 ? 1 : 0
-  name         = "appbackend-PUSH-NOTIFICATIONS-STORAGE"
-  value        = data.azurerm_storage_account.push_notifications_storage.primary_connection_string
-  key_vault_id = var.key_vault_common.id
-  content_type = "string"
-}
-
-#tfsec:ignore:AZU023
 resource "azurerm_key_vault_secret" "appbackend-NORIFICATIONS-STORAGE" {
   count        = var.index == 1 ? 1 : 0
   name         = "appbackend-NORIFICATIONS-STORAGE"

--- a/src/common/_modules/app_gateway/locals.tf
+++ b/src/common/_modules/app_gateway/locals.tf
@@ -514,11 +514,11 @@ locals {
           backend               = "platform-api-gateway",
           rewrite_rule_set_name = "rewrite-rule-set-api-app-rewrite-platform-legacy"
         },
-        # api-gateway-platform-identity = {
-        #   paths                 = ["/api/identity/*"]
-        #   backend               = "platform-api-gateway",
-        #   rewrite_rule_set_name = "rewrite-rule-set-api-app"
-        # },
+        api-gateway-platform-identity = {
+          paths                 = ["/api/identity/*"]
+          backend               = "platform-api-gateway",
+          rewrite_rule_set_name = "rewrite-rule-set-api-app"
+        },
         api-gateway-cdc = {
           paths                 = ["/api/cdc/*"]
           backend               = "platform-api-gateway",

--- a/src/common/_modules/application_gateway/main.tf
+++ b/src/common/_modules/application_gateway/main.tf
@@ -609,6 +609,11 @@ module "app_gw" {
           backend               = "platform-api-gateway",
           rewrite_rule_set_name = "rewrite-rule-set-api-app-rewrite-platform-legacy"
         },
+        api-gateway-platform-auth = {
+          paths                 = ["/api/auth/*"]
+          backend               = "platform-api-gateway",
+          rewrite_rule_set_name = "rewrite-rule-set-api-app"
+        },
         api-gateway-cdc = {
           paths                 = ["/api/cdc/*"]
           backend               = "platform-api-gateway",

--- a/src/common/_modules/application_gateway/main.tf
+++ b/src/common/_modules/application_gateway/main.tf
@@ -609,8 +609,8 @@ module "app_gw" {
           backend               = "platform-api-gateway",
           rewrite_rule_set_name = "rewrite-rule-set-api-app-rewrite-platform-legacy"
         },
-        api-gateway-platform-auth = {
-          paths                 = ["/api/auth/*"]
+        api-gateway-platform-identity = {
+          paths                 = ["/api/identity/*"]
           backend               = "platform-api-gateway",
           rewrite_rule_set_name = "rewrite-rule-set-api-app"
         },

--- a/src/common/_modules/cosmos_api/cosmos_account.tf
+++ b/src/common/_modules/cosmos_api/cosmos_account.tf
@@ -5,7 +5,7 @@ resource "azurerm_cosmosdb_account" "this" {
 
   offer_type          = "Standard"
   free_tier_enabled   = false
-  minimal_tls_version = "Tls"
+  minimal_tls_version = "Tls12"
 
   automatic_failover_enabled = true
   ip_range_filter            = local.ip_range_filter

--- a/src/common/_modules/platform_api_gateway/api_auth.tf
+++ b/src/common/_modules/platform_api_gateway/api_auth.tf
@@ -1,0 +1,65 @@
+resource "azurerm_api_management_product" "auth" {
+  product_id   = "io-auth"
+  display_name = "IO Auth & Identity"
+  description  = "Product for IO A&I APIs"
+
+  api_management_name = module.platform_api_gateway.name
+  resource_group_name = module.platform_api_gateway.resource_group_name
+
+  published             = true
+  subscription_required = false
+  approval_required     = false
+}
+
+resource "azurerm_api_management_product_policy" "auth" {
+  product_id          = azurerm_api_management_product.auth.product_id
+  api_management_name = module.platform_api_gateway.name
+  resource_group_name = module.platform_api_gateway.resource_group_name
+
+  xml_content = file("${path.module}/policies/auth/product_base_policy.xml")
+}
+
+resource "azurerm_api_management_api_version_set" "auth_v1" {
+  name                = "auth_v1"
+  api_management_name = azurerm_api_management_product.auth.api_management_name
+  resource_group_name = azurerm_api_management_product.auth.resource_group_name
+  display_name        = "Auth & Identity app-backend v1"
+  versioning_scheme   = "Segment"
+}
+
+resource "azurerm_api_management_api" "auth" {
+  name                  = format("%s-p-auth-api", var.prefix)
+  api_management_name   = module.platform_api_gateway.name
+  resource_group_name   = module.platform_api_gateway.resource_group_name
+  subscription_required = false
+
+  version_set_id = azurerm_api_management_api_version_set.auth_v1.id
+  version        = "v1"
+  revision       = 1
+
+  description  = "IO Auth & Identity app-backend API"
+  display_name = "Auth & Identity io-backend"
+  path         = "api/auth"
+  protocols    = ["https"]
+
+  import {
+    content_format = "openapi-link"
+    # The commit id refers to the last commit of refactor-openapi-specs branch.
+    content_value = "https://raw.githubusercontent.com/pagopa/io-backend/50a0cf9b2831ac68f13a1098af837c7dba31e3dc/openapi/generated/api_auth.yaml"
+  }
+}
+
+resource "azurerm_api_management_product_api" "auth_auth" {
+  api_name            = azurerm_api_management_api.auth.name
+  product_id          = azurerm_api_management_product.auth.product_id
+  api_management_name = module.platform_api_gateway.name
+  resource_group_name = module.platform_api_gateway.resource_group_name
+}
+
+resource "azurerm_api_management_api_policy" "auth" {
+  api_name            = azurerm_api_management_api.auth.name
+  api_management_name = module.platform_api_gateway.name
+  resource_group_name = module.platform_api_gateway.resource_group_name
+
+  xml_content = file("${path.module}/policies/auth/v1/_base_policy.xml")
+}

--- a/src/common/_modules/platform_api_gateway/api_auth.tf
+++ b/src/common/_modules/platform_api_gateway/api_auth.tf
@@ -19,7 +19,7 @@ resource "azurerm_api_management_product_policy" "auth" {
   xml_content = file("${path.module}/policies/auth/product_base_policy.xml")
 }
 
-resource "azurerm_api_management_api_version_set" "auth_v1" {
+resource "azurerm_api_management_api_version_set" "identity_v1" {
   name                = "auth_v1"
   api_management_name = azurerm_api_management_product.auth.api_management_name
   resource_group_name = azurerm_api_management_product.auth.resource_group_name
@@ -27,37 +27,37 @@ resource "azurerm_api_management_api_version_set" "auth_v1" {
   versioning_scheme   = "Segment"
 }
 
-resource "azurerm_api_management_api" "auth" {
+resource "azurerm_api_management_api" "identity" {
   name                  = format("%s-p-auth-api", var.prefix)
   api_management_name   = module.platform_api_gateway.name
   resource_group_name   = module.platform_api_gateway.resource_group_name
   subscription_required = false
 
-  version_set_id = azurerm_api_management_api_version_set.auth_v1.id
+  version_set_id = azurerm_api_management_api_version_set.identity_v1.id
   version        = "v1"
   revision       = 1
 
   description  = "IO Auth & Identity app-backend API"
   display_name = "Auth & Identity io-backend"
-  path         = "api/auth"
+  path         = "api/identity"
   protocols    = ["https"]
 
   import {
     content_format = "openapi-link"
     # The commit id refers to the last commit of refactor-openapi-specs branch.
-    content_value = "https://raw.githubusercontent.com/pagopa/io-backend/50a0cf9b2831ac68f13a1098af837c7dba31e3dc/openapi/generated/api_auth.yaml"
+    content_value = "https://raw.githubusercontent.com/pagopa/io-backend/8f7cb251fe1f3875a53b066ee062f4a80d117598/openapi/generated/api_auth.yaml"
   }
 }
 
-resource "azurerm_api_management_product_api" "auth_auth" {
-  api_name            = azurerm_api_management_api.auth.name
+resource "azurerm_api_management_product_api" "auth_identity" {
+  api_name            = azurerm_api_management_api.identity.name
   product_id          = azurerm_api_management_product.auth.product_id
   api_management_name = module.platform_api_gateway.name
   resource_group_name = module.platform_api_gateway.resource_group_name
 }
 
-resource "azurerm_api_management_api_policy" "auth" {
-  api_name            = azurerm_api_management_api.auth.name
+resource "azurerm_api_management_api_policy" "identity" {
+  api_name            = azurerm_api_management_api.identity.name
   api_management_name = module.platform_api_gateway.name
   resource_group_name = module.platform_api_gateway.resource_group_name
 

--- a/src/common/_modules/platform_api_gateway/local.tf
+++ b/src/common/_modules/platform_api_gateway/local.tf
@@ -1,3 +1,31 @@
 locals {
   proxy_hostname_internal = "proxy.internal.io.pagopa.it"
+
+  apim_adgroup_rbac = [
+    {
+      principal_id = var.azure_adgroup_platform_admins_object_id
+      description  = "Platform team admin group"
+      role         = "owner"
+    },
+    {
+      principal_id = var.azure_adgroup_auth_admins_object_id
+      description  = "Auth & Identity team admin group"
+      role         = "owner"
+    },
+    {
+      principal_id = var.azure_user_assigned_identity_auth_infra_cd
+      description  = "Auth & Identity team infra CD identity"
+      role         = "owner"
+    },
+    {
+      principal_id = var.azure_adgroup_bonus_admins_object_id
+      description  = "Bonus team admin group"
+      role         = "owner"
+    },
+    {
+      principal_id = var.azure_user_assigned_identity_bonus_infra_cd
+      description  = "Bonus team infra CD identity"
+      role         = "owner"
+    }
+  ]
 }

--- a/src/common/_modules/platform_api_gateway/policies/auth/product_base_policy.xml
+++ b/src/common/_modules/platform_api_gateway/policies/auth/product_base_policy.xml
@@ -1,0 +1,26 @@
+<!--
+    IMPORTANT:
+    - Policy elements can appear only within the <inbound>, <outbound>, <backend> section elements.
+    - To apply a policy to the incoming request (before it is forwarded to the backend service), place a corresponding policy element within the <inbound> section element.
+    - To apply a policy to the outgoing response (before it is sent back to the caller), place a corresponding policy element within the <outbound> section element.
+    - To add a policy, place the cursor at the desired insertion point and select a policy from the sidebar.
+    - To remove a policy, delete the corresponding policy statement from the policy document.
+    - Position the <base> element within a section element to inherit all policies from the corresponding section element in the enclosing scope.
+    - Remove the <base> element to prevent inheriting policies from the corresponding section element in the enclosing scope.
+    - Policies are applied in the order of their appearance, from the top down.
+    - Comments within policy elements are not supported and may disappear. Place your comments between policy elements or at a higher level scope.
+-->
+<policies>
+    <inbound>
+        <base />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/common/_modules/platform_api_gateway/policies/auth/v1/_base_policy.xml
+++ b/src/common/_modules/platform_api_gateway/policies/auth/v1/_base_policy.xml
@@ -1,0 +1,49 @@
+<!--
+    IMPORTANT:
+    - Policy elements can appear only within the <inbound>, <outbound>, <backend> section elements.
+    - To apply a policy to the incoming request (before it is forwarded to the backend service), place a corresponding policy element within the <inbound> section element.
+    - To apply a policy to the outgoing response (before it is sent back to the caller), place a corresponding policy element within the <outbound> section element.
+    - To add a policy, place the cursor at the desired insertion point and select a policy from the sidebar.
+    - To remove a policy, delete the corresponding policy statement from the policy document.
+    - Position the <base> element within a section element to inherit all policies from the corresponding section element in the enclosing scope.
+    - Remove the <base> element to prevent inheriting policies from the corresponding section element in the enclosing scope.
+    - Policies are applied in the order of their appearance, from the top down.
+    - Comments within policy elements are not supported and may disappear. Place your comments between policy elements or at a higher level scope.
+-->
+<policies>
+    <inbound>
+        <base />
+        <!-- https://docs.microsoft.com/en-us/dotnet/api/system.random.next?view=net-6.0#system-random-next(system-int32-system-int32) -->
+        <set-variable name="urlId" value="@{
+            Random rnd = new Random();
+            int urlId = rnd.Next(1, 3);
+            return urlId.ToString();
+        }" />
+        <choose>
+            <when condition="@(context.Variables.GetValueOrDefault<string>("urlId").Equals("1"))">
+                <set-backend-service base-url="https://io-p-app-appbackendl1.azurewebsites.net" />
+            </when>
+            <when condition="@(context.Variables.GetValueOrDefault<string>("urlId").Equals("2"))">
+                <set-backend-service base-url="https://io-p-app-appbackendl2.azurewebsites.net" />
+            </when>
+            <otherwise>
+                <return-response>
+                    <set-status code="500" reason="InternalServerError" />
+                    <set-header name="Microsoft-Azure-Api-Management-Correlation-Id" exists-action="override">
+                        <value>@{return Guid.NewGuid().ToString();}</value>
+                    </set-header>
+                    <set-body>A gateway-related error occurred while processing the request.</set-body>
+                </return-response>
+            </otherwise>
+        </choose>
+    </inbound>
+    <outbound>
+        <base />
+    </outbound>
+    <backend>
+        <base />
+    </backend>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/common/_modules/platform_api_gateway/rbac.tf
+++ b/src/common/_modules/platform_api_gateway/rbac.tf
@@ -27,6 +27,40 @@ module "iam_adgroup_product_admins" {
   ]
 }
 
+module "iam_adgroup_auth_admins" {
+  source  = "pagopa-dx/azure-role-assignments/azurerm"
+  version = "~> 1.0"
+
+  principal_id    = var.azure_adgroup_auth_admins_object_id
+  subscription_id = data.azurerm_client_config.current.subscription_id
+
+  apim = [
+    {
+      name                = module.platform_api_gateway.name
+      resource_group_name = module.platform_api_gateway.resource_group_name
+      description         = "Auth & Identity team admin group"
+      role                = "owner"
+    }
+  ]
+}
+
+module "iam_adgroup_auth_infra_cd" {
+  source  = "pagopa-dx/azure-role-assignments/azurerm"
+  version = "~> 1.0"
+
+  principal_id    = var.azure_user_assigned_identity_auth_infra_cd
+  subscription_id = data.azurerm_client_config.current.subscription_id
+
+  apim = [
+    {
+      name                = module.platform_api_gateway.name
+      resource_group_name = module.platform_api_gateway.resource_group_name
+      description         = "Auth & Identity team infra CD identity"
+      role                = "owner"
+    }
+  ]
+}
+
 module "iam_adgroup_bonus_admins" {
   source  = "pagopa-dx/azure-role-assignments/azurerm"
   version = "~> 1.0"

--- a/src/common/_modules/platform_api_gateway/rbac.tf
+++ b/src/common/_modules/platform_api_gateway/rbac.tf
@@ -27,36 +27,40 @@ module "iam_adgroup_product_admins" {
   ]
 }
 
-module "iam_adgroup_auth_admins" {
-  source  = "pagopa-dx/azure-role-assignments/azurerm"
-  version = "~> 1.0"
-
-  principal_id    = var.azure_adgroup_auth_admins_object_id
-  subscription_id = data.azurerm_client_config.current.subscription_id
-
-  apim = [
+locals {
+  apim_adgroup_rbac = [
     {
-      name                = module.platform_api_gateway.name
-      resource_group_name = module.platform_api_gateway.resource_group_name
-      description         = "Auth & Identity team admin group"
-      role                = "owner"
+      principal_id = var.azure_adgroup_auth_admins_object_id
+      description  = "Auth & Identity team admin group"
+      role         = "owner"
+    },
+    {
+      principal_id = var.azure_user_assigned_identity_auth_infra_cd
+      description  = "Auth & Identity team infra CD identity"
+      role         = "owner"
     }
   ]
+
+  apim_adgroup_rbac_map = {
+    for assignment in local.apim_adgroup_rbac :
+    assignment.principal_id => assignment
+  }
 }
 
-module "iam_adgroup_auth_infra_cd" {
-  source  = "pagopa-dx/azure-role-assignments/azurerm"
-  version = "~> 1.0"
+module "iam_adgroup" {
+  for_each = local.apim_adgroup_rbac_map
+  source   = "pagopa-dx/azure-role-assignments/azurerm"
+  version  = "~> 1.0"
 
-  principal_id    = var.azure_user_assigned_identity_auth_infra_cd
+  principal_id    = each.value.principal_id
   subscription_id = data.azurerm_client_config.current.subscription_id
 
   apim = [
     {
       name                = module.platform_api_gateway.name
       resource_group_name = module.platform_api_gateway.resource_group_name
-      description         = "Auth & Identity team infra CD identity"
-      role                = "owner"
+      description         = each.value.description
+      role                = each.value.role
     }
   ]
 }

--- a/src/common/_modules/platform_api_gateway/rbac.tf
+++ b/src/common/_modules/platform_api_gateway/rbac.tf
@@ -9,48 +9,13 @@ resource "azurerm_key_vault_access_policy" "platform_api_gateway_kv_policy" {
   storage_permissions     = []
 }
 
-# Typo: this module should be renamed to `iam_adgroup_platform_admins`
-module "iam_adgroup_product_admins" {
-  source  = "pagopa-dx/azure-role-assignments/azurerm"
-  version = "~> 1.0"
-
-  principal_id    = var.azure_adgroup_platform_admins_object_id
-  subscription_id = data.azurerm_client_config.current.subscription_id
-
-  apim = [
-    {
-      name                = module.platform_api_gateway.name
-      resource_group_name = module.platform_api_gateway.resource_group_name
-      description         = "Platform team admin group"
-      role                = "owner"
-    }
-  ]
-}
-
-locals {
-  apim_adgroup_rbac = [
-    {
-      principal_id = var.azure_adgroup_auth_admins_object_id
-      description  = "Auth & Identity team admin group"
-      role         = "owner"
-    },
-    {
-      principal_id = var.azure_user_assigned_identity_auth_infra_cd
-      description  = "Auth & Identity team infra CD identity"
-      role         = "owner"
-    }
-  ]
-
-  apim_adgroup_rbac_map = {
+module "iam_adgroup" {
+  for_each = {
     for assignment in local.apim_adgroup_rbac :
     assignment.principal_id => assignment
   }
-}
-
-module "iam_adgroup" {
-  for_each = local.apim_adgroup_rbac_map
-  source   = "pagopa-dx/azure-role-assignments/azurerm"
-  version  = "~> 1.0"
+  source  = "pagopa-dx/azure-role-assignments/azurerm"
+  version = "~> 1.0"
 
   principal_id    = each.value.principal_id
   subscription_id = data.azurerm_client_config.current.subscription_id
@@ -65,36 +30,17 @@ module "iam_adgroup" {
   ]
 }
 
-module "iam_adgroup_bonus_admins" {
-  source  = "pagopa-dx/azure-role-assignments/azurerm"
-  version = "~> 1.0"
-
-  principal_id    = var.azure_adgroup_bonus_admins_object_id
-  subscription_id = data.azurerm_client_config.current.subscription_id
-
-  apim = [
-    {
-      name                = module.platform_api_gateway.name
-      resource_group_name = module.platform_api_gateway.resource_group_name
-      description         = "Bonus team admin group"
-      role                = "owner"
-    }
-  ]
+moved {
+  from = module.iam_adgroup_product_admins
+  to   = module.iam_adgroup["a0ed72be-f9f9-407e-bf25-91761f8d3de7"]
 }
 
-module "iam_adgroup_bonus_infra_cd" {
-  source  = "pagopa-dx/azure-role-assignments/azurerm"
-  version = "~> 1.0"
+moved {
+  from = module.iam_adgroup_bonus_admins
+  to   = module.iam_adgroup["831e5214-2f68-4a13-b25f-7bec962c7e1b"]
+}
 
-  principal_id    = var.azure_user_assigned_identity_bonus_infra_cd
-  subscription_id = data.azurerm_client_config.current.subscription_id
-
-  apim = [
-    {
-      name                = module.platform_api_gateway.name
-      resource_group_name = module.platform_api_gateway.resource_group_name
-      description         = "Bonus team infra CD identity"
-      role                = "owner"
-    }
-  ]
+moved {
+  from = module.iam_adgroup_bonus_infra_cd
+  to   = module.iam_adgroup["ef6b556d-4d33-4467-ad9d-6b5540cbde6b"]
 }

--- a/src/common/_modules/platform_api_gateway/variables.tf
+++ b/src/common/_modules/platform_api_gateway/variables.tf
@@ -87,6 +87,16 @@ variable "azure_adgroup_platform_admins_object_id" {
   description = "Object Id of the Entra group for subscription admins"
 }
 
+variable "azure_adgroup_auth_admins_object_id" {
+  type        = string
+  description = "Object Id of the Entra group for Auth & Identity admins"
+}
+
+variable "azure_user_assigned_identity_auth_infra_cd" {
+  type        = string
+  description = "Principal Id of the User Assigned Identity for Auth Infra CD"
+}
+
 variable "azure_adgroup_bonus_admins_object_id" {
   type        = string
   description = "Object Id of the Entra group for subscription admins"

--- a/src/common/prod/italynorth.tf
+++ b/src/common/prod/italynorth.tf
@@ -101,7 +101,10 @@ module "platform_api_gateway_apim_itn" {
 
   azure_adgroup_platform_admins_object_id = data.azuread_group.platform_admins.object_id
   azure_adgroup_bonus_admins_object_id    = data.azuread_group.bonus_admins.object_id
+  azure_adgroup_auth_admins_object_id   = data.azuread_group.auth_admins.object_id
 
+
+  azure_user_assigned_identity_auth_infra_cd = data.azurerm_user_assigned_identity.auth_n_identity_infra_cd.principal_id
   azure_user_assigned_identity_bonus_infra_cd = data.azurerm_user_assigned_identity.bonus_infra_cd.principal_id
 
   tags = local.tags

--- a/src/common/prod/italynorth.tf
+++ b/src/common/prod/italynorth.tf
@@ -101,10 +101,10 @@ module "platform_api_gateway_apim_itn" {
 
   azure_adgroup_platform_admins_object_id = data.azuread_group.platform_admins.object_id
   azure_adgroup_bonus_admins_object_id    = data.azuread_group.bonus_admins.object_id
-  azure_adgroup_auth_admins_object_id   = data.azuread_group.auth_admins.object_id
+  azure_adgroup_auth_admins_object_id     = data.azuread_group.auth_admins.object_id
 
 
-  azure_user_assigned_identity_auth_infra_cd = data.azurerm_user_assigned_identity.auth_n_identity_infra_cd.principal_id
+  azure_user_assigned_identity_auth_infra_cd  = data.azurerm_user_assigned_identity.auth_n_identity_infra_cd.principal_id
   azure_user_assigned_identity_bonus_infra_cd = data.azurerm_user_assigned_identity.bonus_infra_cd.principal_id
 
   tags = local.tags

--- a/src/common/prod/tfmodules.lock.json
+++ b/src/common/prod/tfmodules.lock.json
@@ -84,10 +84,10 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/0.1.3"
   },
   "github_runner_itn.container_app_github_runner": {
-    "hash": "a6c1125496888723daa6871b07c7b315548cac6dcc22b28bd67f758df6f01e3c",
-    "version": "1.0.10",
+    "hash": "faa85913e464fe631d12d4413d35862ce6d7ff510bfa1b5b7b064c1d8ee77766",
+    "version": "1.1.0",
     "name": "github_selfhosted_runner_on_container_app_jobs",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm/1.0.10"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm/1.1.0"
   },
   "storage_accounts.exportdata_weu_01_com_admins": {
     "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
@@ -155,13 +155,7 @@
     "name": "azure_role_assignments",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
-  "platform_api_gateway_apim_itn.iam_adgroup_auth_admins": {
-    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
-    "version": "1.1.2",
-    "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
-  },
-  "platform_api_gateway_apim_itn.iam_adgroup_auth_infra_cd": {
+  "platform_api_gateway_apim_itn.iam_adgroup": {
     "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
     "version": "1.1.2",
     "name": "azure_role_assignments",

--- a/src/common/prod/tfmodules.lock.json
+++ b/src/common/prod/tfmodules.lock.json
@@ -125,12 +125,6 @@
     "name": "azure_role_assignments",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
-  "platform_api_gateway_apim_itn.iam_adgroup_product_admins": {
-    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
-    "version": "1.1.2",
-    "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
-  },
   "platform_api_gateway_apim_itn.platform_api_gateway": {
     "hash": "7c4ede49c7e6ebd45b656abca088b846d0e417d3e8e9b700464c7acaefbe5d04",
     "version": "1.2.2",
@@ -138,22 +132,10 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-api-management/azurerm/1.2.2"
   },
   "platform_service_bus_namespace_itn.platform_service_bus_namespace": {
-    "hash": "dfda67c934af2fbd12cdb260a0cf3b754c599b1237b708cae8082aa81d53b583",
-    "version": "0.0.3",
+    "hash": "0089b5c107289e4498ee85ff45ce6504528a8de857ad7ba6372c4bec25ccd7d4",
+    "version": "0.0.4",
     "name": "azure_service_bus_namespace",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-service-bus-namespace/azurerm/0.0.3"
-  },
-  "platform_api_gateway_apim_itn.iam_adgroup_bonus_admins": {
-    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
-    "version": "1.1.2",
-    "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
-  },
-  "platform_api_gateway_apim_itn.iam_adgroup_bonus_infra_cd": {
-    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
-    "version": "1.1.2",
-    "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-service-bus-namespace/azurerm/0.0.4"
   },
   "platform_api_gateway_apim_itn.iam_adgroup": {
     "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",

--- a/src/common/prod/tfmodules.lock.json
+++ b/src/common/prod/tfmodules.lock.json
@@ -89,36 +89,6 @@
     "name": "github_selfhosted_runner_on_container_app_jobs",
     "source": "https://registry.terraform.io/modules/pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm/1.0.10"
   },
-  "platform_api_gateway_apim_itn.iam_adgroup_bonus_admins": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
-    "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
-  },
-  "platform_api_gateway_apim_itn.iam_adgroup_bonus_infra_cd": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
-    "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
-  },
-  "platform_api_gateway_apim_itn.iam_adgroup_product_admins": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
-    "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
-  },
-  "platform_api_gateway_apim_itn.platform_api_gateway": {
-    "hash": "7c4ede49c7e6ebd45b656abca088b846d0e417d3e8e9b700464c7acaefbe5d04",
-    "version": "1.2.2",
-    "name": "azure_api_management",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-api-management/azurerm/1.2.2"
-  },
-  "platform_service_bus_namespace_itn.platform_service_bus_namespace": {
-    "hash": "dfda67c934af2fbd12cdb260a0cf3b754c599b1237b708cae8082aa81d53b583",
-    "version": "0.0.3",
-    "name": "azure_service_bus_namespace",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-service-bus-namespace/azurerm/0.0.3"
-  },
   "storage_accounts.exportdata_weu_01_com_admins": {
     "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
     "version": "1.1.1",
@@ -150,6 +120,48 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
   },
   "storage_accounts_itn.retirements_itn_01_admins": {
+    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
+    "version": "1.1.1",
+    "name": "azure_role_assignments",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+  },
+  "platform_api_gateway_apim_itn.iam_adgroup_product_admins": {
+    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
+    "version": "1.1.1",
+    "name": "azure_role_assignments",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+  },
+  "platform_api_gateway_apim_itn.platform_api_gateway": {
+    "hash": "7c4ede49c7e6ebd45b656abca088b846d0e417d3e8e9b700464c7acaefbe5d04",
+    "version": "1.2.2",
+    "name": "azure_api_management",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-api-management/azurerm/1.2.2"
+  },
+  "platform_service_bus_namespace_itn.platform_service_bus_namespace": {
+    "hash": "dfda67c934af2fbd12cdb260a0cf3b754c599b1237b708cae8082aa81d53b583",
+    "version": "0.0.3",
+    "name": "azure_service_bus_namespace",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-service-bus-namespace/azurerm/0.0.3"
+  },
+  "platform_api_gateway_apim_itn.iam_adgroup_bonus_admins": {
+    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
+    "version": "1.1.1",
+    "name": "azure_role_assignments",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+  },
+  "platform_api_gateway_apim_itn.iam_adgroup_bonus_infra_cd": {
+    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
+    "version": "1.1.1",
+    "name": "azure_role_assignments",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+  },
+  "platform_api_gateway_apim_itn.iam_adgroup_auth_admins": {
+    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
+    "version": "1.1.1",
+    "name": "azure_role_assignments",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+  },
+  "platform_api_gateway_apim_itn.iam_adgroup_auth_infra_cd": {
     "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
     "version": "1.1.1",
     "name": "azure_role_assignments",

--- a/src/common/prod/tfmodules.lock.json
+++ b/src/common/prod/tfmodules.lock.json
@@ -90,46 +90,46 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm/1.0.10"
   },
   "storage_accounts.exportdata_weu_01_com_admins": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
     "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
   "storage_accounts.exportdata_weu_01_com_devs": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
     "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
   "storage_accounts.retirements_itn_01_admins": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
     "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
   "storage_accounts_itn.exportdata_weu_01_com_admins": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
     "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
   "storage_accounts_itn.exportdata_weu_01_com_devs": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
     "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
   "storage_accounts_itn.retirements_itn_01_admins": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
     "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
   "platform_api_gateway_apim_itn.iam_adgroup_product_admins": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
     "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
   "platform_api_gateway_apim_itn.platform_api_gateway": {
     "hash": "7c4ede49c7e6ebd45b656abca088b846d0e417d3e8e9b700464c7acaefbe5d04",
@@ -144,27 +144,27 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-service-bus-namespace/azurerm/0.0.3"
   },
   "platform_api_gateway_apim_itn.iam_adgroup_bonus_admins": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
     "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
   "platform_api_gateway_apim_itn.iam_adgroup_bonus_infra_cd": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
     "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
   "platform_api_gateway_apim_itn.iam_adgroup_auth_admins": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
     "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   },
   "platform_api_gateway_apim_itn.iam_adgroup_auth_infra_cd": {
-    "hash": "b2cac5b9d354adabbef1e0404691e8cbda83fde6e16fd9a2ececd03d9278b119",
-    "version": "1.1.1",
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
     "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   }
 }

--- a/src/common/prod/westeurope.tf
+++ b/src/common/prod/westeurope.tf
@@ -315,8 +315,8 @@ module "application_gateway_weu" {
   }
 
   cidr_subnet           = ["10.0.13.0/24"]
-  min_capacity          = 3 # 4 capacity=baseline, 10 capacity=high volume event, 15 capacity=very high volume event
-  max_capacity          = 20
+  min_capacity          = 1 # 4 capacity=baseline, 10 capacity=high volume event, 15 capacity=very high volume event
+  max_capacity          = 10
   alerts_enabled        = true
   deny_paths            = ["\\/admin\\/(.*)"]
   error_action_group_id = module.monitoring_weu.action_groups.error


### PR DESCRIPTION
Add a new API Product to the Platform proxy for domain `auth and identity`.
Define a new API Group with the API definined into `io-backend` for the `auth and identity` domain.
Add routing for the API into the Application Gateway.
Add RBAC for Auth & Identity team admin group and CD identity to the proxy.