### PR TITLE
Scale up autoscale max throughput property of cosmos

### DIFF
--- a/src/common/_modules/cosmos_api/locals.tf
+++ b/src/common/_modules/cosmos_api/locals.tf
@@ -6,7 +6,7 @@ locals {
       partition_key_path    = "/fiscalCode"
       partition_key_version = null
       autoscale_settings = {
-        max_throughput = 5000
+        max_throughput = 10000
       }
     },
     {


### PR DESCRIPTION
Scale up autoscale max throughput property of cosmos (container = activations)

Resolves IOPAE-2193