### PR TITLE
Add continua.ioapp.it certificate and DNS CNAME record

### DIFF
--- a/src/common/_modules/app_gateway/data.tf
+++ b/src/common/_modules/app_gateway/data.tf
@@ -104,6 +104,11 @@ data "azurerm_key_vault_certificate" "app_gw_continua" {
   key_vault_id = var.key_vault.id
 }
 
+data "azurerm_key_vault_certificate" "app_gw_continua_ioapp_it" {
+  name         = var.certificates.continua_ioapp_it
+  key_vault_id = var.key_vault.id
+}
+
 data "azurerm_key_vault_certificate" "app_gw_oauth" {
   name         = var.certificates.oauth_io_pagopa_it
   key_vault_id = var.key_vault.id

--- a/src/common/_modules/app_gateway/locals.tf
+++ b/src/common/_modules/app_gateway/locals.tf
@@ -265,6 +265,23 @@ locals {
       }
     }
 
+    continua-ioapp-it = {
+      protocol           = "Https"
+      host               = format("continua.%s", var.public_dns_zones.ioweb_it.name)
+      port               = 443
+      ssl_profile_name   = null
+      firewall_policy_id = null
+
+      certificate = {
+        name = var.certificates.continua_ioapp_it
+        id = replace(
+          data.azurerm_key_vault_certificate.app_gw_continua_ioapp_it.secret_id,
+          "/${data.azurerm_key_vault_certificate.app_gw_continua_ioapp_it.version}",
+          ""
+        )
+      }
+    }
+
     developerportal-backend-io-italia-it = {
       protocol           = "Https"
       host               = "developerportal-backend.io.italia.it"

--- a/src/common/_modules/global/modules/dns/dns_ioweb_it.tf
+++ b/src/common/_modules/global/modules/dns/dns_ioweb_it.tf
@@ -85,6 +85,15 @@ resource "azurerm_dns_txt_record" "spf_ioweb_it" {
   tags = var.tags
 }
 
+# CNAME for continua
+resource "azurerm_dns_cname_record" "continua" {
+  name                = "continua"
+  zone_name           = azurerm_dns_zone.ioweb_it.name
+  resource_group_name = var.resource_groups.external
+  ttl                 = var.dns_default_ttl_sec
+  record              = "continua.io.pagopa.it"
+}
+
 # CNAME for zendesk help center
 resource "azurerm_dns_cname_record" "zendesk" {
   name                = "assistenza"

--- a/src/common/prod/italynorth.tf
+++ b/src/common/prod/italynorth.tf
@@ -192,6 +192,7 @@ module "application_gateway_itn" {
     developerportal_backend_io_italia_it = "developerportal-backend-io-italia-it"
     firmaconio_selfcare_pagopa_it        = "firmaconio-selfcare-pagopa-it"
     continua_io_pagopa_it                = "continua-io-pagopa-it"
+    continua_ioapp_it                    = "continua-ioapp-it"
     selfcare_io_pagopa_it                = "selfcare-io-pagopa-it"
     oauth_io_pagopa_it                   = "oauth-io-pagopa-it"
     vehicles_ipatente_io_pagopa_it       = "vehicles-ipatente-io-pagopa-it"


### PR DESCRIPTION
Close IOPLT-1846

Add a new listener to application gateway for the domain `continua.ioapp.it`. This listener use a new domain specific certificate. Create a CNAME in DNS zone `ioapp.it`