### PR TITLE
IOPLT-1812 - Fix global caching rule

### DIFF
--- a/src/platform/cdn/_modules/ioapp/rules.tf
+++ b/src/platform/cdn/_modules/ioapp/rules.tf
@@ -19,8 +19,9 @@ resource "azurerm_cdn_frontdoor_rule" "ioapp_global_cache" {
 
   actions {
     route_configuration_override_action {
-      cache_behavior = "OverrideAlways"
-      cache_duration = "00:15:00"
+      cache_behavior                = "OverrideAlways"
+      cache_duration                = "00:15:00"
+      query_string_caching_behavior = "IgnoreQueryString"
     }
 
     response_header_action {


### PR DESCRIPTION
Fix global caching rule for `io-p-itn-ioapp-afd-01` by setting also the `query_string_caching_behavior` attribute, which is required by Azure but wrongly specified as "Optional" on the Terraform docs: 

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule#query_string_caching_behavior-1