### PR TITLE
IOPLT-1993 - Add new redis private dns zone

### DIFF
--- a/src/platform/prod/core/_modules/dns/zones/private_dns_zone_links.tf
+++ b/src/platform/prod/core/_modules/dns/zones/private_dns_zone_links.tf
@@ -9,6 +9,17 @@ resource "azurerm_private_dns_zone_virtual_network_link" "internal_io_pagopa_it_
   tags = var.tags
 }
 
+resource "azurerm_private_dns_zone_virtual_network_link" "redis_azure_net_private_vnet" {
+  for_each              = var.vnets
+  name                  = each.key == "weu" ? "${var.project}-redis-common-common" : each.value.name
+  resource_group_name   = var.resource_groups.common
+  private_dns_zone_name = azurerm_private_dns_zone.privatelink_redis_azure_net.name
+  virtual_network_id    = each.value.id
+  registration_enabled  = false
+
+  tags = var.tags
+}
+
 resource "azurerm_private_dns_zone_virtual_network_link" "redis_private_vnet" {
   for_each              = var.vnets
   name                  = each.key == "weu" ? "${var.project}-redis-common-common" : each.value.name

--- a/src/platform/prod/core/_modules/dns/zones/private_dns_zones.tf
+++ b/src/platform/prod/core/_modules/dns/zones/private_dns_zones.tf
@@ -28,6 +28,13 @@ resource "azurerm_private_dns_a_record" "proxy_internal_io" {
   tags = var.tags
 }
 
+resource "azurerm_private_dns_zone" "privatelink_redis_azure_net" {
+  name                = "privatelink.redis.azure.net"
+  resource_group_name = var.resource_groups.common
+
+  tags = var.tags
+}
+
 resource "azurerm_private_dns_zone" "privatelink_redis_cache" {
   name                = "privatelink.redis.cache.windows.net"
   resource_group_name = var.resource_groups.common


### PR DESCRIPTION
Add new `privatelink.redis.azure.net` private DNS zone to enable the latest version of the redis instances to be created.