### PR TITLE
IOPLT-1919 - Add secret RBAC roles on ITN KV for function admin CI / CD identities

### DIFF
--- a/src/core/prod/data.tf
+++ b/src/core/prod/data.tf
@@ -75,12 +75,12 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
 
 data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_ci" {
   name                = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-infra-github-ci-id-02"
-  resource_group_name = "${local.prefix}-${local.env_short}-rg-02"
+  resource_group_name = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-rg-02"
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_cd" {
   name                = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-infra-github-cd-id-02"
-  resource_group_name = "${local.prefix}-${local.env_short}-rg-02"
+  resource_group_name = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-rg-02"
 }
 
 # TODO: important - this should be removed as it creates a dependency to the common module

--- a/src/core/prod/data.tf
+++ b/src/core/prod/data.tf
@@ -73,15 +73,19 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
   resource_group_name = "${local.prefix}-${local.env_short}-identity-rg"
 }
 
-data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_ci" {
+# Function Admin managed identities
+
+data "azurerm_user_assigned_identity" "managed_identity_io_plt_ci_id_02" {
   name                = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-infra-github-ci-id-02"
   resource_group_name = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-rg-02"
 }
 
-data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_cd" {
+data "azurerm_user_assigned_identity" "managed_identity_io_plt_cd_id_02" {
   name                = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-infra-github-cd-id-02"
   resource_group_name = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-rg-02"
 }
+
+#
 
 # TODO: important - this should be removed as it creates a dependency to the common module
 # to fix this, we need to move all private dns zones from common to core module

--- a/src/core/prod/data.tf
+++ b/src/core/prod/data.tf
@@ -74,12 +74,12 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_ci" {
-  name                = "${local.prefix}-${local.env_short}-plt-infra-github-ci-id-02"
+  name                = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-infra-github-ci-id-02"
   resource_group_name = "${local.prefix}-${local.env_short}-rg-02"
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_cd" {
-  name                = "${local.prefix}-${local.env_short}-plt-infra-github-cd-id-02"
+  name                = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-infra-github-cd-id-02"
   resource_group_name = "${local.prefix}-${local.env_short}-rg-02"
 }
 

--- a/src/core/prod/data.tf
+++ b/src/core/prod/data.tf
@@ -74,12 +74,12 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_ci" {
-  name                = "${local.prefix}-${local.env_short}-functions-admin-ci-identity"
+  name                = "${local.prefix}-${local.env_short}-functions-admin-github-ci-identity"
   resource_group_name = "${local.prefix}-${local.env_short}-identity-rg"
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_cd" {
-  name                = "${local.prefix}-${local.env_short}-functions-admin-cd-identity"
+  name                = "${local.prefix}-${local.env_short}-functions-admin-github-cd-identity"
   resource_group_name = "${local.prefix}-${local.env_short}-identity-rg"
 }
 

--- a/src/core/prod/data.tf
+++ b/src/core/prod/data.tf
@@ -75,12 +75,12 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
 
 data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_ci" {
   name                = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-infra-github-ci-id-02"
-  resource_group_name = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-rg-02"
+  resource_group_name = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-rg-02"
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_cd" {
   name                = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-infra-github-cd-id-02"
-  resource_group_name = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-rg-02"
+  resource_group_name = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-rg-02"
 }
 
 # TODO: important - this should be removed as it creates a dependency to the common module

--- a/src/core/prod/data.tf
+++ b/src/core/prod/data.tf
@@ -73,6 +73,16 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
   resource_group_name = "${local.prefix}-${local.env_short}-identity-rg"
 }
 
+data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_ci" {
+  name                = "${local.prefix}-${local.env_short}-functions-admin-ci-identity"
+  resource_group_name = "${local.prefix}-${local.env_short}-identity-rg"
+}
+
+data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_cd" {
+  name                = "${local.prefix}-${local.env_short}-functions-admin-cd-identity"
+  resource_group_name = "${local.prefix}-${local.env_short}-identity-rg"
+}
+
 # TODO: important - this should be removed as it creates a dependency to the common module
 # to fix this, we need to move all private dns zones from common to core module
 

--- a/src/core/prod/data.tf
+++ b/src/core/prod/data.tf
@@ -73,7 +73,7 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
   resource_group_name = "${local.prefix}-${local.env_short}-identity-rg"
 }
 
-# Function Admin repository managed identities
+# Function Admin repository managed identities
 
 data "azurerm_user_assigned_identity" "managed_identity_io_plt_ci_id_02" {
   name                = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-infra-github-ci-id-02"

--- a/src/core/prod/data.tf
+++ b/src/core/prod/data.tf
@@ -73,7 +73,7 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
   resource_group_name = "${local.prefix}-${local.env_short}-identity-rg"
 }
 
