### PR TITLE
Add permissions to io-p-infra-github-cd-identity to manage RBAC custom roles

### DIFF
--- a/src/core/prod/README.md
+++ b/src/core/prod/README.md
@@ -58,6 +58,7 @@
 | [azurerm_role_assignment.dashboards_svc_devs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.dashboards_wallet_admins](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.dashboards_wallet_devs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.infra_cd_access_control_administrator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azuread_group.admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.auth_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.auth_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |

--- a/src/core/prod/iam.tf
+++ b/src/core/prod/iam.tf
@@ -87,3 +87,10 @@ resource "azurerm_key_vault_access_policy" "kv_common_infra_cd" {
   certificate_permissions = ["Get", "List"]
   key_permissions         = ["Get", "List"]
 }
+
+resource "azurerm_role_assignment" "infra_cd_access_control_administrator" {
+  scope                = data.azurerm_subscription.current
+  principal_id         = data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id
+  role_definition_name = "User Access Administrator"
+  description          = "Allow the io-p-infra-github-cd-identity to manage RBAC permissions"
+}

--- a/src/core/prod/iam.tf
+++ b/src/core/prod/iam.tf
@@ -89,7 +89,7 @@ resource "azurerm_key_vault_access_policy" "kv_common_infra_cd" {
 }
 
 resource "azurerm_role_assignment" "infra_cd_access_control_administrator" {
-  scope                = data.azurerm_subscription.current
+  scope                = data.azurerm_subscription.current.id
   principal_id         = data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id
   role_definition_name = "User Access Administrator"
   description          = "Allow the io-p-infra-github-cd-identity to manage RBAC permissions"


### PR DESCRIPTION
Add the `User Access Administrator` permission to `io-p-infra-github-cd-identity` to manage the RBAC custom roles created with the module `"pagopa-dx/azure-core-infra/azurerm//modules/custom_roles"` 