### PR TITLE
Remove header check for third-party message attachments rewrite rule

### DIFF
--- a/src/common/_modules/app_gateway/locals.tf
+++ b/src/common/_modules/app_gateway/locals.tf
@@ -805,14 +805,6 @@ locals {
           rule_sequence = 200
           conditions = [
             {
-              # Feature-toggle header: any non-empty value enables the routing
-              # to platform-api-gateway via reroute.
-              variable    = "http_req_x-pagopa-com-test-rewrite"
-              pattern     = ".+"
-              ignore_case = true
-              negate      = false
-            },
-            {
               variable    = "var_uri_path"
               pattern     = "^/api/v1/third-party-messages/(.*)/attachments/(.*)$"
               ignore_case = true


### PR DESCRIPTION
Close IOPLT-1861

Eliminate the header check from the rewrite rule for third-party message attachments in the legacy system. This change simplifies the routing logic.