### PR TITLE
Add new db for session-manager related collections

### DIFF
--- a/src/domains/citizen-auth-common/05_database.tf
+++ b/src/domains/citizen-auth-common/05_database.tf
@@ -49,6 +49,13 @@ module "cosmosdb_sql_database_citizen_auth" {
   account_name        = module.cosmosdb_account.name
 }
 
+module "cosmosdb_sql_database_session_manager" {
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3//cosmosdb_sql_database?ref=v8.44.1"
+  name                = "io-auth-SM"
+  resource_group_name = data.azurerm_resource_group.data_rg.name
+  account_name        = module.cosmosdb_account.name
+}
+
 #
 # LolliPOP containers
 #
@@ -102,6 +109,43 @@ resource "azurerm_cosmosdb_sql_container" "session-notifications" {
 
   default_ttl = var.citizen_auth_database.session_notifications.ttl
 
+}
+
+#
+# Session manager containers
+#
+resource "azurerm_cosmosdb_sql_container" "session_tokens" {
+
+  name                = "session-tokens"
+  resource_group_name = data.azurerm_resource_group.data_rg.name
+  account_name        = module.cosmosdb_account.name
+  database_name       = module.cosmosdb_sql_database_session_manager.name
+
+  partition_key_path    = "/sessionId"
+  partition_key_version = 2
+
+  autoscale_settings {
+    max_throughput = var.citizen_auth_database.session_tokens.max_throughput
+  }
+
+  default_ttl = var.citizen_auth_database.session_tokens.ttl
+}
+
+resource "azurerm_cosmosdb_sql_container" "active_sessions" {
+
+  name                = "active-sessions"
+  resource_group_name = data.azurerm_resource_group.data_rg.name
+  account_name        = module.cosmosdb_account.name
+  database_name       = module.cosmosdb_sql_database_session_manager.name
+
+  partition_key_path    = "/fiscalCode"
+  partition_key_version = 2
+
+  autoscale_settings {
+    max_throughput = var.citizen_auth_database.active_sessions.max_throughput
+  }
+
+  default_ttl = var.citizen_auth_database.active_sessions.ttl
 }
 
 // ----------------------------------------------------

--- a/src/domains/citizen-auth-common/05_database.tf
+++ b/src/domains/citizen-auth-common/05_database.tf
@@ -125,10 +125,10 @@ resource "azurerm_cosmosdb_sql_container" "session_tokens" {
   partition_key_version = 2
 
   autoscale_settings {
-    max_throughput = var.citizen_auth_database.session_tokens.max_throughput
+    max_throughput = var.session_manager_database.session_tokens.max_throughput
   }
 
-  default_ttl = var.citizen_auth_database.session_tokens.ttl
+  default_ttl = var.session_manager_database.session_tokens.ttl
 }
 
 resource "azurerm_cosmosdb_sql_container" "active_sessions" {
@@ -142,10 +142,10 @@ resource "azurerm_cosmosdb_sql_container" "active_sessions" {
   partition_key_version = 2
 
   autoscale_settings {
-    max_throughput = var.citizen_auth_database.active_sessions.max_throughput
+    max_throughput = var.session_manager_database.active_sessions.max_throughput
   }
 
-  default_ttl = var.citizen_auth_database.active_sessions.ttl
+  default_ttl = var.session_manager_database.active_sessions.ttl
 }
 
 // ----------------------------------------------------

--- a/src/domains/citizen-auth-common/99_variables.tf
+++ b/src/domains/citizen-auth-common/99_variables.tf
@@ -78,6 +78,15 @@ variable "citizen_auth_database" {
   )
 }
 
+variable "session_manager_database" {
+  type = map(
+    object({
+      max_throughput = number
+      ttl            = number
+    })
+  )
+}
+
 ### External resources
 
 variable "monitor_resource_group_name" {

--- a/src/domains/citizen-auth-common/env/prod/terraform.tfvars
+++ b/src/domains/citizen-auth-common/env/prod/terraform.tfvars
@@ -27,6 +27,14 @@ citizen_auth_database = {
     max_throughput = 9000
     ttl            = -1
   }
+  session_tokens = {
+    max_throughput = 9000
+    ttl            = -1
+  }
+  active_sessions = {
+    max_throughput = 9000
+    ttl            = -1
+  }
 }
 
 ### External resources

--- a/src/domains/citizen-auth-common/env/prod/terraform.tfvars
+++ b/src/domains/citizen-auth-common/env/prod/terraform.tfvars
@@ -27,6 +27,9 @@ citizen_auth_database = {
     max_throughput = 9000
     ttl            = -1
   }
+}
+
+session_manager_database = {
   session_tokens = {
     max_throughput = 9000
     ttl            = -1


### PR DESCRIPTION
Adds a dedicated Cosmos DB SQL database for session-manager data within the citizen-auth-common Terraform domain, and provisions the initial session-manager containers in that database.

Changes:

Introduces a new Cosmos DB SQL database (cosmosdb_sql_database_session_manager) in citizen-auth-common.
Adds two new Cosmos DB SQL containers (session-tokens, active-sessions) under the new database.
Extends prod terraform.tfvars with throughput/TTL settings for the new containers.