### PR TITLE
[IOPAE-2161] Increase activations and services Cosmos container RU

### DIFF
--- a/src/common/_modules/cosmos_api/locals.tf
+++ b/src/common/_modules/cosmos_api/locals.tf
@@ -6,7 +6,7 @@ locals {
       partition_key_path    = "/fiscalCode"
       partition_key_version = null
       autoscale_settings = {
-        max_throughput = 1000
+        max_throughput = 5000
       }
     },
     {
@@ -143,7 +143,7 @@ locals {
       partition_key_path    = "/serviceId"
       partition_key_version = null
       autoscale_settings = {
-        max_throughput = 15000
+        max_throughput = 45000
       }
     },
     {


### PR DESCRIPTION
Following first load tests for _"Bonus Elettrodomestici"_ initiative, this PR increase RU on `activations` and `services` _Cosmos_ containers.