### PR TITLE
IOPLT-1812 -Fix custom domain creation and global cache rule for io-p-itn-ioapp-afd-01

### DIFF
--- a/src/platform/cdn/_modules/ioapp/main.tf
+++ b/src/platform/cdn/_modules/ioapp/main.tf
@@ -12,18 +12,20 @@ module "ioapp" {
     }
   }
 
-  custom_domains = [
-    {
-      host_name = "ioapp.it"
-      # TODO: enable dns block / import txt validation records 
-      /*
+  # TODO: enable custom domain once the traffic is switched to a temporary AGW
+
+  #custom_domains = [
+  #  {
+  #    host_name = "ioapp.it"
+  # TODO: enable dns block / import txt validation records 
+  /*
       dns = {
         zone_name                = data.azurerm_dns_zone.ioapp_it.name
         zone_resource_group_name = data.azurerm_resource_group.core_ext.name
       }
       */
-    }
-  ]
+  #  }
+  # ]
 
   diagnostic_settings = {
     enabled                    = true

--- a/src/platform/cdn/_modules/ioapp/rules.tf
+++ b/src/platform/cdn/_modules/ioapp/rules.tf
@@ -19,8 +19,8 @@ resource "azurerm_cdn_frontdoor_rule" "ioapp_global_cache" {
 
   actions {
     route_configuration_override_action {
-      cache_behavior = "OverrideAlways"
-      cache_duration = "00:15:00"
+      query_string_caching_behavior = "OverrideAlways"
+      cache_duration                = "00:15:00"
     }
 
     response_header_action {

--- a/src/platform/cdn/_modules/ioapp/rules.tf
+++ b/src/platform/cdn/_modules/ioapp/rules.tf
@@ -19,8 +19,8 @@ resource "azurerm_cdn_frontdoor_rule" "ioapp_global_cache" {
 
   actions {
     route_configuration_override_action {
-      query_string_caching_behavior = "OverrideAlways"
-      cache_duration                = "00:15:00"
+      cache_behavior = "Override"
+      cache_duration = "00:15:00"
     }
 
     response_header_action {

--- a/src/platform/cdn/_modules/ioapp/rules.tf
+++ b/src/platform/cdn/_modules/ioapp/rules.tf
@@ -19,7 +19,7 @@ resource "azurerm_cdn_frontdoor_rule" "ioapp_global_cache" {
 
   actions {
     route_configuration_override_action {
-      cache_behavior = "Override"
+      cache_behavior = "OverrideAlways"
       cache_duration = "00:15:00"
     }
 


### PR DESCRIPTION
Disable custom domain creation (will be enabled after a temporary AGW has been created) and fix global caching rule for `io-p-itn-ioapp-afd-01`