### PR TITLE
Add key vault reader role to platform_api_gateway

### DIFF
--- a/src/common/_modules/platform_api_gateway/rbac.tf
+++ b/src/common/_modules/platform_api_gateway/rbac.tf
@@ -44,3 +44,10 @@ moved {
   from = module.iam_adgroup_bonus_infra_cd
   to   = module.iam_adgroup["ef6b556d-4d33-4467-ad9d-6b5540cbde6b"]
 }
+
+resource "azurerm_role_assignment" "apim_key_vault_secrets_reader" {
+  description          = "Allow ${module.platform_api_gateway.name} to read secrets"
+  principal_id         = module.platform_api_gateway.principal_id
+  role_definition_name = "Key Vault Secrets User"
+  scope                = var.key_vault_common.id
+}

--- a/src/common/_modules/platform_api_gateway/variables.tf
+++ b/src/common/_modules/platform_api_gateway/variables.tf
@@ -77,6 +77,15 @@ variable "key_vault" {
   description = "Information of the Key Vault"
 }
 
+variable "key_vault_common" {
+  type = object({
+    id                  = string
+    name                = string
+    resource_group_name = string
+  })
+  description = "Information of the common Key Vault"
+}
+
 variable "datasources" {
   type        = map(any)
   description = "Common datasources"

--- a/src/common/prod/data.tf
+++ b/src/common/prod/data.tf
@@ -162,11 +162,6 @@ data "azurerm_linux_function_app" "services_app_backend_function_app" {
   name                = "${local.project_itn}-svc-app-be-func-01"
 }
 
-data "azurerm_container_app" "services_app_backend_function_app" {
-  resource_group_name = "${local.project_itn}-svc-rg-01"
-  name                = "${local.project_itn}-svc-app-be-func-02"
-}
-
 data "azurerm_linux_function_app" "lollipop_function" {
   name                = "${local.project_itn}-auth-lollipop-func-02"
   resource_group_name = "${local.project_itn}-auth-lollipop-rg-02"

--- a/src/common/prod/italynorth.tf
+++ b/src/common/prod/italynorth.tf
@@ -90,7 +90,8 @@ module "platform_api_gateway_apim_itn" {
     azurerm_client_config = data.azurerm_client_config.current
   }
 
-  key_vault = local.core.key_vault.weu.kv
+  key_vault        = local.core.key_vault.weu.kv
+  key_vault_common = local.core.key_vault.weu.kv_common
 
   action_group_id = local.platform_observability.monitoring_westeurope.action_groups.error
   application_insights = {

--- a/src/common/prod/tfmodules.lock.json
+++ b/src/common/prod/tfmodules.lock.json
@@ -143,12 +143,6 @@
     "name": "azure_role_assignments",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.3.3"
   },
-  "continua_app_service.appservice_continua_itn": {
-    "hash": "574eefa5a3e46ae05349a2a08c1035017b22abe9be747491f1b6fbbfc6d5d332",
-    "version": "2.0.1",
-    "name": "azure_app_service",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-app-service/azurerm/2.0.1"
-  },
   "function_app_admin.function_admin_storage_account": {
     "hash": "651e0b9fba699c98f447843346637928ca376af48081fc31807c88c3be933e9d",
     "version": "2.2.4",
@@ -203,24 +197,6 @@
     "name": "azure_storage_account",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/1.0.1"
   },
-  "assets_locales_cdn.cdn_storage": {
-    "hash": "0e4bd3881f59056e0d49ac38c09b9ebfb885c60527bfdc33ac290d50c707753c",
-    "version": "2.0.0",
-    "name": "azure_storage_account",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/2.0.0"
-  },
-  "assets_locales_cdn.azure_cdn": {
-    "hash": "3e22defd7acd3e01581d9ce2b437dacb3fc94967498561eedbb1dd516c1702ff",
-    "version": "0.7.1",
-    "name": "azure_cdn",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-cdn/azurerm/0.7.1"
-  },
-  "assets_locales_cdn.storage_account_permissions": {
-    "hash": "a8c1a6fa085349f937017deb20236170f0bb9dd78b5ded85ec75d7caeba7a872",
-    "version": "1.3.3",
-    "name": "azure_role_assignments",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.3.3"
-  },
   "function_app_services_02.function_services_role_assignments": {
     "hash": "a8c1a6fa085349f937017deb20236170f0bb9dd78b5ded85ec75d7caeba7a872",
     "version": "1.3.3",
@@ -244,5 +220,29 @@
     "version": "1.3.3",
     "name": "azure_role_assignments",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.3.3"
+  },
+  "assets_locales_cdn.azure_cdn": {
+    "hash": "3e22defd7acd3e01581d9ce2b437dacb3fc94967498561eedbb1dd516c1702ff",
+    "version": "0.7.1",
+    "name": "azure_cdn",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-cdn/azurerm/0.7.1"
+  },
+  "assets_locales_cdn.cdn_storage": {
+    "hash": "0e4bd3881f59056e0d49ac38c09b9ebfb885c60527bfdc33ac290d50c707753c",
+    "version": "2.0.0",
+    "name": "azure_storage_account",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/2.0.0"
+  },
+  "assets_locales_cdn.storage_account_permissions": {
+    "hash": "a8c1a6fa085349f937017deb20236170f0bb9dd78b5ded85ec75d7caeba7a872",
+    "version": "1.3.3",
+    "name": "azure_role_assignments",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.3.3"
+  },
+  "continua_app_service.appservice_continua_itn": {
+    "hash": "574eefa5a3e46ae05349a2a08c1035017b22abe9be747491f1b6fbbfc6d5d332",
+    "version": "2.0.1",
+    "name": "azure_app_service",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-app-service/azurerm/2.0.1"
   }
 }


### PR DESCRIPTION
platform_api_gateway must reads from keyvault because we are gradually removing the use of terraform data for reading secrets.