### PR TITLE
Add permissions for certificate creation and renewal in Key Vault

### DIFF
--- a/src/core/_modules/key_vaults/kv.tf
+++ b/src/core/_modules/key_vaults/kv.tf
@@ -88,5 +88,5 @@ resource "azurerm_key_vault_access_policy" "kv_cd" {
 
   secret_permissions      = ["Get", "List", "Set"]
   storage_permissions     = []
-  certificate_permissions = ["SetIssuers", "DeleteIssuers", "Purge", "List", "Get", "ManageContacts"]
+  certificate_permissions = ["SetIssuers", "DeleteIssuers", "Purge", "List", "Get", "ManageContacts", "Create", "Update", "Import"]
 }


### PR DESCRIPTION
Enhance the Key Vault access policy by adding permissions for creating and renewing certificates. This change allows for better management of certificate lifecycle operations.