### PR TITLE
[#IOPLT-1353] Scaleup appbackend to P2V3 and enable PM2

### DIFF
--- a/src/common/_modules/app_backend/locals.tf
+++ b/src/common/_modules/app_backend/locals.tf
@@ -3,7 +3,7 @@
 locals {
   name = var.name
 
-  app_command_line = "npm run start"
+  app_command_line = "pm2 start dist/src/server.js -i max --no-daemon"
 
   webtest = {
     path        = "/info",

--- a/src/common/prod/westeurope.tf
+++ b/src/common/prod/westeurope.tf
@@ -429,6 +429,8 @@ module "app_backend_weu" {
   slot_allowed_ips              = module.monitoring_weu.appi.reserved_ips
   enable_premium_plan_autoscale = true
 
+  plan_sku = "P2v3"
+
   backend_hostnames = local.backend_hostnames
 
   key_vault        = local.core.key_vault.weu.kv


### PR DESCRIPTION
Scaleup all `appbackend` plans to `P2V3` after load test results.
Enable `PM2` startup command for all `appbackend`.