### PR TITLE
IOPLT-1748 - Remove not destroyable resources from common terraform state

### DIFF
--- a/src/common/prod/italynorth.tf
+++ b/src/common/prod/italynorth.tf
@@ -573,3 +573,17 @@ module "assets_locales_cdn" {
 
   tags = local.tags
 }
+
+removed {
+  from = module.application_gateway_assets_temporary.azurerm_dns_a_record.public_ip_a_record
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.application_gateway_assets_temporary.azurerm_public_ip.agw
+  lifecycle {
+    destroy = false
+  }
+}


### PR DESCRIPTION
Remove `module.application_gateway_assets_temporary.azurerm_dns_a_record.public_ip_a_record` and `module.application_gateway_assets_temporary.azurerm_public_ip.agw` from the `common` terraform state, they will be deleted along with the Microsoft support since they are locked and no visible locks are present.