### PR TITLE
Update Dev APIM enabling user registrations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         exclude: ^.*/(_modules|modules|\.terraform|env|templates|api|api_product)(/.*)?$
         files: src/(common|core|github_runner|identity|migration|repository|domains|platform)
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.102.0
+    rev: v1.108.0
     hooks:
       - id: terraform_tflint
         args:

--- a/src/platform/dev/app-routing/_modules/apim/main.tf
+++ b/src/platform/dev/app-routing/_modules/apim/main.tf
@@ -1,6 +1,6 @@
 module "apim" {
   source  = "pagopa-dx/azure-api-management/azurerm"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   environment = {
     prefix          = var.prefix

--- a/src/platform/dev/app-routing/tfmodules.lock.json
+++ b/src/platform/dev/app-routing/tfmodules.lock.json
@@ -1,9 +1,9 @@
 {
   "apim_itn.apim": {
-    "hash": "010357578132c3cd7931c62e2b87b03b544bb044ded8034b5291de7b9e88d500",
-    "version": "2.2.3",
+    "hash": "781a1344ab2415d1b7cc12dce2edaa24dff156347e59943e231db505101bbe8d",
+    "version": "3.1.0",
     "name": "azure_api_management",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-api-management/azurerm/2.2.3"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-api-management/azurerm/3.1.0"
   },
   "iam_apim_itn_infra_cd": {
     "hash": "4b05c2a48659f272b3c88c4ce846de09870a45e996fbabd1036e36f412112040",

--- a/src/platform/dev/app-routing/tfmodules.lock.json
+++ b/src/platform/dev/app-routing/tfmodules.lock.json
@@ -5,18 +5,6 @@
     "name": "azure_api_management",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-api-management/azurerm/3.1.0"
   },
-  "iam_apim_itn_infra_cd": {
-    "hash": "4b05c2a48659f272b3c88c4ce846de09870a45e996fbabd1036e36f412112040",
-    "version": "2.1.0",
-    "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/2.1.0"
-  },
-  "iam_apim_itn_infra_ci": {
-    "hash": "4b05c2a48659f272b3c88c4ce846de09870a45e996fbabd1036e36f412112040",
-    "version": "2.1.0",
-    "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/2.1.0"
-  },
   "apim_itn.iam_adgroup_admins": {
     "hash": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
     "version": "0.1.3",
@@ -34,5 +22,17 @@
     "version": "0.1.3",
     "name": "azure_role_assignments",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/0.1.3"
+  },
+  "iam_apim_itn_infra_cd": {
+    "hash": "4b05c2a48659f272b3c88c4ce846de09870a45e996fbabd1036e36f412112040",
+    "version": "2.1.0",
+    "name": "azure_role_assignments",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/2.1.0"
+  },
+  "iam_apim_itn_infra_ci": {
+    "hash": "4b05c2a48659f272b3c88c4ce846de09870a45e996fbabd1036e36f412112040",
+    "version": "2.1.0",
+    "name": "azure_role_assignments",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/2.1.0"
   }
 }


### PR DESCRIPTION
Update  `pagopa-dx/azure-api-management/azurerm` module to the newset `3.1.0` which enable user registration in case of Developer Sku.