### PR TITLE
Add TLS certificate creation pipeline for continua.ioapp.it

### DIFF
--- a/.github/workflows/_cron-certificate-continua-ioapp-it.yaml
+++ b/.github/workflows/_cron-certificate-continua-ioapp-it.yaml
@@ -1,0 +1,28 @@
+name: continua.ioapp.it TLS Certificate
+
+on:
+  schedule:
+    - cron: "0 2 * * 3"
+  workflow_dispatch:
+    inputs:
+      force_renewal:
+        description: "Force the certificate renewal to use when cron-triggered execution fails"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  id-token: write
+
+jobs:
+  prod:
+    name: "continua.ioapp.it"
+    uses: pagopa/dx/.github/workflows/release-certificate-v1.yaml@main
+    secrets: inherit
+    with:
+      force_renewal: ${{ inputs.force_renewal || false }}
+      key_vault_name: "io-p-kv"
+      csr_common_name: "continua.ioapp.it"
+      dns_zone: "ioapp.it"
+      dns_zone_resource_group: "io-p-rg-external"
+      environment: "prod-tls"

--- a/.github/workflows/_cron-certificate-continua-ioapp-it.yaml
+++ b/.github/workflows/_cron-certificate-continua-ioapp-it.yaml
@@ -10,7 +10,6 @@ on:
         required: false
         default: false
         type: boolean
-  pull_request:
 
 permissions:
   id-token: write

--- a/.github/workflows/_cron-certificate-continua-ioapp-it.yaml
+++ b/.github/workflows/_cron-certificate-continua-ioapp-it.yaml
@@ -10,6 +10,7 @@ on:
         required: false
         default: false
         type: boolean
+  pull_request:
 
 permissions:
   id-token: write


### PR DESCRIPTION
Implement a new pipeline to create a TLS certificate for continua.ioapp.it, scheduled to run weekly and allowing for manual execution with an option to force renewal.