### PR TITLE
IOPLT-1797 - Common CDN - Keep io.italia.it custom domain as BYOC

### DIFF
--- a/src/platform/prod/cdn/_modules/common/io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/io_italia_it.tf
@@ -5,7 +5,8 @@ resource "azurerm_cdn_frontdoor_custom_domain" "io_italia_it" {
   host_name                = "io.italia.it"
 
   tls {
-    certificate_type = "ManagedCertificate"
+    certificate_type        = "CustomerCertificate"
+    cdn_frontdoor_secret_id = azurerm_cdn_frontdoor_secret.io_italia_it.id
   }
 }
 
@@ -20,6 +21,20 @@ resource "azurerm_cdn_frontdoor_custom_domain" "io_italia_it_legacy" {
   }
 }
 
+resource "azurerm_cdn_frontdoor_secret" "io_italia_it" {
+  name                     = "MigratedSecret-io-italia-it"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.common.id
+
+  secret {
+    customer_certificate {
+      key_vault_certificate_id = "https://io-p-kv-common.vault.azure.net/certificates/io-italia-it"
+    }
+  }
+}
+
+# TODO: uncomment snippet when switching to managed certificates
+
+/*
 resource "azurerm_dns_txt_record" "io_italia_it" {
   name                = "_dnsauth"
   zone_name           = var.public_dns_zones.io_italia_it.name
@@ -32,6 +47,7 @@ resource "azurerm_dns_txt_record" "io_italia_it" {
 
   tags = var.tags
 }
+*/
 
 resource "azurerm_dns_a_record" "io_italia_it" {
   name                = "@"

--- a/src/platform/prod/cdn/_modules/common/io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/io_italia_it.tf
@@ -5,6 +5,8 @@ resource "azurerm_cdn_frontdoor_custom_domain" "io_italia_it" {
   host_name                = "io.italia.it"
 
   tls {
+    # Cannot switch to ManagedCertificate since the auto rotation with Apex Domains is not fully automated (requires manual domain revalidation):
+    # https://learn.microsoft.com/en-gb/azure/frontdoor/apex-domain?WT.mc_id=Portal-Microsoft_Azure_AFDX#azure-front-door-managed-tls-certificate-rotation
     certificate_type        = "CustomerCertificate"
     cdn_frontdoor_secret_id = azurerm_cdn_frontdoor_secret.io_italia_it.id
   }
@@ -31,23 +33,6 @@ resource "azurerm_cdn_frontdoor_secret" "io_italia_it" {
     }
   }
 }
-
-# TODO: uncomment snippet when switching to managed certificates
-
-/*
-resource "azurerm_dns_txt_record" "io_italia_it" {
-  name                = "_dnsauth"
-  zone_name           = var.public_dns_zones.io_italia_it.name
-  resource_group_name = var.resource_group_external
-  ttl                 = 3600
-
-  record {
-    value = azurerm_cdn_frontdoor_custom_domain.io_italia_it.validation_token
-  }
-
-  tags = var.tags
-}
-*/
 
 resource "azurerm_dns_a_record" "io_italia_it" {
   name                = "@"

--- a/src/platform/prod/cdn/_modules/common/io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/io_italia_it.tf
@@ -29,6 +29,8 @@ resource "azurerm_dns_txt_record" "io_italia_it" {
   record {
     value = azurerm_cdn_frontdoor_custom_domain.io_italia_it.validation_token
   }
+
+  tags = var.tags
 }
 
 resource "azurerm_dns_a_record" "io_italia_it" {

--- a/src/platform/prod/cdn/_modules/common/io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/io_italia_it.tf
@@ -5,8 +5,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "io_italia_it" {
   host_name                = "io.italia.it"
 
   tls {
-    certificate_type        = "CustomerCertificate"
-    cdn_frontdoor_secret_id = azurerm_cdn_frontdoor_secret.io_italia_it.id
+    certificate_type = "ManagedCertificate"
   }
 }
 
@@ -21,20 +20,6 @@ resource "azurerm_cdn_frontdoor_custom_domain" "io_italia_it_legacy" {
   }
 }
 
-resource "azurerm_cdn_frontdoor_secret" "io_italia_it" {
-  name                     = "MigratedSecret-io-italia-it"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.common.id
-
-  secret {
-    customer_certificate {
-      key_vault_certificate_id = "https://io-p-kv-common.vault.azure.net/certificates/io-italia-it"
-    }
-  }
-}
-
-# TODO: uncomment snippet when switching to managed certificates
-
-/*
 resource "azurerm_dns_txt_record" "io_italia_it" {
   name                = "_dnsauth"
   zone_name           = var.public_dns_zones.io_italia_it.name
@@ -45,7 +30,6 @@ resource "azurerm_dns_txt_record" "io_italia_it" {
     value = azurerm_cdn_frontdoor_custom_domain.io_italia_it.validation_token
   }
 }
-*/
 
 resource "azurerm_dns_a_record" "io_italia_it" {
   name                = "@"

--- a/src/platform/prod/cdn/import.tf
+++ b/src/platform/prod/cdn/import.tf
@@ -1,8 +1,3 @@
 # Use this file to import the wanted resources inside the state file, 
 # remember to cleanup the import code blocks with a separate PR once the import has been completed successfully.
 # Here is the documentation which explains how to use the import code block: https://developer.hashicorp.com/terraform/language/block/import
-
-import {
-  to = module.common.azurerm_dns_txt_record.io_italia_it
-  id = "/subscriptions/ec285037-c673-4f58-b594-d7c480da4e8b/resourceGroups/io-p-rg-external/providers/Microsoft.Network/dnsZones/io.italia.it/TXT/_dnsauth"
-}

--- a/src/platform/prod/cdn/import.tf
+++ b/src/platform/prod/cdn/import.tf
@@ -1,7 +1,8 @@
 # Use this file to import the wanted resources inside the state file, 
 # remember to cleanup the import code blocks with a separate PR once the import has been completed successfully.
+# Here is the documentation which explains how to use the import code block: https://developer.hashicorp.com/terraform/language/block/import
 
 import {
-  to = module.common.azurerm_dns_txt_record.developer_io_italia_it
-  id = "/subscriptions/ec285037-c673-4f58-b594-d7c480da4e8b/resourceGroups/io-p-rg-external/providers/Microsoft.Network/dnsZones/io.italia.it/TXT/_dnsauth.developer"
+  to = module.common.azurerm_dns_txt_record.io_italia_it
+  id = "/subscriptions/ec285037-c673-4f58-b594-d7c480da4e8b/resourceGroups/io-p-rg-external/providers/Microsoft.Network/dnsZones/io.italia.it/TXT/_dnsauth"
 }


### PR DESCRIPTION
Keep io.italia.it on `io-p-cdn-common` as BYOC since the certificate autorotation for apex domain requires a manual TXT record update:
https://learn.microsoft.com/en-gb/azure/frontdoor/apex-domain?WT.mc_id=Portal-Microsoft_Azure_AFDX#azure-front-door-managed-tls-certificate-rotation