-# Function Admin managed identities
+# Function Admin repository managed identities
 
 data "azurerm_user_assigned_identity" "managed_identity_io_plt_ci_id_02" {
   name                = "${local.prefix}-${local.env_short}-${local.location_short.italynorth}-plt-infra-github-ci-id-02"

--- a/src/core/prod/data.tf
+++ b/src/core/prod/data.tf
@@ -74,13 +74,13 @@ data "azurerm_user_assigned_identity" "managed_identity_io_infra_cd" {
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_ci" {
-  name                = "${local.prefix}-${local.env_short}-functions-admin-github-ci-identity"
-  resource_group_name = "${local.prefix}-${local.env_short}-identity-rg"
+  name                = "${local.prefix}-${local.env_short}-plt-infra-github-ci-id-02"
+  resource_group_name = "${local.prefix}-${local.env_short}-rg-02"
 }
 
 data "azurerm_user_assigned_identity" "managed_identity_io_functions_admin_cd" {
-  name                = "${local.prefix}-${local.env_short}-functions-admin-github-cd-identity"
-  resource_group_name = "${local.prefix}-${local.env_short}-identity-rg"
+  name                = "${local.prefix}-${local.env_short}-plt-infra-github-cd-id-02"
+  resource_group_name = "${local.prefix}-${local.env_short}-rg-02"
 }
 
 # TODO: important - this should be removed as it creates a dependency to the common module

--- a/src/core/prod/westeurope.tf
+++ b/src/core/prod/westeurope.tf
@@ -70,7 +70,7 @@ module "key_vault_weu" {
   ]
 
   ci = [
-    data.azurerm_user_assigned_identity.managed_identity_io_infra_ci.principal_id
+    data.azurerm_user_assigned_identity.managed_identity_io_infra_ci.principal_id,
     data.azurerm_user_assigned_identity.managed_identity_io_plt_ci_id_02.principal_id
   ]
 

--- a/src/core/prod/westeurope.tf
+++ b/src/core/prod/westeurope.tf
@@ -75,7 +75,7 @@ module "key_vault_weu" {
   ]
 
   cd = [
-    data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id,
+    data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id
     data.azurerm_user_assigned_identity.managed_identity_io_plt_cd_id_02.principal_id
   ]
 

--- a/src/core/prod/westeurope.tf
+++ b/src/core/prod/westeurope.tf
@@ -70,11 +70,13 @@ module "key_vault_weu" {
   ]
 
   ci = [
-    data.azurerm_user_assigned_identity.managed_identity_io_infra_ci.principal_id
+    data.azurerm_user_assigned_identity.managed_identity_io_infra_ci.principal_id,
+    data.azurerm_user_assigned_identity.managed_identity_io_functions_admin_ci.principal_id
   ]
 
   cd = [
-    data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id
+    data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id,
+    data.azurerm_user_assigned_identity.managed_identity_io_functions_admin_cd.principal_id
   ]
 
   platform_iac_sp_object_id                 = data.azuread_service_principal.platform_iac_sp.object_id

--- a/src/core/prod/westeurope.tf
+++ b/src/core/prod/westeurope.tf
@@ -75,7 +75,7 @@ module "key_vault_weu" {
   ]
 
   cd = [
-    data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id
+    data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id,
     data.azurerm_user_assigned_identity.managed_identity_io_plt_cd_id_02.principal_id
   ]
 

--- a/src/core/prod/westeurope.tf
+++ b/src/core/prod/westeurope.tf
@@ -71,12 +71,12 @@ module "key_vault_weu" {
 
   ci = [
     data.azurerm_user_assigned_identity.managed_identity_io_infra_ci.principal_id,
-    data.azurerm_user_assigned_identity.managed_identity_io_functions_admin_ci.principal_id
+    data.azurerm_user_assigned_identity.managed_identity_io_plt_ci_id_02.principal_id
   ]
 
   cd = [
     data.azurerm_user_assigned_identity.managed_identity_io_infra_cd.principal_id,
-    data.azurerm_user_assigned_identity.managed_identity_io_functions_admin_cd.principal_id
+    data.azurerm_user_assigned_identity.managed_identity_io_plt_cd_id_02.principal_id
   ]
 
   platform_iac_sp_object_id                 = data.azuread_service_principal.platform_iac_sp.object_id

--- a/src/core/prod/westeurope.tf
+++ b/src/core/prod/westeurope.tf
@@ -70,7 +70,7 @@ module "key_vault_weu" {
   ]
 
   ci = [
-    data.azurerm_user_assigned_identity.managed_identity_io_infra_ci.principal_id,
+    data.azurerm_user_assigned_identity.managed_identity_io_infra_ci.principal_id
     data.azurerm_user_assigned_identity.managed_identity_io_plt_ci_id_02.principal_id
   ]
 


### PR DESCRIPTION
Add secret RBAC roles on ITN KV for function admin CI / CD identities , mandatory for the infrastructure resources migration from common to the monorepo.

Main PR: https://github.com/pagopa/io-functions-admin/pull/298