### PR TITLE
Add missing route for continua.ioapp.it on ITN AGW

### DIFF
--- a/src/common/_modules/app_gateway/locals.tf
+++ b/src/common/_modules/app_gateway/locals.tf
@@ -703,6 +703,12 @@ locals {
       rewrite_rule_set_name = "rewrite-rule-set-ipatente-io-app"
       priority              = 133
     }
+    continua-ioapp-it = {
+      listener              = "continua-ioapp-it"
+      backend               = "continua-app"
+      rewrite_rule_set_name = "rewrite-rule-set-continua"
+      priority              = 134
+    }
   }
 
   rewrite_rule_sets = [


### PR DESCRIPTION
Add missing route for the continua.ioapp.it listener on ITN AGW, created with https://github.com/pagopa/io-infra/pull/1907