### PR TITLE
IOPLT-1799 - Remove stale references to fn assets and assets rg from common

### DIFF
--- a/src/common/_modules/app_backend/variables.tf
+++ b/src/common/_modules/app_backend/variables.tf
@@ -182,7 +182,6 @@ variable "backend_hostnames" {
   type = object({
     app                  = list(string)
     com_citizen_func     = string
-    assets_cdn           = string
     services_app_backend = string
     lollipop             = string
     cgn                  = string

--- a/src/common/_modules/function_admin/local.tf
+++ b/src/common/_modules/function_admin/local.tf
@@ -1,9 +1,8 @@
 locals {
-  project            = "${var.prefix}-${var.env_short}"
-  vnet_common_name   = format("%s-vnet-common", local.project)
-  rg_common_name     = format("%s-rg-common", local.project)
-  rg_internal_name   = format("%s-rg-internal", local.project)
-  rg_assets_cdn_name = format("%s-assets-cdn-rg", local.project)
+  project          = "${var.prefix}-${var.env_short}"
+  vnet_common_name = format("%s-vnet-common", local.project)
+  rg_common_name   = format("%s-rg-common", local.project)
+  rg_internal_name = format("%s-rg-internal", local.project)
 
   apim_itn_name                  = "${var.project_itn}-apim-01"
   common_resource_group_name_itn = "${var.project_itn}-common-rg-01"

--- a/src/common/_modules/function_admin/storage-account.tf
+++ b/src/common/_modules/function_admin/storage-account.tf
@@ -29,7 +29,7 @@ module "function_admin_storage_account" {
 
 module "user_data_backups_storage_account" {
   source  = "pagopa-dx/azure-storage-account/azurerm"
-  version = "~> 2.1"
+  version = "~> 2.0"
 
   environment = {
     prefix          = var.prefix

--- a/src/common/_modules/function_admin/storage-account.tf
+++ b/src/common/_modules/function_admin/storage-account.tf
@@ -29,7 +29,7 @@ module "function_admin_storage_account" {
 
 module "user_data_backups_storage_account" {
   source  = "pagopa-dx/azure-storage-account/azurerm"
-  version = "~> 2.0"
+  version = "~> 2.1"
 
   environment = {
     prefix          = var.prefix

--- a/src/common/_modules/function_services/function-app/local.tf
+++ b/src/common/_modules/function_services/function-app/local.tf
@@ -1,9 +1,8 @@
 locals {
-  project            = "${var.prefix}-${var.env_short}"
-  vnet_common_name   = format("%s-vnet-common", local.project)
-  rg_common_name     = format("%s-rg-common", local.project)
-  rg_internal_name   = format("%s-rg-internal", local.project)
-  rg_assets_cdn_name = format("%s-assets-cdn-rg", local.project)
+  project          = "${var.prefix}-${var.env_short}"
+  vnet_common_name = format("%s-vnet-common", local.project)
+  rg_common_name   = format("%s-rg-common", local.project)
+  rg_internal_name = format("%s-rg-internal", local.project)
 
   apim_itn_name = "${local.project}-${var.location_itn}-apim-01"
 }

--- a/src/common/prod/README.md
+++ b/src/common/prod/README.md
@@ -74,7 +74,6 @@
 | [azurerm_key_vault.ioweb_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault.itn_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_linux_function_app.com_citizen_func](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
-| [azurerm_linux_function_app.function_assets_cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
 | [azurerm_linux_function_app.function_profile](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
 | [azurerm_linux_function_app.io_fims_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
 | [azurerm_linux_function_app.io_sign_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) | data source |
@@ -102,7 +101,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_apim"></a> [apim](#output\_apim) | n/a |
 | <a name="output_pep_subnets"></a> [pep\_subnets](#output\_pep\_subnets) | n/a |
 | <a name="output_private_endpoints"></a> [private\_endpoints](#output\_private\_endpoints) | n/a |

--- a/src/common/prod/README.md
+++ b/src/common/prod/README.md
@@ -101,7 +101,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_apim"></a> [apim](#output\_apim) | n/a |
 | <a name="output_pep_subnets"></a> [pep\_subnets](#output\_pep\_subnets) | n/a |
 | <a name="output_private_endpoints"></a> [private\_endpoints](#output\_private\_endpoints) | n/a |

--- a/src/common/prod/data.tf
+++ b/src/common/prod/data.tf
@@ -111,11 +111,6 @@ data "azurerm_subnet" "cosmos_api_allowed" {
 }
 
 # Functions
-data "azurerm_linux_function_app" "function_assets_cdn" {
-  name                = "${local.project_weu_legacy}-assets-cdn-fn"
-  resource_group_name = "${local.project_weu_legacy}-assets-cdn-rg"
-}
-
 data "azurerm_linux_function_app" "function_profile" {
   name                = "${local.project_itn}-auth-profile-func-02"
   resource_group_name = "${local.project_itn}-auth-main-rg-01"

--- a/src/common/prod/locals.tf
+++ b/src/common/prod/locals.tf
@@ -62,7 +62,6 @@ locals {
   backend_hostnames = {
     app                  = [data.azurerm_linux_function_app.function_profile.default_hostname]
     com_citizen_func     = data.azurerm_linux_function_app.com_citizen_func.default_hostname
-    assets_cdn           = data.azurerm_linux_function_app.function_assets_cdn.default_hostname
     services_app_backend = data.azurerm_linux_function_app.services_app_backend_function_app.default_hostname
     # services_app_backend = data.azurerm_container_app.services_app_backend_function_app.ingress[0].fqdn
     lollipop      = data.azurerm_linux_function_app.lollipop_function.default_hostname
@@ -197,9 +196,8 @@ locals {
   ]
 
   function_services = {
-    rg_common_name     = format("%s-rg-common", local.project_weu_legacy)
-    rg_internal_name   = format("%s-rg-internal", local.project_weu_legacy)
-    rg_assets_cdn_name = format("%s-assets-cdn-rg", local.project_weu_legacy)
+    rg_common_name   = format("%s-rg-common", local.project_weu_legacy)
+    rg_internal_name = format("%s-rg-internal", local.project_weu_legacy)
 
     tags = {
       BusinessUnit = "App IO"

--- a/src/common/prod/tfmodules.lock.json
+++ b/src/common/prod/tfmodules.lock.json
@@ -126,10 +126,10 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-api-management/azurerm/2.2.3"
   },
   "platform_service_bus_namespace_itn.platform_service_bus_namespace": {
-    "hash": "4b551c1ee3c135ce50ee2532143e19a08fc5f8567889b819e0719e22d82d7451",
-    "version": "0.1.0",
+    "hash": "60808badb44a3e7e87db7d39fb7130b26d1d1a68433d247ad2e938d33bb8d245",
+    "version": "0.1.1",
     "name": "azure_service_bus_namespace",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-service-bus-namespace/azurerm/0.1.0"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-service-bus-namespace/azurerm/0.1.1"
   },
   "platform_api_gateway_apim_itn.iam_adgroup": {
     "hash": "a8c1a6fa085349f937017deb20236170f0bb9dd78b5ded85ec75d7caeba7a872",
@@ -156,22 +156,22 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-app-service/azurerm/2.0.1"
   },
   "function_app_admin.function_admin_storage_account": {
-    "hash": "5a369299255aaa17f1dd7222c971889beeb0ad9f729f8483bf1a6a9268bbd845",
-    "version": "2.2.3",
+    "hash": "651e0b9fba699c98f447843346637928ca376af48081fc31807c88c3be933e9d",
+    "version": "2.2.4",
     "name": "azure_storage_account",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/2.2.3"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/2.2.4"
   },
   "function_app_admin.user_data_backups_storage_account": {
-    "hash": "5a369299255aaa17f1dd7222c971889beeb0ad9f729f8483bf1a6a9268bbd845",
-    "version": "2.2.3",
+    "hash": "651e0b9fba699c98f447843346637928ca376af48081fc31807c88c3be933e9d",
+    "version": "2.2.4",
     "name": "azure_storage_account",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/2.2.3"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/2.2.4"
   },
   "function_app_admin.user_data_download_storage_account": {
-    "hash": "5a369299255aaa17f1dd7222c971889beeb0ad9f729f8483bf1a6a9268bbd845",
-    "version": "2.2.3",
+    "hash": "651e0b9fba699c98f447843346637928ca376af48081fc31807c88c3be933e9d",
+    "version": "2.2.4",
     "name": "azure_storage_account",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/2.2.3"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/2.2.4"
   },
   "function_app_admin.function_admin_itn": {
     "hash": "d31ce9fad7a8c180762b175b691cbb3b114c2caf3dca7f28da754c9f9bac20b3",
@@ -186,10 +186,10 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/5.0.2"
   },
   "function_app_elt.storage_account_itn_elt": {
-    "hash": "5a369299255aaa17f1dd7222c971889beeb0ad9f729f8483bf1a6a9268bbd845",
-    "version": "2.2.3",
+    "hash": "651e0b9fba699c98f447843346637928ca376af48081fc31807c88c3be933e9d",
+    "version": "2.2.4",
     "name": "azure_storage_account",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/2.2.3"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/2.2.4"
   },
   "function_app_services_02.function_services": {
     "hash": "d31ce9fad7a8c180762b175b691cbb3b114c2caf3dca7f28da754c9f9bac20b3",


### PR DESCRIPTION
Remove remaining references / data for `function_assets_cdn` and `rg_assets_cdn_name` from `common` since the function and resource groups have been deleted.