### PR TITLE
Add legacy rewrite rule set for third-party message attachments

### DIFF
--- a/src/common/_modules/app_gateway/locals.tf
+++ b/src/common/_modules/app_gateway/locals.tf
@@ -605,6 +605,16 @@ locals {
           backend               = "platform-api-gateway",
           rewrite_rule_set_name = "rewrite-rule-set-api-app"
         },
+        # NOTE: this path_rule covers the whole /api/v1/third-party-messages/* prefix
+        # because Azure Application Gateway does not support wildcards in the middle
+        # of a path pattern. The discrimination "attachments only" + "gated by custom
+        # header" is delegated to the conditions of the associated rewrite rule set
+        # (see `rewrite-rule-set-api-third-party-attachments-legacy`).
+        api-gateway-communication-third-party = {
+          paths                 = ["/api/v1/third-party-messages/*"],
+          backend               = "appbackend-app",
+          rewrite_rule_set_name = "rewrite-rule-set-api-third-party-attachments-legacy"
+        },
         api-gateway-fims = {
           paths                 = ["/api/fims/*"],
           backend               = "platform-api-gateway",
@@ -778,6 +788,43 @@ locals {
             path         = "/api/platform-legacy{var_uri_path}"
             query_string = null
             reroute      = false
+            components   = "path_only"
+          }
+          request_header_configurations  = []
+          response_header_configurations = []
+        }
+      ]
+    },
+    {
+      # Header-gated rollout of the new communication backend for third-party message attachments.
+      name = "rewrite-rule-set-api-third-party-attachments-legacy"
+      rewrite_rules = [
+        local.io_backend_ip_headers_rule,
+        {
+          name          = "rewrite-url-third-party-attachments-legacy"
+          rule_sequence = 200
+          conditions = [
+            {
+              # Feature-toggle header: any non-empty value enables the routing
+              # to platform-api-gateway via reroute.
+              variable    = "http_req_x-pagopa-com-test-rewrite"
+              pattern     = ".+"
+              ignore_case = true
+              negate      = false
+            },
+            {
+              variable    = "var_uri_path"
+              pattern     = "^/api/v1/third-party-messages/(.*)/attachments/(.*)$"
+              ignore_case = true
+              negate      = false
+            }
+          ]
+
+          # URL rewriting preserving the specific endpoint
+          url = {
+            path         = "/api/communication/v1/third-party-messages/{var_uri_path_1}/attachments/{var_uri_path_2}"
+            query_string = null
+            reroute      = true
             components   = "path_only"
           }
           request_header_configurations  = []


### PR DESCRIPTION
Close IOPLT-1860

Introduce a legacy rewrite rule set to manage third-party message attachments, enabling a header-gated rollout for the proxy.