### PR TITLE
IOPLT-1746 - Switch assets.cdn.io.italia.it and assets.cdn.io.pagopa.it to new ITN assets CDN 

### DIFF
--- a/src/common/_modules/assets_cdn/custom_domains.tf
+++ b/src/common/_modules/assets_cdn/custom_domains.tf
@@ -1,17 +1,6 @@
-
 resource "azurerm_dns_cname_record" "assets_cdn_io_pagopa_it" {
   name                = "assets.cdn"
   zone_name           = var.public_dns_zones.io.name
-  resource_group_name = var.resource_group_external
-  ttl                 = var.dns_default_ttl_sec
-  record              = "redirect.assets.cdn.io.pagopa.it" # Switched to temporary AGW
-
-  tags = var.tags
-}
-
-resource "azurerm_dns_cname_record" "assets_cdn_io_italia_it" {
-  name                = "assets.cdn"
-  zone_name           = var.public_dns_zones.io_italia_it.name
   resource_group_name = var.resource_group_external
   ttl                 = var.dns_default_ttl_sec
   record              = "redirect.assets.cdn.io.pagopa.it" # Switched to temporary AGW

--- a/src/common/_modules/assets_cdn/custom_domains.tf
+++ b/src/common/_modules/assets_cdn/custom_domains.tf
@@ -1,9 +1,0 @@
-resource "azurerm_dns_cname_record" "assets_cdn_io_pagopa_it" {
-  name                = "assets.cdn"
-  zone_name           = var.public_dns_zones.io.name
-  resource_group_name = var.resource_group_external
-  ttl                 = var.dns_default_ttl_sec
-  record              = "redirect.assets.cdn.io.pagopa.it" # Switched to temporary AGW
-
-  tags = var.tags
-}

--- a/src/common/_modules/assets_locales_cdn/main.tf
+++ b/src/common/_modules/assets_locales_cdn/main.tf
@@ -27,6 +27,10 @@ module "azure_cdn" {
     },
     {
       host_name = "assets.cdn.io.pagopa.it"
+      dns = {
+        zone_name                = var.public_dns_zones.io.name
+        zone_resource_group_name = var.resource_group_external
+      }
     },
     {
       host_name = "assets.cdn.io.italia.it"

--- a/src/common/_modules/assets_locales_cdn/main.tf
+++ b/src/common/_modules/assets_locales_cdn/main.tf
@@ -30,6 +30,10 @@ module "azure_cdn" {
     },
     {
       host_name = "assets.cdn.io.italia.it"
+      dns = {
+        zone_name                = var.public_dns_zones.io_italia_it.name
+        zone_resource_group_name = var.resource_group_external
+      }
     }
   ]
 

--- a/src/common/prod/italynorth.tf
+++ b/src/common/prod/italynorth.tf
@@ -602,3 +602,11 @@ moved {
   from = module.assets_cdn_weu.azurerm_dns_cname_record.assets_cdn_io_italia_it
   to   = module.assets_locales_cdn.module.azure_cdn.azurerm_dns_cname_record.this["assets.cdn.io.italia.it"]
 }
+import {
+  to = module.assets_locales_cdn.module.azure_cdn.azurerm_dns_txt_record.validation["assets.cdn.io.pagopa.it"]
+  id = "/subscriptions/ec285037-c673-4f58-b594-d7c480da4e8b/resourceGroups/io-p-rg-external/providers/Microsoft.Network/dnsZones/io.pagopa.it/TXT/_dnsauth.assets.cdn"
+}
+moved {
+  from = module.assets_cdn_weu.azurerm_dns_cname_record.assets_cdn_io_pagopa_it
+  to   = module.assets_locales_cdn.module.azure_cdn.azurerm_dns_cname_record.this["assets.cdn.io.pagopa.it"]
+}

--- a/src/common/prod/italynorth.tf
+++ b/src/common/prod/italynorth.tf
@@ -595,6 +595,10 @@ module "application_gateway_assets_temporary" {
 }
 
 import {
-  to = module.application_gateway_assets_temporary.azurerm_dns_a_record.public_ip_a_record
-  id = "/subscriptions/ec285037-c673-4f58-b594-d7c480da4e8b/resourceGroups/io-p-rg-external/providers/Microsoft.Network/dnsZones/io.pagopa.it/A/redirect.assets.cdn"
+  to = module.assets_locales_cdn.module.azure_cdn.azurerm_dns_txt_record.validation["assets.cdn.io.italia.it"]
+  id = "/subscriptions/ec285037-c673-4f58-b594-d7c480da4e8b/resourceGroups/io-p-rg-external/providers/Microsoft.Network/dnsZones/io.italia.it/A/assets.cdn"
+}
+moved {
+  from = module.assets_cdn_weu.azurerm_dns_cname_record.assets_cdn_io_italia_it
+  to   = module.assets_locales_cdn.module.azure_cdn.azurerm_dns_cname_record.this["assets.cdn.io.italia.it"]
 }

--- a/src/common/prod/italynorth.tf
+++ b/src/common/prod/italynorth.tf
@@ -596,7 +596,7 @@ module "application_gateway_assets_temporary" {
 
 import {
   to = module.assets_locales_cdn.module.azure_cdn.azurerm_dns_txt_record.validation["assets.cdn.io.italia.it"]
-  id = "/subscriptions/ec285037-c673-4f58-b594-d7c480da4e8b/resourceGroups/io-p-rg-external/providers/Microsoft.Network/dnsZones/io.italia.it/A/assets.cdn"
+  id = "/subscriptions/ec285037-c673-4f58-b594-d7c480da4e8b/resourceGroups/io-p-rg-external/providers/Microsoft.Network/dnsZones/io.italia.it/TXT/_dnsauth.assets.cdn"
 }
 moved {
   from = module.assets_cdn_weu.azurerm_dns_cname_record.assets_cdn_io_italia_it


### PR DESCRIPTION
Switch `assets.cdn.io.italia.it` and `assets.cdn.io.pagopa.it` to the new ITN assets CDN