### PR TITLE
IOPLT-1882 - Switch to default https redirect on all routes on io-p-cdn-common

### DIFF
--- a/src/platform/prod/cdn/_modules/common/assets_io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/assets_io_italia_it.tf
@@ -91,7 +91,7 @@ resource "azurerm_cdn_frontdoor_route" "assets_io_italia_it" {
   enabled                       = true
 
   forwarding_protocol    = "MatchRequest"
-  https_redirect_enabled = false # TODO: switch to default https redirect on route level
+  https_redirect_enabled = true
   patterns_to_match      = ["/*"]
   supported_protocols    = ["Https"]
 

--- a/src/platform/prod/cdn/_modules/common/developer_io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/developer_io_italia_it.tf
@@ -92,7 +92,7 @@ resource "azurerm_cdn_frontdoor_route" "developer_io_italia_it" {
   enabled                       = true
 
   forwarding_protocol    = "MatchRequest"
-  https_redirect_enabled = false
+  https_redirect_enabled = true
   patterns_to_match      = ["/*"]
   supported_protocols    = ["Https"]
 
@@ -125,26 +125,4 @@ resource "azurerm_cdn_frontdoor_custom_domain_association" "developer_io_italia_
 resource "azurerm_cdn_frontdoor_rule_set" "developer_io_italia_it" {
   name                     = "Migratediopcdnendpointdeveloperportal"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.common.id
-}
-
-resource "azurerm_cdn_frontdoor_rule" "developer_io_italia_it_enforce_https" {
-  name                      = "EngorceHTTPS" # TODO: switch to default https redirect on route level
-  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.developer_io_italia_it.id
-  order                     = 1
-
-  conditions {
-    request_scheme_condition {
-      operator         = "Equal"
-      match_values     = ["HTTPS"]
-      negate_condition = true
-    }
-  }
-
-  actions {
-    url_redirect_action {
-      redirect_type        = "Found"
-      redirect_protocol    = "Https"
-      destination_hostname = ""
-    }
-  }
 }

--- a/src/platform/prod/cdn/_modules/common/io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/io_italia_it.tf
@@ -92,7 +92,7 @@ resource "azurerm_cdn_frontdoor_route" "io_italia_it" {
   enabled                       = true
 
   forwarding_protocol    = "MatchRequest"
-  https_redirect_enabled = false
+  https_redirect_enabled = true
   patterns_to_match      = ["/*"]
   supported_protocols    = ["Http", "Https"]
 
@@ -141,31 +141,9 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_global" {
   }
 }
 
-resource "azurerm_cdn_frontdoor_rule" "io_italia_it_enforce_https" {
-  name                      = "EnforceHTTPS" # TODO: switch to default https redirect on route level
-  order                     = 1
-  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
-
-  actions {
-    url_redirect_action {
-      redirect_type        = "Found"
-      redirect_protocol    = "Https"
-      destination_hostname = ""
-    }
-  }
-
-  conditions {
-    request_scheme_condition {
-      match_values     = ["HTTP"]
-      operator         = "Equal"
-      negate_condition = false
-    }
-  }
-}
-
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_fix_dots" {
   name                      = "FixDots"
-  order                     = 2
+  order                     = 1
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -187,7 +165,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_fix_dots" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_fix_dots2" {
   name                      = "FixDots2"
-  order                     = 3
+  order                     = 2
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -209,7 +187,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_fix_dots2" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_redirect_firma" {
   name                      = "RedirectFirma"
-  order                     = 4
+  order                     = 3
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -234,7 +212,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_redirect_firma" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_faq" {
   name                      = "Faq"
-  order                     = 5
+  order                     = 4
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -258,7 +236,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_faq" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_documenti_su_io_faq" {
   name                      = "DocumentiSuIoFaq"
-  order                     = 6
+  order                     = 5
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -282,7 +260,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_documenti_su_io_faq" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_carta_giovani_faq" {
   name                      = "CartaGiovaniFaq"
-  order                     = 7
+  order                     = 6
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -306,7 +284,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_carta_giovani_faq" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_funzionalita_dismessa" {
   name                      = "FunzionalitaDismess"
-  order                     = 8
+  order                     = 7
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -341,7 +319,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_funzionalita_dismessa" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_giornalisti" {
   name                      = "Giornalisti"
-  order                     = 9
+  order                     = 8
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -365,7 +343,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_giornalisti" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_pubbliche_amministrazioni" {
   name                      = "PubblicheAmministrazioni"
-  order                     = 10
+  order                     = 9
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -389,7 +367,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_pubbliche_amministrazioni" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_enti_nazionali" {
   name                      = "EntiNazionali"
-  order                     = 11
+  order                     = 10
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -413,7 +391,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_enti_nazionali" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_cittadini" {
   name                      = "Cittadini"
-  order                     = 12
+  order                     = 11
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -437,7 +415,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_cittadini" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_cgn_guida_beneficiari" {
   name                      = "CGNGuidaBeneficiari"
-  order                     = 13
+  order                     = 12
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -464,7 +442,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_cgn_guida_beneficiari" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_cgn_informativa_beneficiari" {
   name                      = "CGNInformativaBeneficiari"
-  order                     = 14
+  order                     = 13
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -491,7 +469,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_cgn_informativa_beneficiari"
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_cgn_informative_operatori" {
   name                      = "CGNInformativeOperatori"
-  order                     = 15
+  order                     = 14
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -518,7 +496,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_cgn_informative_operatori" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_note_legali" {
   name                      = "NoteLegali"
-  order                     = 16
+  order                     = 15
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -542,7 +520,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_note_legali" {
 
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_privacy_policy" {
   name                      = "PrivacyPolicy"
-  order                     = 17
+  order                     = 16
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
 
   actions {
@@ -566,7 +544,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_privacy_policy" {
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_informativa_newsletter" {
   name                      = "InformativaNewsletter"
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
-  order                     = 18
+  order                     = 17
   behavior_on_match         = "Continue"
 
   actions {
@@ -594,7 +572,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_informativa_newsletter" {
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_same_path" {
   name                      = "SamePath"
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
-  order                     = 19
+  order                     = 18
   behavior_on_match         = "Continue"
 
   actions {
@@ -626,7 +604,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_same_path" {
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_homepage" {
   name                      = "Homepage"
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
-  order                     = 20
+  order                     = 19
   behavior_on_match         = "Continue"
 
   actions {
@@ -650,7 +628,7 @@ resource "azurerm_cdn_frontdoor_rule" "io_italia_it_homepage" {
 resource "azurerm_cdn_frontdoor_rule" "io_italia_it_io_web" {
   name                      = "IoWeb"
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.io_italia_it.id
-  order                     = 21
+  order                     = 20
   behavior_on_match         = "Continue"
 
   actions {

--- a/src/platform/prod/cdn/_modules/common/static_web_io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/static_web_io_italia_it.tf
@@ -88,7 +88,7 @@ resource "azurerm_cdn_frontdoor_route" "static_web_io_italia_it" {
   enabled                       = true
 
   forwarding_protocol    = "MatchRequest"
-  https_redirect_enabled = false # TODO: switch to default https redirect on route level
+  https_redirect_enabled = true
   patterns_to_match      = ["/*"]
   supported_protocols    = ["Https"]
 

--- a/src/platform/prod/cdn/tfmodules.lock.json
+++ b/src/platform/prod/cdn/tfmodules.lock.json
@@ -1,8 +1,8 @@
 {
   "ioapp.ioapp": {
-    "hash": "8939f4b0e8e5263ae3d07d15f025be154d832586382b4fddeb0dec38eaf780e3",
-    "version": "0.6.4",
+    "hash": "b5b04d347d5ac257e273f1cf67a05ed5953eb555645d2aee4934663bdc11e069",
+    "version": "0.7.0",
     "name": "azure_cdn",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-cdn/azurerm/0.6.4"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-cdn/azurerm/0.7.0"
   }
 }


### PR DESCRIPTION
Switch to default HTTPS redirect on all routes of `io-p-cdn-common` , decommissioning the legacy setup.