### PR TITLE
add roles to read certificates from new ioweb kv

### DIFF
--- a/src/common/_modules/app_gateway/data.tf
+++ b/src/common/_modules/app_gateway/data.tf
@@ -70,8 +70,8 @@ data "azurerm_key_vault_certificate" "app_gw_api_app" {
 # Key Vault where the certificate for api-web domain is located
 ###
 data "azurerm_key_vault" "ioweb_kv" {
-  name                = format("%s-ioweb-kv", var.project_legacy)
-  resource_group_name = format("%s-ioweb-sec-rg", var.project_legacy)
+  name                = format("%s-ioweb-kv-01", var.project)
+  resource_group_name = format("%s-auth-main-rg-01", var.project)
 }
 
 data "azurerm_key_vault_certificate" "app_gw_api_web" {

--- a/src/common/_modules/app_gateway/rbac.tf
+++ b/src/common/_modules/app_gateway/rbac.tf
@@ -35,3 +35,23 @@ resource "azurerm_key_vault_access_policy" "app_gateway_policy_ioweb" {
   certificate_permissions = ["Get", "List"]
   storage_permissions     = []
 }
+
+module "app_gw_ioweb_kv" {
+  source  = "pagopa-dx/azure-role-assignments/azurerm"
+  version = "~> 1.1"
+
+  subscription_id = var.subscription_id
+  principal_id    = azurerm_user_assigned_identity.appgateway.principal_id
+
+  key_vault = [
+    {
+      name                = var.ioweb_kv.name
+      resource_group_name = var.ioweb_kv.resource_group_name
+      has_rbac_support    = true
+      description         = "Allow certificate read access to the Application Gateway identity on the IOWeb Key Vault"
+      roles = {
+        certificates = "reader"
+      }
+    }
+  ]
+}

--- a/src/common/_modules/app_gateway/variables.tf
+++ b/src/common/_modules/app_gateway/variables.tf
@@ -126,3 +126,16 @@ variable "error_action_group_id" {
   type        = string
   description = "Azure Monitor error action group id"
 }
+
+variable "subscription_id" {
+  type        = string
+  description = "Id of the current subscription"
+}
+
+variable "ioweb_kv" {
+  type = object({
+    name                = string
+    resource_group_name = string
+  })
+  description = "IO-Web Key Vault used to store certificates"
+}

--- a/src/common/_modules/application_gateway/data.tf
+++ b/src/common/_modules/application_gateway/data.tf
@@ -70,8 +70,8 @@ data "azurerm_key_vault_certificate" "app_gw_api_app" {
 # kv where the certificate for api-web domain is located
 ###
 data "azurerm_key_vault" "ioweb_kv" {
-  name                = format("%s-ioweb-kv", var.project)
-  resource_group_name = format("%s-ioweb-sec-rg", var.project)
+  name                = format("%s-ioweb-kv-01", var.project)
+  resource_group_name = format("%s-auth-main-rg-01", var.project)
 }
 
 data "azurerm_key_vault_certificate" "app_gw_api_web" {

--- a/src/common/_modules/application_gateway/rbac.tf
+++ b/src/common/_modules/application_gateway/rbac.tf
@@ -36,3 +36,25 @@ resource "azurerm_key_vault_access_policy" "app_gateway_policy_ioweb" {
   certificate_permissions = ["Get", "List"]
   storage_permissions     = []
 }
+
+//TODO: add permissions (RBAC) to new IOWEB KV
+
+module "app_gw_ioweb_kv" {
+  source  = "pagopa-dx/azure-role-assignments/azurerm"
+  version = "~> 1.1"
+
+  subscription_id = var.subscription_id
+  principal_id    = azurerm_user_assigned_identity.appgateway.principal_id
+
+  key_vault = [
+    {
+      name                = var.ioweb_kv.name
+      resource_group_name = var.ioweb_kv.resource_group_name
+      has_rbac_support    = true
+      description         = "Allow certificate read access to the Application Gateway identity on the IOWeb Key Vault"
+      roles = {
+        certificates = "reader"
+      }
+    }
+  ]
+}

--- a/src/common/_modules/application_gateway/variables.tf
+++ b/src/common/_modules/application_gateway/variables.tf
@@ -128,3 +128,16 @@ variable "error_action_group_id" {
   type        = string
   description = "Azure Monitor error action group id"
 }
+
+variable "subscription_id" {
+  type        = string
+  description = "Id of the current subscription"
+}
+
+variable "ioweb_kv" {
+  type = object({
+    name                = string
+    resource_group_name = string
+  })
+  description = "IO-Web Key Vault used to store certificates"
+}

--- a/src/common/prod/README.md
+++ b/src/common/prod/README.md
@@ -59,6 +59,7 @@
 | [azuread_service_principal.apim_client_svc](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
 | [azuread_service_principal.dev_portal_svc](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_key_vault.ioweb_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_linux_function_app.com_citizen_func](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
 | [azurerm_linux_function_app.eucovidcert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
 | [azurerm_linux_function_app.function_assets_cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |

--- a/src/common/prod/data.tf
+++ b/src/common/prod/data.tf
@@ -167,3 +167,10 @@ data "azurerm_subnet" "itn_msgs_sending_func_snet" {
   resource_group_name  = local.core.networking.itn.vnet_common.resource_group_name
   virtual_network_name = local.core.networking.itn.vnet_common.name
 }
+
+# Key Vaults
+
+data "azurerm_key_vault" "ioweb_kv" {
+  name                = "${local.project_itn}-ioweb-kv-01"
+  resource_group_name = "${local.project_itn}-auth-main-rg-01"
+}

--- a/src/common/prod/italynorth.tf
+++ b/src/common/prod/italynorth.tf
@@ -110,7 +110,6 @@ module "platform_api_gateway_apim_itn" {
   tags = local.tags
 }
 
-
 module "platform_service_bus_namespace_itn" {
   // private DNS zone dependency
   depends_on = [module.global]
@@ -160,6 +159,8 @@ module "application_gateway_itn" {
   prefix                = local.prefix
   resource_group_common = local.core.resource_groups.italynorth.common
 
+  subscription_id = data.azurerm_subscription.current.subscription_id
+
   datasources = {
     azurerm_client_config = data.azurerm_client_config.current
   }
@@ -200,6 +201,11 @@ module "application_gateway_itn" {
   alerts_enabled        = true
   deny_paths            = ["\\/admin\\/(.*)"]
   error_action_group_id = module.monitoring_weu.action_groups.error
+
+  ioweb_kv = {
+    name                = data.azurerm_key_vault.ioweb_kv.name
+    resource_group_name = data.azurerm_key_vault.ioweb_kv.resource_group_name
+  }
 
   tags = local.tags
 }

--- a/src/common/prod/tfmodules.lock.json
+++ b/src/common/prod/tfmodules.lock.json
@@ -142,5 +142,17 @@
     "version": "1.1.2",
     "name": "azure_role_assignments",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
+  },
+  "application_gateway_itn.app_gw_ioweb_kv": {
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
+    "name": "azure_role_assignments",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
+  },
+  "application_gateway_weu.app_gw_ioweb_kv": {
+    "hash": "433fe44b2863b8af8d4f4206ee2590599b0cb67d78b372e65d68317d3199aaa1",
+    "version": "1.1.2",
+    "name": "azure_role_assignments",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.1.2"
   }
 }

--- a/src/common/prod/westeurope.tf
+++ b/src/common/prod/westeurope.tf
@@ -282,6 +282,8 @@ module "application_gateway_weu" {
   resource_group_security = local.core.resource_groups.westeurope.sec
   resource_group_common   = local.core.resource_groups.westeurope.common
 
+  subscription_id = data.azurerm_subscription.current.subscription_id
+
   datasources = {
     azurerm_client_config = data.azurerm_client_config.current
   }
@@ -320,6 +322,11 @@ module "application_gateway_weu" {
   alerts_enabled        = true
   deny_paths            = ["\\/admin\\/(.*)"]
   error_action_group_id = module.monitoring_weu.action_groups.error
+
+  ioweb_kv = {
+    name                = data.azurerm_key_vault.ioweb_kv.name
+    resource_group_name = data.azurerm_key_vault.ioweb_kv.resource_group_name
+  }
 
   tags = local.tags
 }


### PR DESCRIPTION
Close CES-1138

As the target KV is set to use RBAC authentication, the following manual steps should be executed after applying this PR:

```pwsh
# Get the Application Gateway we want to modify
$appgw = Get-AzApplicationGateway -Name io-p-itn-agw-01 -ResourceGroupName io-p-itn-common-rg-01
```

For **each** certificate:
```pwsh
# Get the secret ID from Key Vault
$secret = Get-AzKeyVaultSecret -VaultName "io-p-itn-ioweb-kv-01" -Name "CertificateName"

# Remove the secret version so Application Gateway uses the latest version in future syncs
$secretId = $secret.Id.Replace($secret.Version, "")

# Specify the secret ID from Key Vault 
Add-AzApplicationGatewaySslCertificate -KeyVaultSecretId $secretId -ApplicationGateway $appgw -Name $secret.Name

# Commit the changes to the Application Gateway
Set-AzApplicationGateway -ApplicationGateway $appgw
```