### PR TITLE
[#IOPLT-1347]add lifecycle management rule on iopitnfuncsvcst01 storage

### DIFF
--- a/src/common/_modules/cosmos_api/locals.tf
+++ b/src/common/_modules/cosmos_api/locals.tf
@@ -89,7 +89,7 @@ locals {
       partition_key_version = null
 
       autoscale_settings = {
-        max_throughput = 13000
+        max_throughput = 14000
       }
     },
     {
@@ -156,7 +156,7 @@ locals {
       partition_key_path    = "/fiscalCode"
       partition_key_version = null
       autoscale_settings = {
-        max_throughput = 2000
+        max_throughput = 4000
       }
     },
     {

--- a/src/common/_modules/function_services/function-app/storage-account.tf
+++ b/src/common/_modules/function_services/function-app/storage-account.tf
@@ -27,6 +27,24 @@ module "services_storage_account" {
   tags = var.tags
 }
 
+resource "azurerm_storage_management_policy" "processing_messages_container_rule" {
+  storage_account_id = module.services_storage_account.id
+
+  rule {
+    name    = "deleteafterdays"
+    enabled = true
+    filters {
+      prefix_match = ["processing-messages"]
+      blob_types   = ["blockBlob"]
+    }
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = 1
+      }
+    }
+  }
+}
+
 
 
 ################################

--- a/src/common/_modules/function_services/function-app/storage-account.tf
+++ b/src/common/_modules/function_services/function-app/storage-account.tf
@@ -39,7 +39,13 @@ resource "azurerm_storage_management_policy" "processing_messages_container_rule
     }
     actions {
       base_blob {
-        delete_after_days_since_modification_greater_than = 1
+        delete_after_days_since_creation_greater_than = 1
+      }
+      snapshot {
+        delete_after_days_since_creation_greater_than = 1
+      }
+      version {
+        delete_after_days_since_creation = 1
       }
     }
   }


### PR DESCRIPTION
needed to match configuration of `iopservicesfn1sdt` after migrating to itn 