### PR TITLE
Switch profiles-to-sanitize queue to new ITN auth maintenance storage

### DIFF
--- a/src/domains/functions/README.md
+++ b/src/domains/functions/README.md
@@ -89,6 +89,7 @@
 | [azurerm_private_dns_zone.privatelink_queue_core](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.privatelink_table_core](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_storage_account.assets_cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
+| [azurerm_storage_account.auth_maintenance_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.citizen_auth_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.ioweb_spid_logs_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.locked_profiles_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |

--- a/src/domains/functions/data.tf
+++ b/src/domains/functions/data.tf
@@ -115,7 +115,7 @@ data "azurerm_key_vault_secret" "common_MAILUP_SECRET" {
 # UNIQUE EMAIL ENFORCEMENT
 #
 # TODO: Remove when switch to new itn storage account is done
-# This is used only in fn-admin for profile-to-sanitize queue
+
 data "azurerm_storage_account" "citizen_auth_common" {
   name                = "iopweucitizenauthst"
   resource_group_name = "io-p-citizen-auth-data-rg"

--- a/src/domains/functions/data.tf
+++ b/src/domains/functions/data.tf
@@ -114,11 +114,18 @@ data "azurerm_key_vault_secret" "common_MAILUP_SECRET" {
 #
 # UNIQUE EMAIL ENFORCEMENT
 #
-
+# TODO: Remove when switch to new itn storage account is done
+# This is used only in fn-admin for profile-to-sanitize queue
 data "azurerm_storage_account" "citizen_auth_common" {
   name                = "iopweucitizenauthst"
   resource_group_name = "io-p-citizen-auth-data-rg"
 }
+
+data "azurerm_storage_account" "auth_maintenance_storage" {
+  name                = replace(format("%s-itn-auth-mnt-st-01", local.project), "-", "")
+  resource_group_name = format("%s-itn-auth-main-rg-01", local.project)
+}
+
 
 #
 # Notifications resources

--- a/src/domains/functions/function_admin.tf
+++ b/src/domains/functions/function_admin.tf
@@ -143,8 +143,8 @@ locals {
       MAILUP_SECRET                = data.azurerm_key_vault_secret.common_MAILUP_SECRET.value
 
       # UNIQUE EMAIL ENFORCEMENT
-      CitizenAuthStorageConnection = data.azurerm_storage_account.citizen_auth_common.primary_connection_string
-      SanitizeUserProfileQueueName = "profiles-to-sanitize"
+      CitizenAuthStorageConnection = data.azurerm_storage_account.auth_maintenance_storage.primary_connection_string
+      SanitizeUserProfileQueueName = "profiles-to-sanitize-01"
 
       # Locked Profile Storage
       LOCKED_PROFILES_STORAGE_CONNECTION_STRING = data.azurerm_storage_account.locked_profiles_storage.primary_connection_string


### PR DESCRIPTION
Switch source queue for fn-admin/SanitizeProfileEmail to the newly created in `iopitnauthmntst01` ITN Storage