### PR TITLE
IOPLT-1837 - Assets CDN migration to platform - Add storage accounts output from common

### DIFF
--- a/src/common/prod/README.md
+++ b/src/common/prod/README.md
@@ -106,5 +106,6 @@ No inputs.
 | <a name="output_pep_subnets"></a> [pep\_subnets](#output\_pep\_subnets) | n/a |
 | <a name="output_private_endpoints"></a> [private\_endpoints](#output\_private\_endpoints) | n/a |
 | <a name="output_public_dns_zones"></a> [public\_dns\_zones](#output\_public\_dns\_zones) | n/a |
+| <a name="output_storage_accounts"></a> [storage\_accounts](#output\_storage\_accounts) | n/a |
 | <a name="output_virtual_networks"></a> [virtual\_networks](#output\_virtual\_networks) | n/a |
 <!-- END_TF_DOCS -->

--- a/src/common/prod/outputs.tf
+++ b/src/common/prod/outputs.tf
@@ -49,3 +49,14 @@ output "monitoring" {
     }
   }
 }
+
+output "storage_accounts" {
+  value = {
+    itn = {
+      logs = {
+        id   = module.storage_accounts_itn.logs_itn.id
+        name = module.storage_accounts_itn.logs_itn.name
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add storage accounts output on common for the Assets CDN migration from `common` to `platform`