### PR TITLE
IOPLT-1950 - Add required dns records for onemail on uat.ioapp.it

### DIFF
--- a/src/platform/prod/core/_modules/dns/zones/uat_ioapp_it.tf
+++ b/src/platform/prod/core/_modules/dns/zones/uat_ioapp_it.tf
@@ -94,7 +94,7 @@ locals {
 resource "azurerm_dns_cname_record" "dkim_uat_ioapp_it" {
   for_each = local.uat_ioapp_it_dkim_records
 
-  name                = each.key
+  name                = "${each.key}._domainkey"
   zone_name           = azurerm_dns_zone.uat_ioapp_it.name
   resource_group_name = var.resource_groups.external
   ttl                 = var.dns_default_ttl_sec

--- a/src/platform/prod/core/_modules/dns/zones/uat_ioapp_it.tf
+++ b/src/platform/prod/core/_modules/dns/zones/uat_ioapp_it.tf
@@ -127,4 +127,6 @@ resource "azurerm_dns_txt_record" "bounce_uat_ioapp_it" {
   record {
     value = "v=spf1 include:amazonses.com ~all"
   }
+
+  tags = var.tags
 }

--- a/src/platform/prod/core/_modules/dns/zones/uat_ioapp_it.tf
+++ b/src/platform/prod/core/_modules/dns/zones/uat_ioapp_it.tf
@@ -65,16 +65,66 @@ resource "azurerm_dns_ns_record" "uat_ioapp_it_delegation" {
   records = azurerm_dns_zone.uat_ioapp_it.name_servers
 }
 
-/*
-# DMARC record for uat.ioapp.it
+
+# DMARC 
+
 resource "azurerm_dns_txt_record" "dmarc_uat_ioapp_it" {
   name                = "_dmarc"
   zone_name           = azurerm_dns_zone.uat_ioapp_it.name
   resource_group_name = var.resource_groups.external
   ttl                 = var.dns_default_ttl_sec
   record {
-    value = "v=DMARC1; p=reject; rua=mailto:dmarc@0f1qy7b5.uriports.com; aspf=s; adkim=s"
+    value = "v=DMARC1; p=none;"
   }
   tags = var.tags
 }
-*/
+
+#
+
+# DKIM
+
+locals {
+  uat_ioapp_it_dkim_records = {
+    rhxsps73fjdvsgzpgba6m3u5cc2t4h5j = "rhxsps73fjdvsgzpgba6m3u5cc2t4h5j.dkim.eu-south-1.amazonses.com"
+    p5l7nlscxrgukjuzhpun43wefqfste36 = "p5l7nlscxrgukjuzhpun43wefqfste36.dkim.eu-south-1.amazonses.com"
+    wjtcf2j435u5i2ub375a7q4z456hzezu = "wjtcf2j435u5i2ub375a7q4z456hzezu.dkim.eu-south-1.amazonses.com"
+  }
+}
+
+resource "azurerm_dns_cname_record" "dkim_uat_ioapp_it" {
+  for_each = local.uat_ioapp_it_dkim_records
+
+  name                = each.key
+  zone_name           = azurerm_dns_zone.uat_ioapp_it.name
+  resource_group_name = var.resource_groups.external
+  ttl                 = var.dns_default_ttl_sec
+  record              = each.value
+  tags                = var.tags
+}
+
+#
+
+resource "azurerm_dns_mx_record" "bounce_uat_ioapp_it" {
+  name                = "bounce"
+  zone_name           = azurerm_dns_zone.uat_ioapp_it.name
+  resource_group_name = var.resource_groups.external
+  ttl                 = var.dns_default_ttl_sec
+
+  record {
+    preference = 10
+    exchange   = "feedback-smtp.eu-south-1.amazonses.com"
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_dns_txt_record" "bounce_uat_ioapp_it" {
+  name                = "bounce"
+  zone_name           = azurerm_dns_zone.uat_ioapp_it.name
+  resource_group_name = var.resource_groups.external
+  ttl                 = var.dns_default_ttl_sec
+
+  record {
+    value = "v=spf1 include:amazonses.com ~all"
+  }
+}


### PR DESCRIPTION
Add required onemail DNS records for the `uat.ioapp.it` dns zone