### PR TITLE
IOPLT-1886 - Remove from codebase already decommissioned io-p-cdn-common legacy domains

### DIFF
--- a/src/platform/prod/cdn/_modules/common/assets_io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/assets_io_italia_it.tf
@@ -9,17 +9,6 @@ resource "azurerm_cdn_frontdoor_custom_domain" "assets_io_italia_it" {
   }
 }
 
-resource "azurerm_cdn_frontdoor_custom_domain" "assets_io_italia_it_legacy" {
-  name                     = "io-p-cdnendpoint-assets-Migrated"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.common.id
-  dns_zone_id              = var.public_dns_zones.io_italia_it.id
-  host_name                = "io-p-cdnendpoint-assets.azureedge.net"
-
-  tls {
-    certificate_type = "ManagedCertificate"
-  }
-}
-
 resource "azurerm_dns_txt_record" "assets_io_italia_it" {
   name                = join(".", ["_dnsauth", "assets"])
   zone_name           = var.public_dns_zones.io_italia_it.name
@@ -96,8 +85,7 @@ resource "azurerm_cdn_frontdoor_route" "assets_io_italia_it" {
   supported_protocols    = ["Http", "Https"]
 
   cdn_frontdoor_custom_domain_ids = [
-    azurerm_cdn_frontdoor_custom_domain.assets_io_italia_it.id,
-    azurerm_cdn_frontdoor_custom_domain.assets_io_italia_it_legacy.id
+    azurerm_cdn_frontdoor_custom_domain.assets_io_italia_it.id
   ]
   link_to_default_domain = true
 

--- a/src/platform/prod/cdn/_modules/common/developer_io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/developer_io_italia_it.tf
@@ -9,16 +9,6 @@ resource "azurerm_cdn_frontdoor_custom_domain" "developer_io_italia_it" {
   }
 }
 
-resource "azurerm_cdn_frontdoor_custom_domain" "developer_io_italia_it_legacy" {
-  name                     = "io-p-cdnendpoint-developerportal-Migrated"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.common.id
-  host_name                = "io-p-cdnendpoint-developerportal.azureedge.net"
-
-  tls {
-    certificate_type = "ManagedCertificate"
-  }
-}
-
 resource "azurerm_dns_txt_record" "developer_io_italia_it" {
   name                = join(".", ["_dnsauth", "developer"])
   zone_name           = var.public_dns_zones.io_italia_it.name
@@ -95,8 +85,7 @@ resource "azurerm_cdn_frontdoor_route" "developer_io_italia_it" {
   supported_protocols    = ["Http", "Https"]
 
   cdn_frontdoor_custom_domain_ids = [
-    azurerm_cdn_frontdoor_custom_domain.developer_io_italia_it.id,
-    azurerm_cdn_frontdoor_custom_domain.developer_io_italia_it_legacy.id
+    azurerm_cdn_frontdoor_custom_domain.developer_io_italia_it.id
   ]
   link_to_default_domain = true
 

--- a/src/platform/prod/cdn/_modules/common/io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/io_italia_it.tf
@@ -12,17 +12,6 @@ resource "azurerm_cdn_frontdoor_custom_domain" "io_italia_it" {
   }
 }
 
-resource "azurerm_cdn_frontdoor_custom_domain" "io_italia_it_legacy" {
-  name                     = "io-p-cdnendpoint-iowebsite-Migrated"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.common.id
-  dns_zone_id              = var.public_dns_zones.io_italia_it.id
-  host_name                = "io-p-cdnendpoint-iowebsite.azureedge.net"
-
-  tls {
-    certificate_type = "ManagedCertificate"
-  }
-}
-
 resource "azurerm_cdn_frontdoor_secret" "io_italia_it" {
   name                     = "MigratedSecret-io-italia-it"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.common.id
@@ -97,8 +86,7 @@ resource "azurerm_cdn_frontdoor_route" "io_italia_it" {
   supported_protocols    = ["Http", "Https"]
 
   cdn_frontdoor_custom_domain_ids = [
-    azurerm_cdn_frontdoor_custom_domain.io_italia_it.id,
-    azurerm_cdn_frontdoor_custom_domain.io_italia_it_legacy.id
+    azurerm_cdn_frontdoor_custom_domain.io_italia_it.id
   ]
   link_to_default_domain = true
 

--- a/src/platform/prod/cdn/_modules/common/static_web_io_italia_it.tf
+++ b/src/platform/prod/cdn/_modules/common/static_web_io_italia_it.tf
@@ -9,16 +9,6 @@ resource "azurerm_cdn_frontdoor_custom_domain" "static_web_io_italia_it" {
   }
 }
 
-resource "azurerm_cdn_frontdoor_custom_domain" "static_web_io_italia_it_legacy" {
-  name                     = "io-p-cdnendpoint-websiteassets-Migrated"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.common.id
-  host_name                = "io-p-cdnendpoint-websiteassets.azureedge.net"
-
-  tls {
-    certificate_type = "ManagedCertificate"
-  }
-}
-
 resource "azurerm_dns_txt_record" "static_web_io_italia_it" {
   name                = join(".", ["_dnsauth", "static-web"])
   zone_name           = var.public_dns_zones.io_italia_it.name
@@ -93,8 +83,7 @@ resource "azurerm_cdn_frontdoor_route" "static_web_io_italia_it" {
   supported_protocols    = ["Http", "Https"]
 
   cdn_frontdoor_custom_domain_ids = [
-    azurerm_cdn_frontdoor_custom_domain.static_web_io_italia_it.id,
-    azurerm_cdn_frontdoor_custom_domain.static_web_io_italia_it_legacy.id
+    azurerm_cdn_frontdoor_custom_domain.static_web_io_italia_it.id
   ]
   link_to_default_domain = true
 


### PR DESCRIPTION
Remove from codebase already decommissioned `io-p-cdn-common` legacy domains.